### PR TITLE
add support for `random` attack to consider previous trials

### DIFF
--- a/datapacks/omega-flowey/data/_/functions/README.md
+++ b/datapacks/omega-flowey/data/_/functions/README.md
@@ -5,6 +5,7 @@ This directory contains convenience functions for developers for quicker calls t
 ## Functions
 
 - `attack`: runs the pre-defined attack's `start` function
+  - `attack/random/n`: randomly starts an attack from the `boss_fight`'s attack phase `n` (e.g. `n = 0`)
 - `boss_fight`: starts the vanilla boss fight
 - `heal`: heals the executing player to full, fills the hunger bar, and applies infinite night vision
 - `reset_scores`: resets the `omega-flowey` boss's attack score parameters

--- a/datapacks/omega-flowey/data/_/functions/attack/random/0.mcfunction
+++ b/datapacks/omega-flowey/data/_/functions/attack/random/0.mcfunction
@@ -1,0 +1,1 @@
+function entity:hostile/omega-flowey/attack/random/attack_phase/0

--- a/datapacks/omega-flowey/data/entity/functions/directorial/boss_fight/vanilla/phase/attack/initialize/0.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/directorial/boss_fight/vanilla/phase/attack/initialize/0.mcfunction
@@ -4,3 +4,7 @@ scoreboard players set @s boss-fight.attack.clock.total 503
 
 # Play music
 playsound omega-flowey:music.phase.1 record @a ~ ~ ~ 10 1
+
+## Add tags
+# Use logic to decrease chance of repeating attacks during `attack/random`
+tag @s add attack.random.consider_previous_trials

--- a/datapacks/omega-flowey/data/entity/functions/directorial/boss_fight/vanilla/phase/attack/terminate.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/directorial/boss_fight/vanilla/phase/attack/terminate.mcfunction
@@ -9,4 +9,6 @@ scoreboard players operation @s boss-fight.attack.phase.i %= @s boss-fight.attac
 function entity:directorial/boss_fight/vanilla/phase/warn/initialize
 
 # Remove tags
+tag @s remove attack.random.consider_previous_trials
+function entity:hostile/omega-flowey/attack/random/remove_previous_tags
 tag @s remove boss_fight.phase.attack

--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/attack_phase/0.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/attack_phase/0.mcfunction
@@ -1,6 +1,6 @@
 ## Initializes a random attack for entities (`boss_fight`) with `boss-fight.attack.phase.i` == 0
 
-# Set influences to defaults for random_phase_0
+# Set influences to defaults for attack_phase 0
 scoreboard players set #attack-friendliness-pellets attack.weight 1
 scoreboard players set #attack-homing-vines attack.weight 1
 scoreboard players set #attack-x-bullets-lower attack.weight 1

--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/attack_phase/0.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/attack_phase/0.mcfunction
@@ -1,10 +1,10 @@
 ## Initializes a random attack for entities (`boss_fight`) with `boss-fight.attack.phase.i` == 0
 
 # Set influences to defaults for attack_phase 0
-scoreboard players set #attack-friendliness-pellets attack.weight 1
-scoreboard players set #attack-homing-vines attack.weight 1
-scoreboard players set #attack-x-bullets-lower attack.weight 1
-scoreboard players set #attack-x-bullets-upper attack.weight 1
+scoreboard players set #attack-friendliness-pellets attack.weight 2
+scoreboard players set #attack-homing-vines attack.weight 2
+scoreboard players set #attack-x-bullets-lower attack.weight 2
+scoreboard players set #attack-x-bullets-upper attack.weight 2
 
 # Run base `start` function
 function entity:hostile/omega-flowey/attack/random/start

--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/choose_attack.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/choose_attack.mcfunction
@@ -5,21 +5,21 @@
 # if random < 0, attack has been ran already
 
 scoreboard players operation @s math.0 -= #attack-dentata-snakes attack.weight
-execute if score #attack-dentata-snakes attack.weight matches 1.. if score @s math.0 matches ..0 run function entity:hostile/omega-flowey/attack/dentata-snakes/start
+execute if score #attack-dentata-snakes attack.weight matches 1.. if score @s math.0 matches ..0 run function entity:hostile/omega-flowey/attack/random/choose_attack/dentata-snakes
 execute if score #attack-dentata-snakes attack.weight matches 1.. if score @s math.0 matches ..0 run return 0
 
 scoreboard players operation @s math.0 -= #attack-friendliness-pellets attack.weight
-execute if score #attack-friendliness-pellets attack.weight matches 1.. if score @s math.0 matches ..0 run function entity:hostile/omega-flowey/attack/friendliness-pellets/start
+execute if score #attack-friendliness-pellets attack.weight matches 1.. if score @s math.0 matches ..0 run function entity:hostile/omega-flowey/attack/random/choose_attack/friendliness-pellets
 execute if score #attack-friendliness-pellets attack.weight matches 1.. if score @s math.0 matches ..0 run return 0
 
 scoreboard players operation @s math.0 -= #attack-homing-vines attack.weight
-execute if score #attack-homing-vines attack.weight matches 1.. if score @s math.0 matches ..0 run function entity:hostile/omega-flowey/attack/homing-vines/start
+execute if score #attack-homing-vines attack.weight matches 1.. if score @s math.0 matches ..0 run function entity:hostile/omega-flowey/attack/random/choose_attack/homing-vines
 execute if score #attack-homing-vines attack.weight matches 1.. if score @s math.0 matches ..0 run return 0
 
 scoreboard players operation @s math.0 -= #attack-x-bullets-lower attack.weight
-execute if score #attack-x-bullets-lower attack.weight matches 1.. if score @s math.0 matches ..0 run function entity:hostile/omega-flowey/attack/x-bullets-lower/start
+execute if score #attack-x-bullets-lower attack.weight matches 1.. if score @s math.0 matches ..0 run function entity:hostile/omega-flowey/attack/random/choose_attack/x-bullets-lower
 execute if score #attack-x-bullets-lower attack.weight matches 1.. if score @s math.0 matches ..0 run return 0
 
 scoreboard players operation @s math.0 -= #attack-x-bullets-upper attack.weight
-execute if score #attack-x-bullets-upper attack.weight matches 1.. if score @s math.0 matches ..0 run function entity:hostile/omega-flowey/attack/x-bullets-upper/start
+execute if score #attack-x-bullets-upper attack.weight matches 1.. if score @s math.0 matches ..0 run function entity:hostile/omega-flowey/attack/random/choose_attack/x-bullets-upper
 execute if score #attack-x-bullets-upper attack.weight matches 1.. if score @s math.0 matches ..0 run return 0

--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/choose_attack/dentata-snakes.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/choose_attack/dentata-snakes.mcfunction
@@ -1,0 +1,5 @@
+execute if entity @s[tag=attack.random.consider_previous_trials] run function entity:hostile/omega-flowey/attack/random/remove_previous_tags
+execute if entity @s[tag=attack.random.consider_previous_trials] run tag @s add attack.random.previous_attack.dentata-snakes
+
+# Start attack
+function entity:hostile/omega-flowey/attack/dentata-snakes/start

--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/choose_attack/friendliness-pellets.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/choose_attack/friendliness-pellets.mcfunction
@@ -1,0 +1,5 @@
+execute if entity @s[tag=attack.random.consider_previous_trials] run function entity:hostile/omega-flowey/attack/random/remove_previous_tags
+execute if entity @s[tag=attack.random.consider_previous_trials] run tag @s add attack.random.previous_attack.friendliness-pellets
+
+# Start attack
+function entity:hostile/omega-flowey/attack/friendliness-pellets/start

--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/choose_attack/homing-vines.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/choose_attack/homing-vines.mcfunction
@@ -1,0 +1,5 @@
+execute if entity @s[tag=attack.random.consider_previous_trials] run function entity:hostile/omega-flowey/attack/random/remove_previous_tags
+execute if entity @s[tag=attack.random.consider_previous_trials] run tag @s add attack.random.previous_attack.homing-vines
+
+# Start attack
+function entity:hostile/omega-flowey/attack/homing-vines/start

--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/choose_attack/x-bullets-lower.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/choose_attack/x-bullets-lower.mcfunction
@@ -1,0 +1,5 @@
+execute if entity @s[tag=attack.random.consider_previous_trials] run function entity:hostile/omega-flowey/attack/random/remove_previous_tags
+execute if entity @s[tag=attack.random.consider_previous_trials] run tag @s add attack.random.previous_attack.x-bullets-lower
+
+# Start attack
+function entity:hostile/omega-flowey/attack/x-bullets-lower/start

--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/choose_attack/x-bullets-upper.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/choose_attack/x-bullets-upper.mcfunction
@@ -1,0 +1,5 @@
+execute if entity @s[tag=attack.random.consider_previous_trials] run function entity:hostile/omega-flowey/attack/random/remove_previous_tags
+execute if entity @s[tag=attack.random.consider_previous_trials] run tag @s add attack.random.previous_attack.x-bullets-upper
+
+# Start attack
+function entity:hostile/omega-flowey/attack/x-bullets-upper/start

--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/reduce_weights.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/reduce_weights.mcfunction
@@ -1,0 +1,15 @@
+## Reduce weight of attack if it was just ran
+execute if entity @s[tag=attack.random.previous_attack.dentata-snakes] run scoreboard players remove #attack-dentata-snakes attack.weight 1
+execute if entity @s[tag=attack.random.previous_attack.dentata-snakes] run tag @s remove attack.random.previous_attack.dentata-snakes
+
+execute if entity @s[tag=attack.random.previous_attack.friendliness-pellets] run scoreboard players remove #attack-friendliness-pellets attack.weight 1
+execute if entity @s[tag=attack.random.previous_attack.friendliness-pellets] run tag @s remove attack.random.previous_attack.friendliness-pellets
+
+execute if entity @s[tag=attack.random.previous_attack.homing-vines] run scoreboard players remove #attack-homing-vines attack.weight 1
+execute if entity @s[tag=attack.random.previous_attack.homing-vines] run tag @s remove attack.random.previous_attack.homing-vines
+
+execute if entity @s[tag=attack.random.previous_attack.x-bullets-lower] run scoreboard players remove #attack-x-bullets-lower attack.weight 1
+execute if entity @s[tag=attack.random.previous_attack.x-bullets-lower] run tag @s remove attack.random.previous_attack.x-bullets-lower
+
+execute if entity @s[tag=attack.random.previous_attack.x-bullets-upper] run scoreboard players remove #attack-x-bullets-upper attack.weight 1
+execute if entity @s[tag=attack.random.previous_attack.x-bullets-upper] run tag @s remove attack.random.previous_attack.x-bullets-upper

--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/remove_previous_tags.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/remove_previous_tags.mcfunction
@@ -1,0 +1,5 @@
+tag @s remove attack.random.previous_attack.dentata-snakes
+tag @s remove attack.random.previous_attack.friendliness-pellets
+tag @s remove attack.random.previous_attack.homing-vines
+tag @s remove attack.random.previous_attack.x-bullets-lower
+tag @s remove attack.random.previous_attack.x-bullets-upper

--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/start.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/start.mcfunction
@@ -1,5 +1,7 @@
 ## Randomize which attack to run based on `attack.weight`s
 
+execute if entity @s[tag=attack.random.consider_previous_trials] run function entity:hostile/omega-flowey/attack/random/reduce_weights
+
 function entity:hostile/omega-flowey/attack/random/sum_weights
 
 # Get randomized value to choose an attack to run


### PR DESCRIPTION
# Summary
## Problem
Previously, when running the `random` attack repeatedly often we'd see attacks repeated back-to-back, e.g. spamming `friendliness-pellets` 3x in a row.

While this was technically still "random", it didn't _feel_ random. It can feel like the map is almost broken when a specific attack repeats more than twice back-to-back.

From [CavemanFilm's video](https://youtu.be/k9d7zWBSuSw?t=304) where the `friendliness-pellets` attack occurs 4x in a row:
> Oh wow you're just spamming those!
Now he actually _does_ mix up his attacks...

The player had to clarify for the video that the attacks are indeed randomized since it doesn't necessarily _feel_ random due to just how many times it spammed the single attack.

## Solution
To fix this, we can adjust the weight of an attack so that it's less likely to repeat if we just ran the attack previously. In a phrase, `consider_previous_trials` (where a "trial" is an instance of us randomly choosing an attack to run).

Currently, we just subtract 1 from the current weight for the attack that was just ran. This decreases the chances of us repeating that specific attack.

For example, with default weights:
| attack | weight | probability |
|-|-|-|
|A|2|33%|
|B|2|33%|
|C|2|33%|

There'd be an equal 33% chance for us to choose any one of the above attacks A/B/C (they have equal weights).

If we were to then choose attack A, for example, the weights for the **next trial** would look as follows:
| attack | weight | probability |
|-|-|-|
|A|1|20%|
|B|2|40%|
|C|2|40%|

So attack A would go from a 33% chance of being chosen to a 20% chance. This means we can _still_ choose it twice in a row (or more...), but it's much less likely than before with independent trials.

---

We also increases the base weights for attack-phase 0's attacks from `1` -> `2`, so that an attack running prior doesn't mean it has a 0% chance of being chosen next (avoiding a weight of 1 turning into a weight of 0).

---

Lastly, we're gating this behavior behind a tag `attack.random.consider_previous_trials` so that without it, we could have independent trials if needed.

---

## Reproducing in-game
This specifically is intended to make the attacks ran by the boss fight not repeat back-to-back as often. So run the boss fight with the following commands to see how it feels:
```mcfunction
function _:reset
function _:boss_fight
```

## Preview
https://youtu.be/FG67KEDMQto

During the fight above, we're logging to chat the weights of each attack as we're randomly choosing one. It's in the order of `[friendliness_pellets, homing_vines, x_bullets_lower, x_bullets_upper]`.

The weights are also set to `1` so that when decreased by `1` (to 0) after running previously, an attack will **not** run again. Just to explicitly force the boss fight to not repeat attacks back-to-back.

---

## Supplemental changes
- add convenience function for `random` attacks (specifically boss fight attack-phase 0)
- minor code cleanup (https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/f7978580ad1833dd60acba94d34045d0874fdcc7)
