### PR TITLE
fix `yarn down` not extracting world to saves directory if world save doesn't already exist

### DIFF
--- a/package-scripts/sync-world.js
+++ b/package-scripts/sync-world.js
@@ -85,12 +85,20 @@ const syncDown = async () => {
 
   await deleteOldBackups();
 
-  console.log('Backing up your current world as a precautionary measure...');
-  const name = await createTempWorldBackupName();
-  const path = `${tempBackupPath}/${name}`;
-  await backupWorld(path, false);
+  /** We can only temp backup the current world if it already exists */
+  if (await exists(minecraftWorldPath)) {
+    console.log('Backing up your current world as a precautionary measure...');
+    const name = await createTempWorldBackupName();
+    const path = `${tempBackupPath}/${name}`;
+    await backupWorld(path, false);
 
-  await remove(minecraftWorldPath);
+    await remove(minecraftWorldPath);
+  } else {
+    console.log(
+      'No pre-existing world save to backup, moving straight to extraction',
+    );
+  }
+
   console.log('Extracting world backup to client saves directory...');
   await extract(worldBackupPath, { dir: minecraftWorldPath });
 


### PR DESCRIPTION
# Summary

- fixes #93

I tried to setup the repo on a new laptop and `yarn down` failed with:

```
[Error: ENOENT: no such file or directory, stat 'C:\Users\tehaf\AppData\Roaming\.minecraft\saves\omega-flowey-remastered']
```

This PR fixes that issue by checking to see if the world save actually exists before performing any operations around it.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Test plan

Runs locally if you don't have a world save with the map name in your Minecraft `saves` directory (e.g. `omega-flowey-remastered`)

<!--
does this PR include any unit tests for its new code?
if yes, briefly describe them.
if no, explain why.
-->

## Reproducing in-game

<!--
how to view the thing you added in-game (Minecraft), if applicable.
- are there certain commands to run?
- if not applicable, write `N/A`.

e.g.:
```mcfunction
function _:reset
function _:summon
function entity:hostile/omega-flowey/attack/x-bullets-lower/start
```
-->

1. backup your local world save manually
2. delete your local world save
3. run `yarn down`

## Preview

N/A

<!-- `in-game -- before` can be `N/A` if this is a new addition to the map -->

---

## Supplemental changes

N/A

<!--
describe what other changes this PR makes which aren't specific to its main purpose.
- does it contain a world backup? (recommended)
- does it contain other miscellaneous code cleanup?

format these extra changes with bullet points, preferrably.
-->
