### PR TITLE
add unit tests for `utils:math/vector/dot`, `omega-flowey:reset`, and `omega-flowey:setup`

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: CarbonSmasher/packtest_runner@1fb6264e2e6ebfd84b1ed1456cebd127bf421b7f
+      - uses: CarbonSmasher/packtest_runner@86d606f25d2bd2faa08b017326fe99964ac3aa5c
         with:
           packs: 'datapacks/omega-flowey'
           packtest-url: 'https://github.com/misode/packtest/releases/download/v1.0.0-beta5/packtest-1.0.0-beta5.jar'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: CarbonSmasher/packtest_runner@9d13d673bf9d3f2fad2b833d036e5e12ff65e056
+      - uses: CarbonSmasher/packtest_runner@1fb6264e2e6ebfd84b1ed1456cebd127bf421b7f
         with:
           packs: 'datapacks/omega-flowey'
+          packtest-url: 'https://github.com/misode/packtest/releases/download/v1.0.0-beta5/packtest-1.0.0-beta5.jar'

--- a/datapacks/omega-flowey/data/omega-flowey/tests/reset/should_wipe_scores.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/tests/reset/should_wipe_scores.mcfunction
@@ -1,0 +1,18 @@
+# @batch omega-flowey:setup
+# @optional
+# TODO this test can't run until we update to `packtest@v1.0.0-beta5`
+
+## should wipe any preexisting scores
+
+scoreboard objectives add some.objective dummy
+scoreboard players set #omega-flowey:reset math.0 1
+scoreboard players set #omega-flowey:reset some.objective -124
+assert score #omega-flowey:reset math.0 matches 1
+assert score #omega-flowey:reset some.objective matches -124
+function omega-flowey:reset
+
+execute store success score #omega-flowey:reset math.1 run scoreboard players get #omega-flowey:reset math.0
+assert score #omega-flowey:reset math.1 matches 0
+
+execute store success score #omega-flowey:reset math.1 run scoreboard players get #omega-flowey:reset some.objective
+assert score #omega-flowey:reset math.1 matches 0

--- a/datapacks/omega-flowey/data/omega-flowey/tests/reset/should_wipe_scores.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/tests/reset/should_wipe_scores.mcfunction
@@ -1,6 +1,4 @@
 # @batch omega-flowey:setup
-# @optional
-# TODO this test can't run until we update to `packtest@v1.0.0-beta5`
 
 ## should wipe any preexisting scores
 

--- a/datapacks/omega-flowey/data/omega-flowey/tests/setup/should_add_teams.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/tests/setup/should_add_teams.mcfunction
@@ -1,0 +1,22 @@
+# @batch omega-flowey:setup
+# @optional
+# TODO this test can't run until we update to `packtest@v1.0.0-beta5`
+
+## should add the `player` team
+function omega-flowey:reset
+
+team remove player
+
+# create an entity with a group id
+summon minecraft:pig ~ ~ ~ { Tags: ["omega-flowey", "test.setup.should-add-teams"], DeathLootTable: empty, NoAI: 1, PersistenceRequired: 1, }
+
+# should not be able to join team that doesn't exist
+execute store success score #omega-flowey:setup math.0 as @e[tag=test.setup.should-add-teams] run team join player
+assert score #omega-flowey:setup math.0 matches 0
+
+# add the team
+function omega-flowey:setup
+
+# should be able to join team that exists
+execute store success score #omega-flowey:setup math.0 as @e[tag=test.setup.should-add-teams] run team join player
+assert score #omega-flowey:setup math.0 matches 1

--- a/datapacks/omega-flowey/data/omega-flowey/tests/setup/should_add_teams.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/tests/setup/should_add_teams.mcfunction
@@ -1,6 +1,4 @@
 # @batch omega-flowey:setup
-# @optional
-# TODO this test can't run until we update to `packtest@v1.0.0-beta5`
 
 ## should add the `player` team
 function omega-flowey:reset

--- a/datapacks/omega-flowey/data/omega-flowey/tests/setup/should_reset_group_ids.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/tests/setup/should_reset_group_ids.mcfunction
@@ -1,0 +1,20 @@
+# @batch omega-flowey:setup
+
+## should wipe any preexisting scores
+
+function omega-flowey:reset
+
+# create an entity with a group id
+summon minecraft:marker ~ ~ ~ {Tags:["omega-flowey","groupable","test.setup.should-reset-group-ids"]}
+
+assert score #group.id.next group.id matches 0
+execute as @e[tag=test.setup.should-reset-group-ids] run function entity:group/set
+assert score #group.id.next group.id matches 1
+
+# killing `groupable` entities should not immediately reset #group.id.next
+kill @e[tag=test.setup.should-reset-group-ids]
+assert score #group.id.next group.id matches 1
+
+function omega-flowey:setup
+
+assert score #group.id.next group.id matches 0

--- a/datapacks/omega-flowey/data/utils/functions/math/vector/dot_macro.mcfunction
+++ b/datapacks/omega-flowey/data/utils/functions/math/vector/dot_macro.mcfunction
@@ -1,15 +1,15 @@
 scoreboard players set #utils:math.vector.dot math.0 0
 
-$execute store result storage utils:math.vector.dot out float 1 run data get storage utils:math.vector.dot u.x $(x)
-execute store result score #utils:math.vector.dot math.1 run data get storage utils:math.vector.dot out 100
+$execute store result storage utils:math.vector.dot out float $(x) run data get storage utils:math.vector.dot u.x 100
+execute store result score #utils:math.vector.dot math.1 run data get storage utils:math.vector.dot out
 scoreboard players operation #utils:math.vector.dot math.0 += #utils:math.vector.dot math.1
 
-$execute store result storage utils:math.vector.dot out float 1 run data get storage utils:math.vector.dot u.y $(y)
-execute store result score #utils:math.vector.dot math.1 run data get storage utils:math.vector.dot out 100
+$execute store result storage utils:math.vector.dot out float $(y) run data get storage utils:math.vector.dot u.y 100
+execute store result score #utils:math.vector.dot math.1 run data get storage utils:math.vector.dot out
 scoreboard players operation #utils:math.vector.dot math.0 += #utils:math.vector.dot math.1
 
-$execute store result storage utils:math.vector.dot out float 1 run data get storage utils:math.vector.dot u.z $(z)
-execute store result score #utils:math.vector.dot math.1 run data get storage utils:math.vector.dot out 100
+$execute store result storage utils:math.vector.dot out float $(z) run data get storage utils:math.vector.dot u.z 100
+execute store result score #utils:math.vector.dot math.1 run data get storage utils:math.vector.dot out
 scoreboard players operation #utils:math.vector.dot math.0 += #utils:math.vector.dot math.1
 
 execute store result storage utils:math.vector.dot out int 1 run scoreboard players get #utils:math.vector.dot math.0

--- a/datapacks/omega-flowey/data/utils/functions/math/vector/dot_macro.mcfunction
+++ b/datapacks/omega-flowey/data/utils/functions/math/vector/dot_macro.mcfunction
@@ -1,15 +1,15 @@
-scoreboard players set @s math.0 0
+scoreboard players set #utils:math.vector.dot math.0 0
 
 $execute store result storage utils:math.vector.dot out float 1 run data get storage utils:math.vector.dot u.x $(x)
-execute store result score @s math.1 run data get storage utils:math.vector.dot out 100
-scoreboard players operation @s math.0 += @s math.1
+execute store result score #utils:math.vector.dot math.1 run data get storage utils:math.vector.dot out 100
+scoreboard players operation #utils:math.vector.dot math.0 += #utils:math.vector.dot math.1
 
 $execute store result storage utils:math.vector.dot out float 1 run data get storage utils:math.vector.dot u.y $(y)
-execute store result score @s math.1 run data get storage utils:math.vector.dot out 100
-scoreboard players operation @s math.0 += @s math.1
+execute store result score #utils:math.vector.dot math.1 run data get storage utils:math.vector.dot out 100
+scoreboard players operation #utils:math.vector.dot math.0 += #utils:math.vector.dot math.1
 
 $execute store result storage utils:math.vector.dot out float 1 run data get storage utils:math.vector.dot u.z $(z)
-execute store result score @s math.1 run data get storage utils:math.vector.dot out 100
-scoreboard players operation @s math.0 += @s math.1
+execute store result score #utils:math.vector.dot math.1 run data get storage utils:math.vector.dot out 100
+scoreboard players operation #utils:math.vector.dot math.0 += #utils:math.vector.dot math.1
 
-execute store result storage utils:math.vector.dot out int 1 run scoreboard players get @s math.0
+execute store result storage utils:math.vector.dot out int 1 run scoreboard players get #utils:math.vector.dot math.0

--- a/datapacks/omega-flowey/data/utils/tests/math/max.mcfunction
+++ b/datapacks/omega-flowey/data/utils/tests/math/max.mcfunction
@@ -4,24 +4,20 @@
 data remove storage utils:math.max a
 data remove storage utils:math.max b
 data remove storage utils:math.max out
-scoreboard players reset *
-function omega-flowey:setup
+function omega-flowey:reset
 
-# cases
+## cases
 data merge storage utils:math.max { a: 10, b: 10 }
 function utils:math/max
 execute store result score #utils:math.max math.0 run data get storage utils:math.max out
-
 assert score #utils:math.max math.0 matches 10
 
 data merge storage utils:math.max { a: 0, b: 1 }
 function utils:math/max
 execute store result score #utils:math.max math.0 run data get storage utils:math.max out
-
 assert score #utils:math.max math.0 matches 1
 
 data merge storage utils:math.max { a: 2, b: 1 }
 function utils:math/max
 execute store result score #utils:math.max math.0 run data get storage utils:math.max out
-
 assert score #utils:math.max math.0 matches 2

--- a/datapacks/omega-flowey/data/utils/tests/math/min.mcfunction
+++ b/datapacks/omega-flowey/data/utils/tests/math/min.mcfunction
@@ -4,24 +4,20 @@
 data remove storage utils:math.min a
 data remove storage utils:math.min b
 data remove storage utils:math.min out
-scoreboard players reset *
-function omega-flowey:setup
+function omega-flowey:reset
 
-# cases
+## cases
 data merge storage utils:math.min { a: 10, b: 10 }
 function utils:math/min
 execute store result score #utils:math.min math.0 run data get storage utils:math.min out
-
 assert score #utils:math.min math.0 matches 10
 
 data merge storage utils:math.min { a: 0, b: 1 }
 function utils:math/min
 execute store result score #utils:math.min math.0 run data get storage utils:math.min out
-
 assert score #utils:math.min math.0 matches 0
 
 data merge storage utils:math.min { a: 2, b: 1 }
 function utils:math/min
 execute store result score #utils:math.min math.0 run data get storage utils:math.min out
-
 assert score #utils:math.min math.0 matches 1

--- a/datapacks/omega-flowey/data/utils/tests/math/vector/dot.mcfunction
+++ b/datapacks/omega-flowey/data/utils/tests/math/vector/dot.mcfunction
@@ -7,33 +7,45 @@ data remove storage utils:math.vector.dot out
 scoreboard players reset *
 function omega-flowey:setup
 
-# cases
+## cases
+# 0-vectors
 data merge storage utils:math.vector.dot { u: { x: 0, y: 0, z: 0 }, v: { x: 0, y: 0, z: 0 } }
 function utils:math/vector/dot
 execute store result score #utils:math.vector.dot math.0 run data get storage utils:math.vector.dot out
 assert score #utils:math.vector.dot math.0 matches 0
 
+# mismatched axes -> 0
 data merge storage utils:math.vector.dot { u: { x: 1, y: 0, z: 0 }, v: { x: 0, y: 1, z: 0 } }
 function utils:math/vector/dot
 execute store result score #utils:math.vector.dot math.0 run data get storage utils:math.vector.dot out
 assert score #utils:math.vector.dot math.0 matches 0
 
+# single axis
 data merge storage utils:math.vector.dot { u: { x: 1, y: 0, z: 0 }, v: { x: 1, y: 0, z: 0 } }
 function utils:math/vector/dot
 execute store result score #utils:math.vector.dot math.0 run data get storage utils:math.vector.dot out
 assert score #utils:math.vector.dot math.0 matches 100
 
+# negative values
 data merge storage utils:math.vector.dot { u: { x: -1, y: 0, z: 0 }, v: { x: 1, y: 0, z: 0 } }
 function utils:math/vector/dot
 execute store result score #utils:math.vector.dot math.0 run data get storage utils:math.vector.dot out
 assert score #utils:math.vector.dot math.0 matches -100
 
+# positive + negative values
 data merge storage utils:math.vector.dot { u: { x: 2, y: 0, z: 5 }, v: { x: 1, y: 0, z: -1 } }
 function utils:math/vector/dot
 execute store result score #utils:math.vector.dot math.0 run data get storage utils:math.vector.dot out
 assert score #utils:math.vector.dot math.0 matches -300
 
+# full vectors
 data merge storage utils:math.vector.dot { u: { x: 1, y: 2, z: 3 }, v: { x: 4, y: 5, z: 6 } }
 function utils:math/vector/dot
 execute store result score #utils:math.vector.dot math.0 run data get storage utils:math.vector.dot out
 assert score #utils:math.vector.dot math.0 matches 3200
+
+# supports decimal values up to 100th place
+data merge storage utils:math.vector.dot { u: { x: 1.5, y: 2.1, z: 3.12 }, v: { x: 3, y: 5, z: 7 } }
+function utils:math/vector/dot
+execute store result score #utils:math.vector.dot math.0 run data get storage utils:math.vector.dot out
+assert score #utils:math.vector.dot math.0 matches 3684

--- a/datapacks/omega-flowey/data/utils/tests/math/vector/dot.mcfunction
+++ b/datapacks/omega-flowey/data/utils/tests/math/vector/dot.mcfunction
@@ -1,0 +1,39 @@
+# @batch utils:math
+
+# setup
+data remove storage utils:math.vector.dot u
+data remove storage utils:math.vector.dot v
+data remove storage utils:math.vector.dot out
+scoreboard players reset *
+function omega-flowey:setup
+
+# cases
+data merge storage utils:math.vector.dot { u: { x: 0, y: 0, z: 0 }, v: { x: 0, y: 0, z: 0 } }
+function utils:math/vector/dot
+execute store result score #utils:math.vector.dot math.0 run data get storage utils:math.vector.dot out
+assert score #utils:math.vector.dot math.0 matches 0
+
+data merge storage utils:math.vector.dot { u: { x: 1, y: 0, z: 0 }, v: { x: 0, y: 1, z: 0 } }
+function utils:math/vector/dot
+execute store result score #utils:math.vector.dot math.0 run data get storage utils:math.vector.dot out
+assert score #utils:math.vector.dot math.0 matches 0
+
+data merge storage utils:math.vector.dot { u: { x: 1, y: 0, z: 0 }, v: { x: 1, y: 0, z: 0 } }
+function utils:math/vector/dot
+execute store result score #utils:math.vector.dot math.0 run data get storage utils:math.vector.dot out
+assert score #utils:math.vector.dot math.0 matches 100
+
+data merge storage utils:math.vector.dot { u: { x: -1, y: 0, z: 0 }, v: { x: 1, y: 0, z: 0 } }
+function utils:math/vector/dot
+execute store result score #utils:math.vector.dot math.0 run data get storage utils:math.vector.dot out
+assert score #utils:math.vector.dot math.0 matches -100
+
+data merge storage utils:math.vector.dot { u: { x: 2, y: 0, z: 5 }, v: { x: 1, y: 0, z: -1 } }
+function utils:math/vector/dot
+execute store result score #utils:math.vector.dot math.0 run data get storage utils:math.vector.dot out
+assert score #utils:math.vector.dot math.0 matches -300
+
+data merge storage utils:math.vector.dot { u: { x: 1, y: 2, z: 3 }, v: { x: 4, y: 5, z: 6 } }
+function utils:math/vector/dot
+execute store result score #utils:math.vector.dot math.0 run data get storage utils:math.vector.dot out
+assert score #utils:math.vector.dot math.0 matches 3200

--- a/datapacks/omega-flowey/data/utils/tests/math/vector/dot.mcfunction
+++ b/datapacks/omega-flowey/data/utils/tests/math/vector/dot.mcfunction
@@ -4,8 +4,7 @@
 data remove storage utils:math.vector.dot u
 data remove storage utils:math.vector.dot v
 data remove storage utils:math.vector.dot out
-scoreboard players reset *
-function omega-flowey:setup
+function omega-flowey:reset
 
 ## cases
 # 0-vectors


### PR DESCRIPTION
# Summary
This PR adds unit tests for:
- `utils:math/vector/dot`
- `omega-flowey:reset`
- `omega-flowey:setup`

**NOTE**: the tests for `utils:math/vector/dot` revealed that the function isn't perfect (it's non-commutative), but that's fine for now since it's unclear if we even want to use it (for the `homing-vines` attack's hitbox).

This PR also updates to the fixed `packtest_runner` version from https://github.com/CarbonSmasher/packtest_runner/pull/1 that includes support for specifying a custom `packtest` version to use (allowing us to update the variable for new `packtest` features instead of waiting on `packtest_runner` to update).

---

## Test plan
see **Summary** ^

unit tests pass

## Reproducing in-game
In the modded client run:
```mcfunction
test runall
```

## Preview
N/A

---

## Supplemental changes
N/A
