### PR TITLE
add support for unit testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: CarbonSmasher/packtest_runner@e2cab04a758a802a6ebcee979fe40fb0140df3de
+      - uses: CarbonSmasher/packtest_runner@9d13d673bf9d3f2fad2b833d036e5e12ff65e056
         with:
           packs: 'datapacks/omega-flowey'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,12 @@
+name: Run tests
+
+on: [push, workflow_dispatch]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: CarbonSmasher/packtest_runner@82535200a0a3870ef2b337b0cd3ad34c1acbeb61
+        with:
+          packs: 'datapacks/omega-flowey'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: CarbonSmasher/packtest_runner@82535200a0a3870ef2b337b0cd3ad34c1acbeb61
+      - uses: CarbonSmasher/packtest_runner@e2cab04a758a802a6ebcee979fe40fb0140df3de
         with:
           packs: 'datapacks/omega-flowey'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,7 +1,8 @@
-name: Run tests
+name: validate
 
 on: [push, workflow_dispatch]
 
+# TODO: add linting
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "packtest_runner"]
+	path = packtest_runner
+	url = https://github.com/CarbonSmasher/packtest_runner
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "packtest_runner"]
-	path = packtest_runner
-	url = https://github.com/CarbonSmasher/packtest_runner
-	branch = main

--- a/README.md
+++ b/README.md
@@ -6,3 +6,13 @@ Back in early 2016 I released `Omega Flowey in Minecraft`.
 - [original thread](https://www.reddit.com/r/Undertale/comments/4a9jht/spoilers_omega_flowey_boss_fight_in_minecraft/)
 
 Since then I've gained a lot of skills both in Minecraft map development and in programming generally. This repo will store any and everything relating to development of a remaster of the original map for modern Minecraft version(s) with better gameplay, performance, and visuals.
+
+## Contributing
+
+### Setup
+
+1. Configure git to automatically update submodules with `git pull`s by defaulting the `submodule.recurse` flag to `true`:
+
+```bash
+git config --global submodule.recurse true
+```

--- a/README.md
+++ b/README.md
@@ -11,8 +11,12 @@ Since then I've gained a lot of skills both in Minecraft map development and in 
 
 ### Setup
 
-1. Configure git to automatically update submodules with `git pull`s by defaulting the `submodule.recurse` flag to `true`:
+#### Testing
 
-```bash
-git config --global submodule.recurse true
-```
+1. Download the [Fabric mod loader](https://fabricmc.net/) and install a new profile to your Minecraft launcher
+2. Download the [Fabric API](https://www.curseforge.com/minecraft/mc-mods/fabric-api/files) jar
+3. Download the latest release jar of [`packtest`](https://github.com/misode/packtest/releases)
+4. Move the `Fabric API` and `packtest` jars into your `mods` folder in the Minecraft directory (typically `%appdata%/.minecraft/mods`)
+5. Run the new profile in your Minecraft launcher to launch a (lightly) modded instance that's able to run `packtest`'s new commands designed for testing
+   1. Try: `test runall`
+   2. See `packtest`'s [README](https://github.com/misode/packtest) for full command documentation

--- a/datapacks/omega-flowey/data/utils/functions/math/max.mcfunction
+++ b/datapacks/omega-flowey/data/utils/functions/math/max.mcfunction
@@ -3,7 +3,7 @@
 #   b: int
 # outputs:
 #   out: the higher value between `a` and `b` (Math.max(a, b))
-execute store result score @s math.0 run data get storage utils:math.max a
-execute store result score @s math.1 run data get storage utils:math.max b
-execute store result storage utils:math.max out int 1 run scoreboard players get @s math.0
-execute if score @s math.0 < @s math.1 store result storage utils:math.max out int 1 run scoreboard players get @s math.1
+execute store result score #utils:math.max math.0 run data get storage utils:math.max a
+execute store result score #utils:math.max math.1 run data get storage utils:math.max b
+execute store result storage utils:math.max out int 1 run scoreboard players get #utils:math.max math.0
+execute if score #utils:math.max math.0 < #utils:math.max math.1 store result storage utils:math.max out int 1 run scoreboard players get #utils:math.max math.1

--- a/datapacks/omega-flowey/data/utils/functions/math/min.mcfunction
+++ b/datapacks/omega-flowey/data/utils/functions/math/min.mcfunction
@@ -3,7 +3,7 @@
 #   b: int
 # outputs:
 #   out: the lower value between `a` and `b` (Math.min(a, b))
-execute store result score @s math.0 run data get storage utils:math.min a
-execute store result score @s math.1 run data get storage utils:math.min b
-execute store result storage utils:math.min out int 1 run scoreboard players get @s math.0
-execute if score @s math.0 > @s math.1 store result storage utils:math.min out int 1 run scoreboard players get @s math.1
+execute store result score #utils:math.min math.0 run data get storage utils:math.min a
+execute store result score #utils:math.min math.1 run data get storage utils:math.min b
+execute store result storage utils:math.min out int 1 run scoreboard players get #utils:math.min math.0
+execute if score #utils:math.min math.0 > #utils:math.min math.1 store result storage utils:math.min out int 1 run scoreboard players get #utils:math.min math.1

--- a/datapacks/omega-flowey/data/utils/tests/math/max.mcfunction
+++ b/datapacks/omega-flowey/data/utils/tests/math/max.mcfunction
@@ -1,0 +1,27 @@
+# @batch utils:math
+
+# setup
+data remove storage utils:math.max a
+data remove storage utils:math.max b
+data remove storage utils:math.max out
+scoreboard players reset *
+function omega-flowey:setup
+
+# cases
+data merge storage utils:math.max { a: 10, b: 10 }
+function utils:math/max
+execute store result score #utils:math.max math.0 run data get storage utils:math.max out
+
+assert score #utils:math.max math.0 matches 10
+
+data merge storage utils:math.max { a: 0, b: 1 }
+function utils:math/max
+execute store result score #utils:math.max math.0 run data get storage utils:math.max out
+
+assert score #utils:math.max math.0 matches 1
+
+data merge storage utils:math.max { a: 2, b: 1 }
+function utils:math/max
+execute store result score #utils:math.max math.0 run data get storage utils:math.max out
+
+assert score #utils:math.max math.0 matches 2

--- a/datapacks/omega-flowey/data/utils/tests/math/min.mcfunction
+++ b/datapacks/omega-flowey/data/utils/tests/math/min.mcfunction
@@ -1,0 +1,27 @@
+# @batch utils:math
+
+# setup
+data remove storage utils:math.min a
+data remove storage utils:math.min b
+data remove storage utils:math.min out
+scoreboard players reset *
+function omega-flowey:setup
+
+# cases
+data merge storage utils:math.min { a: 10, b: 10 }
+function utils:math/min
+execute store result score #utils:math.min math.0 run data get storage utils:math.min out
+
+assert score #utils:math.min math.0 matches 10
+
+data merge storage utils:math.min { a: 0, b: 1 }
+function utils:math/min
+execute store result score #utils:math.min math.0 run data get storage utils:math.min out
+
+assert score #utils:math.min math.0 matches 0
+
+data merge storage utils:math.min { a: 2, b: 1 }
+function utils:math/min
+execute store result score #utils:math.min math.0 run data get storage utils:math.min out
+
+assert score #utils:math.min math.0 matches 1

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -7,6 +7,13 @@ what is the primary purpose of this PR?
 
 ---
 
+## Test plan
+<!--
+does this PR include any unit tests for its new code?
+if yes, briefly describe them.
+if no, explain why.
+-->
+
 ## Reproducing in-game
 <!--
 how to view the thing you added in-game (Minecraft), if applicable.


### PR DESCRIPTION
# Summary
fixes early merge of #32 

This PR adds support for `.mcfunction` unit tests via the [packtest](https://github.com/misode/packtest) and [packtest_runner](https://github.com/CarbonSmasher/packtest_runner) repos. See this [sample repo](https://github.com/misode/packtest-runner-example) for another example (that was used here) to get tests to run in CI.

- adds github workflow to run `packtest`
- adds unit tests for `utils:math/max` and `utils:math/min` functions
- updates `README.md` with instructions for how to install the modded client required to run tests locally
- updates the pull request template to include a `Test plan` section

---

## Reproducing in-game
```mcfunction
test runall
```

## Preview
see this PR's commit history and the corresponding CI statuses (❌'s and ✔️'s)

---

## Supplemental changes
<!--
describe what other changes this PR makes which aren't specific to its main purpose.
- does it contain a world backup? (recommended)
- does it contain other miscellaneous code cleanup?

format these extra changes with bullet points, preferrably.
-->
- world sync (pre-opening world with modded client)