### PR TITLE
🥅 Print error when trying to start `x-bullets` attack without eye model

### DIFF
--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/dentata-snakes/bullet/initialize/tail_macro.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/dentata-snakes/bullet/initialize/tail_macro.mcfunction
@@ -3,5 +3,4 @@ $function animated_java:dentata_snake_ball/animations/roll_scale_$(scale_rounded
 
 # Print error if there is no matching function (and as a result the animation tag isn't added)
 # animation tag is e.g.: `aj.dentata_snake_ball.animation.roll_scale_50`
-$execute unless entity @s[tag=aj.dentata_snake_ball.animation.roll_scale_$(scale_rounded)] run data merge storage utils:error { error: '[ {"text":"No corresponding animation found for ","color":"yellow"}, {"text": "scale ", "color": "red"}, {"text":"$(scale_rounded) ","color":"aqua"},{"text":"with model "}, {"text":"dentata_snake_ball ","color":"blue"} ]'}
-$execute unless entity @s[tag=aj.dentata_snake_ball.animation.roll_scale_$(scale_rounded)] run function utils:error with storage utils:error
+$execute unless entity @s[tag=aj.dentata_snake_ball.animation.roll_scale_$(scale_rounded)] run function utils:error { error: '[ {"text":"No corresponding animation found for ","color":"yellow"}, {"text": "scale ", "color": "red"}, {"text":"$(scale_rounded) ","color":"aqua"},{"text":"with model "}, {"text":"dentata_snake_ball ","color":"blue"} ]'}

--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/flies/executor/initialize/indicator/error.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/flies/executor/initialize/indicator/error.mcfunction
@@ -1,2 +1,1 @@
-data merge storage utils:error { error: '[ {"text": "Cannot start another ", "color":"yellow"}, {"text": "flies ", "color": "red"}, {"text":"attack when two are already running.","color":"yellow"} ]'}
-function utils:error with storage utils:error
+function utils:error { error: '[ {"text": "Cannot start another ", "color":"yellow"}, {"text": "flies ", "color": "red"}, {"text":"attack when two are already running.","color":"yellow"} ]'}

--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/error/zero_sum.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/random/error/zero_sum.mcfunction
@@ -1,4 +1,3 @@
-data merge storage utils:error { error: '[ {"text": "Sum of ", "color":"yellow"}, {"text": "0 ", "color": "red"}, {"text":"when trying to randomize attack. ","color":"yellow"}, {"text": "(No attack weights?)", "color": "aqua"} ]'}
-function utils:error with storage utils:error
+function utils:error { error: '[ {"text": "Sum of ", "color":"yellow"}, {"text": "0 ", "color": "red"}, {"text":"when trying to randomize attack. ","color":"yellow"}, {"text": "(No attack weights?)", "color": "aqua"} ]'}
 
 return 1

--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/x-bullets-lower/executor/initialize.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/x-bullets-lower/executor/initialize.mcfunction
@@ -1,3 +1,11 @@
+# check for pre-existence of at least one lower_eye model
+scoreboard players set #attack.x-bullets-lower.lower_eye_exists attack.flag 0
+execute if entity @e[type=minecraft:item_display,tag=aj.lower_eye.root] run scoreboard players set #attack.x-bullets-lower.lower_eye_exists attack.flag 1
+
+# throw an error if no model exists
+execute if score #attack.x-bullets-lower.lower_eye_exists attack.flag matches 0 run function entity:hostile/omega-flowey/attack/x-bullets-shared/executor/initialize/error { "type": "lower" }
+execute if score #attack.x-bullets-lower.lower_eye_exists attack.flag matches 0 run return fail
+
 execute at @e[tag=aj.lower_eye.locator.pupil] run function entity:hostile/omega-flowey/attack/x-bullets-lower/executor/initialize/effects
 
 # Set scores

--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/x-bullets-shared/executor/initialize/error.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/x-bullets-shared/executor/initialize/error.mcfunction
@@ -1,0 +1,2 @@
+$function utils:error { error: '[ {"text": "No ", "color": "yellow"}, {"text": "$(type)_eye ", "color": "aqua"}, {"text":"model exists. At least one ", "color": "yellow"}, {"text": "$(type)_eye ", "color": "aqua"}, {"text": "model must exist before starting the ", "color": "yellow"}, {"text": "x-bullets-$(type) ", "color": "red"}, {"text": "attack.", "color":"yellow"} ]'}
+kill @s

--- a/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/x-bullets-upper/executor/initialize.mcfunction
+++ b/datapacks/omega-flowey/data/entity/functions/hostile/omega-flowey/attack/x-bullets-upper/executor/initialize.mcfunction
@@ -1,3 +1,11 @@
+# check for pre-existence of at least one upper_eye model
+scoreboard players set #attack.x-bullets-upper.upper_eye_exists attack.flag 0
+execute if entity @e[type=minecraft:item_display,tag=aj.upper_eye.root] run scoreboard players set #attack.x-bullets-upper.upper_eye_exists attack.flag 1
+
+# throw an error if no model exists
+execute if score #attack.x-bullets-upper.upper_eye_exists attack.flag matches 0 run function entity:hostile/omega-flowey/attack/x-bullets-shared/executor/initialize/error { "type": "upper" }
+execute if score #attack.x-bullets-upper.upper_eye_exists attack.flag matches 0 run return fail
+
 execute at @e[tag=aj.upper_eye.locator.pupil] run function entity:hostile/omega-flowey/attack/x-bullets-upper/executor/initialize/effects
 
 # Set scores


### PR DESCRIPTION
# Summary

- closes #48

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

<!--
does this PR include any unit tests for its new code?
if yes, briefly describe them.
if no, explain why.
-->

## Reproducing in-game

```mcfunction
function _:attack/x-bullets-upper
function _:attack/x-bullets-lower
```

## Preview

<!--
provide visuals (GIFs preferred) showing a before/after of your PR's purpose.
contrasts between in-game (Minecraft) and Undertale are also great.
-->

| error message |
|-|
|![preview](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/assets/13565346/e6551a86-6629-48ba-8f95-653d0d1ccbe3) |



<!-- `in-game -- before` can be `N/A` if this is a new addition to the map -->

---

## Supplemental changes
- specify error function parameters directly after function call instead of in storage: https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/536b08a016c2b4ee7da1b94a54573753fe1b9e30
  - didn't realize when i made these commands you could specify macro parameters directly
  - tested each error to make sure they still appear as expected
<!--
describe what other changes this PR makes which aren't specific to its main purpose.
- does it contain a world backup? (recommended)
- does it contain other miscellaneous code cleanup?

format these extra changes with bullet points, preferrably.
-->
