### PR TITLE
upgrade `PackTest` workflow to simplier + faster version

### DIFF
--- a/.github/workflows/datapack.yml
+++ b/.github/workflows/datapack.yml
@@ -2,14 +2,34 @@ name: datapack
 
 on: [push]
 
+env:
+  FABRIC_API: https://cdn.modrinth.com/data/P7dR8mSH/versions/JMCwDuki/fabric-api-0.92.0%2B1.20.4.jar
+  FABRIC_SERVER: https://meta.fabricmc.net/v2/versions/loader/1.20.4/0.15.3/0.11.2/server/jar
+  PACKTEST: https://cdn.modrinth.com/data/XsKUhp45/versions/Gq3rUEy6/packtest-1.3-mc1.20.4.jar
+
 # TODO(37): add linting
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run PackTest
-        uses: CarbonSmasher/packtest_runner@86d606f25d2bd2faa08b017326fe99964ac3aa5c
+      - uses: actions/setup-java@v4
         with:
-          packs: 'datapacks/omega-flowey'
-          packtest-url: 'https://github.com/misode/packtest/releases/download/v1.0/packtest-1.0-mc1.20.4.jar'
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Download server files
+        run: |
+          curl -o server.jar $FABRIC_SERVER
+          mkdir mods
+          curl -o mods/fabric-api.jar $FABRIC_API
+          curl -o mods/packtest.jar $PACKTEST
+
+      - name: Copy packs to world
+        run: |
+          mkdir -p world/datapacks
+          cp -r datapacks world/datapacks
+
+      - name: Run test server
+        run: |
+          java -Xmx2G -Dpacktest.auto -jar server.jar nogui


### PR DESCRIPTION
# Summary

Misode made a workflow that can run PackTest without any special third party code. Just some simple `curl`s in a shell script (the workflow file itself) and it runs much faster than before with `packtest_runner`.

- see: https://discord.com/channels/154777837382008833/1185733502294044802/1190466881488945162

interestingly it seems like caching is already implemented/not worth implementing in most of the download/install steps. After the actual server starting + running tests, all the other steps are 1s or 0s.

![image](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/assets/13565346/fb10d911-6170-45b0-9c1a-072d45c3e6ed)

So it's either already caching (likely) or doesn't even need it if its not.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Test plan
tests still run as expected. runtime goes from >2m to ~30s.

<!--
does this PR include any unit tests for its new code?
if yes, briefly describe them.
if no, explain why.
-->

## Reproducing in-game
N/A
<!--
how to view the thing you added in-game (Minecraft), if applicable.
- are there certain commands to run?
- if not applicable, write `N/A`.

e.g.:
```mcfunction
function _:reset
function _:summon
function entity:hostile/omega-flowey/attack/x-bullets-lower/start
```
-->

## Preview
see workflow runs associated with this branch's commits
<!--
provide visuals (GIFs preferred) showing a before/after of your PR's purpose.
contrasts between in-game (Minecraft) and Undertale are also great.
-->

<!-- `in-game -- before` can be `N/A` if this is a new addition to the map -->

---

## Supplemental changes
N/A
<!--
describe what other changes this PR makes which aren't specific to its main purpose.
- does it contain a world backup? (recommended)
- does it contain other miscellaneous code cleanup?

format these extra changes with bullet points, preferrably.
-->
