### PR TITLE
increase weight reducer of "previous_trials" logic for random attacks

### DIFF
--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/attack_phase/0.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/attack_phase/0.mcfunction
@@ -1,10 +1,10 @@
 ## Initializes a random attack for entities (`boss_fight`) with `boss-fight.attack.phase.i` == 0
 
 # Set influences to defaults for attack_phase 0
-scoreboard players set #attack-friendliness-pellets attack.weight 2
-scoreboard players set #attack-homing-vines attack.weight 2
-scoreboard players set #attack-x-bullets-lower attack.weight 2
-scoreboard players set #attack-x-bullets-upper attack.weight 2
+scoreboard players set #attack-friendliness-pellets attack.weight 3
+scoreboard players set #attack-homing-vines attack.weight 3
+scoreboard players set #attack-x-bullets-lower attack.weight 3
+scoreboard players set #attack-x-bullets-upper attack.weight 3
 
 # Run base `start` function
 function entity:hostile/omega-flowey/attack/random/start

--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/reduce_weights.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/reduce_weights.mcfunction
@@ -1,18 +1,20 @@
 ## Reduce weight of attack if it was just ran
-execute if entity @s[tag=attack.random.previous_attack.dentata-snakes] run scoreboard players remove #attack-dentata-snakes attack.weight 1
+scoreboard players set @s attack.weight 1
+
+execute if entity @s[tag=attack.random.previous_attack.dentata-snakes] run scoreboard players operation #attack-dentata-snakes attack.weight -= @s attack.weight
 execute if entity @s[tag=attack.random.previous_attack.dentata-snakes] run tag @s remove attack.random.previous_attack.dentata-snakes
 
-execute if entity @s[tag=attack.random.previous_attack.finger-guns] run scoreboard players remove #attack-finger-guns attack.weight 1
+execute if entity @s[tag=attack.random.previous_attack.finger-guns] run scoreboard players operation #attack-finger-guns attack.weight -= @s attack.weight
 execute if entity @s[tag=attack.random.previous_attack.finger-guns] run tag @s remove attack.random.previous_attack.finger-guns
 
-execute if entity @s[tag=attack.random.previous_attack.friendliness-pellets] run scoreboard players remove #attack-friendliness-pellets attack.weight 1
+execute if entity @s[tag=attack.random.previous_attack.friendliness-pellets] run scoreboard players operation #attack-friendliness-pellets attack.weight -= @s attack.weight
 execute if entity @s[tag=attack.random.previous_attack.friendliness-pellets] run tag @s remove attack.random.previous_attack.friendliness-pellets
 
-execute if entity @s[tag=attack.random.previous_attack.homing-vines] run scoreboard players remove #attack-homing-vines attack.weight 1
+execute if entity @s[tag=attack.random.previous_attack.homing-vines] run scoreboard players operation #attack-homing-vines attack.weight -= @s attack.weight
 execute if entity @s[tag=attack.random.previous_attack.homing-vines] run tag @s remove attack.random.previous_attack.homing-vines
 
-execute if entity @s[tag=attack.random.previous_attack.x-bullets-lower] run scoreboard players remove #attack-x-bullets-lower attack.weight 1
+execute if entity @s[tag=attack.random.previous_attack.x-bullets-lower] run scoreboard players operation #attack-x-bullets-lower attack.weight -= @s attack.weight
 execute if entity @s[tag=attack.random.previous_attack.x-bullets-lower] run tag @s remove attack.random.previous_attack.x-bullets-lower
 
-execute if entity @s[tag=attack.random.previous_attack.x-bullets-upper] run scoreboard players remove #attack-x-bullets-upper attack.weight 1
+execute if entity @s[tag=attack.random.previous_attack.x-bullets-upper] run scoreboard players operation #attack-x-bullets-upper attack.weight -= @s attack.weight
 execute if entity @s[tag=attack.random.previous_attack.x-bullets-upper] run tag @s remove attack.random.previous_attack.x-bullets-upper

--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/reduce_weights.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/reduce_weights.mcfunction
@@ -1,5 +1,5 @@
 ## Reduce weight of attack if it was just ran
-scoreboard players set @s attack.weight 1
+scoreboard players set @s attack.weight 2
 
 execute if entity @s[tag=attack.random.previous_attack.dentata-snakes] run scoreboard players operation #attack-dentata-snakes attack.weight -= @s attack.weight
 execute if entity @s[tag=attack.random.previous_attack.dentata-snakes] run tag @s remove attack.random.previous_attack.dentata-snakes


### PR DESCRIPTION
# Summary
Currently, we reduced the weight of the previously-ran attack through the `random` attack from `2` -> `1`.

#29 has more details, but as an example:

## before

if the base weights for attacks were:

| attack | x-bullets-lower | x-bullets-upper | finger-guns |
|-|-|-|-|
| base weight | 2 | 2 | 2 |
| probability of being chosen | 33% | 33% | 33% |

and we run the `random` attack -> it runs `finger-guns`, the weights/probabilities become:

| attack | x-bullets-lower | x-bullets-upper | finger-guns |
|-|-|-|-|
| weight | 2 | 2 | 1 |
| probability of being chosen | 40% | 40% | 20% |

## after

in this PR, we increase the base weights from `2` -> `3` and increase the weight reducer from `1` -> `2`. this changes the previously-ran attack table to:

| attack | x-bullets-lower | x-bullets-upper | finger-guns |
|-|-|-|-|
| weight | 3 | 3 | 1 |
| **probability of being chosen** | **43%** | **43%** | **14%** |

## TL;DR

**we are making it so if an attack runs from the randomizer, we have an _even smaller chance_ of running it again compared to previously**

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Test plan
tested in-game with the same test strategies found in #29 

<!--
does this PR include any unit tests for its new code?
if yes, briefly describe them.
if no, explain why.
-->

## Reproducing in-game

from #29 

> This specifically is intended to make the attacks ran by the boss fight not repeat back-to-back as often. So run the boss fight with the following commands to see how it feels:
```mcfunction
function _:reset
function _:boss_fight

```
<!--
how to view the thing you added in-game (Minecraft), if applicable.
- are there certain commands to run?
- if not applicable, write `N/A`.

e.g.:
```mcfunction
function _:reset
function _:summon
function entity:hostile/omega-flowey/attack/x-bullets-lower/start
```
-->

## Preview
N/A

its just adjusting random weights

<!--
provide visuals (GIFs preferred) showing a before/after of your PR's purpose.
contrasts between in-game (Minecraft) and Undertale are also great.
-->

<!-- `in-game -- before` can be `N/A` if this is a new addition to the map -->

---

## Supplemental changes
N/A
<!--
describe what other changes this PR makes which aren't specific to its main purpose.
- does it contain a world backup? (recommended)
- does it contain other miscellaneous code cleanup?

format these extra changes with bullet points, preferrably.
-->
