### PR TITLE
⬆️ ⚔️ migrate `homing-vines` attack to AJ v1.0.0

### DIFF
--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/homing-vines/blinking_lane/summon/raw.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/homing-vines/blinking_lane/summon/raw.mcfunction
@@ -1,2 +1,2 @@
 # Summon blinking-lane
-function animated_java:homing_vine_blinking_lane/summon
+function animated_java:homing_vine_blinking_lane/summon { args: {} }

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/homing-vines/bullet/initialize.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/homing-vines/bullet/initialize.mcfunction
@@ -11,8 +11,5 @@ playsound omega-flowey:attack.homing-vines.summon hostile @a ~ ~ ~ 5 1
 execute store result entity @s Rotation[0] float 1 run data get storage attack:homing-vines bullet_yaw
 execute store result entity @s Rotation[1] float 1 run data get storage attack:homing-vines bullet_pitch
 
-# Start animation (just a hack to further lengthen the vine)
-function animated_java:homing_vine/animations/default/play
-
 # Remove tags
 tag @s remove attack-bullet-new

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/homing-vines/indicator/loop/summon_bullet.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/homing-vines/indicator/loop/summon_bullet.mcfunction
@@ -1,5 +1,5 @@
-# Summon bullet
-$execute positioned $(x) $(y) $(z) rotated $(bullet_yaw) $(bullet_pitch) run function animated_java:homing_vine/summon
+# Summon bullet (animation is just a hack to further lengthen the vine)
+$execute positioned $(x) $(y) $(z) rotated $(bullet_yaw) $(bullet_pitch) run function animated_java:homing_vine/summon { args: { animation: "default", start_animation: true } }
 
 # Initialize bullet
 execute if entity @s[tag=!homing-vines-save-states] as @e[tag=attack-bullet-new] run function entity:hostile/omega-flowey/attack/homing-vines/bullet/initialize

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/homing-vine-blinking-lane.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/homing-vine-blinking-lane.ajblueprint
@@ -1,55 +1,32 @@
 {
 	"meta": {
-		"format": "animated_java/ajmodel",
-		"format_version": "0.4.8",
-		"uuid": "548e36d4-c419-e5a0-7385-8f1062b9691f"
+		"format": "animated_java_blueprint",
+		"format_version": "0.5.3",
+		"uuid": "548e36d4-c419-e5a0-7385-8f1062b9691f",
+		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\homing-vine-blinking-lane.ajblueprint",
+		"last_used_export_namespace": "homing_vine_blinking_lane"
 	},
-	"animated_java": {
-		"settings": {
-			"project_namespace": "homing_vine_blinking_lane",
-			"project_resolution": [16, 16],
-			"target_minecraft_version": "1.20+",
-			"rig_item": "minecraft:white_dye",
-			"rig_item_model": "",
-			"rig_export_folder": "",
-			"texture_export_folder": "",
-			"enable_advanced_resource_pack_settings": false,
-			"resource_pack_mcmeta": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\pack.mcmeta",
-			"verbose": true,
-			"exporter": "animated_java:datapack_exporter"
-		},
-		"exporter_settings": {
-			"animated_java:datapack_exporter": {
-				"datapack_mcmeta": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java\\pack.mcmeta",
-				"outdated_rig_warning": true,
-				"root_entity_nbt": "{}",
-				"use_component_system": true,
-				"include_variant_summon_functions": true,
-				"include_apply_variant_functions": true,
-				"include_uninstall_function": true,
-				"include_pause_all_animations_function": true,
-				"include_remove_rigs_function": true,
-				"include_remove_all_function": true,
-				"include_on_load_function_tags": true,
-				"include_on_tick_function_tags": true,
-				"include_on_summon_function_tags": true,
-				"include_on_remove_function_tags": true
-			},
-			"animated_java:json_exporter": {
-				"output_file": ""
-			}
-		},
-		"variants": [
-			{
-				"name": "default",
-				"textureMap": {},
-				"uuid": "216293ac-ba41-3ada-6f65-96eb22f315d7",
-				"boneConfig": {},
-				"default": true,
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			}
-		]
+	"project_settings": {
+		"export_namespace": "homing_vine_blinking_lane",
+		"show_bounding_box": false,
+		"auto_bounding_box": true,
+		"bounding_box": [48, 48],
+		"enable_plugin_mode": false,
+		"enable_resource_pack": true,
+		"enable_data_pack": true,
+		"display_item": "minecraft:white_dye",
+		"customModelDataOffset": 0,
+		"enable_advanced_resource_pack_settings": false,
+		"resource_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\",
+		"display_item_path": "",
+		"model_folder": "",
+		"texture_folder": "",
+		"enable_advanced_data_pack_settings": false,
+		"data_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java\\",
+		"summon_commands": "data merge entity @s {CustomName: '\"Homing-Vines Blinking Lane\"', view_range: 0 }\ntag @s add omega-flowey-remastered\ntag @s add groupable\ntag @s add hostile\ntag @s add omega-flowey\ntag @s add attack\ntag @s add homing-vines\ntag @s add homing-vines-blinking-lane\ntag @s add homing-vines-blinking-lane-new",
+		"interpolation_duration": 1,
+		"teleportation_duration": 1,
+		"use_storage_for_animation": false
 	},
 	"resolution": {
 		"width": 16,
@@ -148,7 +125,13 @@
 			"name": "root",
 			"origin": [0, 11, 0],
 			"color": 0,
-			"nbt": "{CustomName: '\"Homing-Vines Blinking Lane\"', Tags:[\"omega-flowey-remastered\",\"groupable\",\"hostile\",\"omega-flowey\",\"attack\",\"homing-vines\",\"homing-vines-blinking-lane\",\"homing-vines-blinking-lane-new\"], view_range: 0 }",
+			"configs": {
+				"default": {
+					"inherit_settings": true,
+					"nbt": ""
+				},
+				"variants": {}
+			},
 			"uuid": "12b07b44-c52f-fffb-7cfa-cb571609acdb",
 			"export": true,
 			"mirror_uv": false,
@@ -162,7 +145,7 @@
 	"textures": [
 		{
 			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\attacks\\homing-vine-blinking-lane.png",
-			"name": "homing-vine-blinking-lane",
+			"name": "homing-vine-blinking-lane.png",
 			"folder": "",
 			"namespace": "",
 			"id": "0",
@@ -184,9 +167,20 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "f5af35d5-3b6f-d0f1-08ce-40d942d8a3ea",
-			"relative_path": "../../../../../../textures/custom/attacks/homing-vine-blinking-lane.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAgCAYAAAAbifjMAAAAAXNSR0IArs4c6QAAADRJREFUSEtjfHlzwn8GCgDjqAEMo2HAMBoGDMMjDBYaGlFWHowawMA4GgajYQAqD4Z+OgAAVXFVYfqulm0AAAAASUVORK5CYII=",
 			"mode": "bitmap"
 		}
-	]
+	],
+	"variants": {
+		"default": {
+			"display_name": "default",
+			"name": "default",
+			"uuid": "216293ac-ba41-3ada-6f65-96eb22f315d7",
+			"texture_map": {},
+			"excluded_bones": []
+		},
+		"list": []
+	},
+	"animations": [],
+	"animation_controllers": []
 }

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/homing-vine.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/homing-vine.ajblueprint
@@ -1,55 +1,32 @@
 {
 	"meta": {
-		"format": "animated_java/ajmodel",
-		"format_version": "0.4.8",
-		"uuid": "36b84ded-f8a9-cbdc-bae4-05c4f6bdb170"
+		"format": "animated_java_blueprint",
+		"format_version": "0.5.3",
+		"uuid": "36b84ded-f8a9-cbdc-bae4-05c4f6bdb170",
+		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\homing-vine.ajblueprint",
+		"last_used_export_namespace": "homing_vine"
 	},
-	"animated_java": {
-		"settings": {
-			"project_namespace": "homing_vine",
-			"project_resolution": [16, 16],
-			"target_minecraft_version": "1.20+",
-			"rig_item": "minecraft:white_dye",
-			"rig_item_model": "",
-			"rig_export_folder": "",
-			"texture_export_folder": "",
-			"enable_advanced_resource_pack_settings": false,
-			"resource_pack_mcmeta": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\pack.mcmeta",
-			"verbose": true,
-			"exporter": "animated_java:datapack_exporter"
-		},
-		"exporter_settings": {
-			"animated_java:datapack_exporter": {
-				"datapack_mcmeta": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java\\pack.mcmeta",
-				"outdated_rig_warning": true,
-				"root_entity_nbt": "{CustomName: '\"Homing-Vines Bullet\"', Tags:[\"omega-flowey-remastered\",\"hostile\",\"omega-flowey\",\"attack\",\"attack-bullet\",\"attack-bullet-new\",\"homing-vines\"]}",
-				"use_component_system": true,
-				"include_variant_summon_functions": true,
-				"include_apply_variant_functions": true,
-				"include_uninstall_function": true,
-				"include_pause_all_animations_function": true,
-				"include_remove_rigs_function": true,
-				"include_remove_all_function": true,
-				"include_on_load_function_tags": true,
-				"include_on_tick_function_tags": true,
-				"include_on_summon_function_tags": true,
-				"include_on_remove_function_tags": true
-			},
-			"animated_java:json_exporter": {
-				"output_file": ""
-			}
-		},
-		"variants": [
-			{
-				"name": "default",
-				"textureMap": {},
-				"uuid": "c4f5ae03-0852-324b-fd1b-356af03d9d51",
-				"boneConfig": {},
-				"default": true,
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			}
-		]
+	"project_settings": {
+		"export_namespace": "homing_vine",
+		"show_bounding_box": false,
+		"auto_bounding_box": true,
+		"bounding_box": [48, 48],
+		"enable_plugin_mode": false,
+		"enable_resource_pack": true,
+		"enable_data_pack": true,
+		"display_item": "minecraft:white_dye",
+		"customModelDataOffset": 0,
+		"enable_advanced_resource_pack_settings": false,
+		"resource_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\",
+		"display_item_path": "",
+		"model_folder": "",
+		"texture_folder": "",
+		"enable_advanced_data_pack_settings": false,
+		"data_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java\\",
+		"summon_commands": "data merge entity @s {CustomName:\"\\\"Homing-Vines Bullet\\\"\"}\ntag @s add omega-flowey-remastered\ntag @s add hostile\ntag @s add omega-flowey\ntag @s add attack\ntag @s add attack-bullet\ntag @s add attack-bullet-new\ntag @s add homing-vines",
+		"interpolation_duration": 1,
+		"teleportation_duration": 1,
+		"use_storage_for_animation": false
 	},
 	"resolution": {
 		"width": 16,
@@ -2063,7 +2040,10 @@
 			"origin": [0, 0, 35],
 			"rotation": [0, -180, 0],
 			"color": 0,
-			"nbt": "{}",
+			"configs": {
+				"default": {},
+				"variants": {}
+			},
 			"uuid": "c1728807-c214-1e93-b0fe-135c728a5e9a",
 			"export": true,
 			"mirror_uv": false,
@@ -2076,7 +2056,10 @@
 					"name": "hand",
 					"origin": [0, 0, 35],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "56692b12-ecba-8cc2-bde7-6b3f858489a1",
 					"export": true,
 					"mirror_uv": false,
@@ -2098,7 +2081,10 @@
 					"name": "vine",
 					"origin": [0, 0, 35],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "3b4f98ae-0998-0b9c-c1c6-223d4fe8f796",
 					"export": true,
 					"mirror_uv": false,
@@ -2153,7 +2139,7 @@
 	"textures": [
 		{
 			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\attacks\\homing-vine.png",
-			"name": "homing-vine",
+			"name": "homing-vine.png",
 			"folder": "",
 			"namespace": "",
 			"id": "0",
@@ -2175,13 +2161,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "7d5e2671-4dbb-df40-7ea9-f4337a16a3f7",
-			"relative_path": "../../../../../../textures/custom/attacks/homing-vine.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAbFJREFUOE9dk7tKA1EQhueEXDWkkEAKFUJEg0YFMa0W6dJZaGtlI1j5BD6DT2JnlydIJURRMATUQggWIRp3E7LyTZz1mGl291z+mfnmX9c8rUZrlQW570wkkwuF4Pv1fSzB51i/l4t56Y8C/W72prrWqmWkvOnEXVztRVyurKZltz3Qzbt6QfLlUB7boQSjtBSKkRRzGXnrD1X8ufulooRrnOxEZGbje5CQ7ksYV+JnziymZKWUiitDePfgV4AMxKDvdHHykVQxgtIbnSAuGxGCfSpyMLC+usdZLZvM1gLvHDQ2yaWJDHvpWNwdnW9H9EcmKoCFhX/Rb89EeSpEnzi9Wsk3pWwsiFi1ntbsBvu2nJhB3KollSyXqcKHykVrydhYewgqAy4yY/9JW9nCNIZJWybGOyJUowI+oN7D38zJbOU+NfLxCC2RMgAiozG68+DmM5tPjIcKcIgWMMf8FDhoo/WdatZ2Z5f7kW8WbGzEgWa2Zc3caCb61wKj5OewbADcaM0MxLjM6r44QgrRPM8IGSkbVEWYyRC3Mfri7vpwXRmQhTA49h/w5LJvX3iRFKEfGFFJPfB6UZcAAAAASUVORK5CYII=",
 			"mode": "bitmap"
 		},
 		{
 			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.1\\1.20.1\\assets\\minecraft\\textures\\block\\orange_shulker_box.png",
-			"name": "orange_shulker_box",
+			"name": "orange_shulker_box.png",
 			"folder": "",
 			"namespace": "",
 			"id": "1",
@@ -2203,11 +2188,20 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "01f91ea7-2bb8-43e5-c193-983fd538939e",
-			"relative_path": "C:/Users/afro/AppData/Roaming/.minecraft/versions/1.20.1/1.20.1/assets/minecraft/textures/block/orange_shulker_box.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAbNJREFUOE91U9lOwzAQHCcB0jRNCxKXBHwYT4h34GcRL1yCIkEPodK0KSqODbPGrcvhF3tt787uzK7qnsK2Wxm43spK9iJ39qSaYa4ttoqlbYxdvD+/VlBv55m97VdYi4C9IhHH3lhjboDDjrNfxhofgc13C6CTAmp8kdnHQYXdIkGj2RSH2XQqe2gTOS9acj8tS/TLGs11QLGEdN05K6Vg6lo+RXEsO5e1FtaYlbtqMsH1UEPdn8DmaYIszxcOfx5UBGtccJ+lBCAH3eFqCcwkROc5vCM6eWh7Dh4GlRAoWagIsAa11ogTRyLLYkksxaOTWAngOUgbDagocjUb8+eZWTAId2Zx1dfLABtpukD06ROZQX36PoNfHDwOgxK+WfdoYf0enTL2ytr1wegstXeDdxy0YzRbTuf/1k8O8rAPvIz85EkLmQ9V8RyIjJ7ErFWIzuL0rYRvop8y0l40EluZMu7ksbQq0d9nMwFkVqFNpSgnnbsjje0MrpFuehUIzOFhCSRoXgNHm8vhYkDOC9fKMF0ew7IhtAGeJ67SgwJgL3bHzt7PgSQC7kaQqeU719PX+yeCixcOaG7iAAAAAABJRU5ErkJggg==",
 			"mode": "bitmap"
 		}
 	],
+	"variants": {
+		"default": {
+			"display_name": "default",
+			"name": "default",
+			"uuid": "c4f5ae03-0852-324b-fd1b-356af03d9d51",
+			"texture_map": {},
+			"excluded_bones": []
+		},
+		"list": []
+	},
 	"animations": [
 		{
 			"uuid": "ef6b83da-7de7-2460-f5d9-dd9ed613abe7",
@@ -2216,13 +2210,14 @@
 			"override": false,
 			"length": 0.05,
 			"snapping": 20,
-			"selected": false,
+			"selected": true,
+			"saved": true,
+			"path": "",
 			"anim_time_update": "",
 			"blend_weight": "",
 			"start_delay": "",
 			"loop_delay": "",
-			"affected_bones": [],
-			"affected_bones_is_a_whitelist": false,
+			"excluded_bones": [],
 			"animators": {
 				"3b4f98ae-0998-0b9c-c1c6-223d4fe8f796": {
 					"name": "vine",
@@ -2240,7 +2235,9 @@
 							"uuid": "81a53348-5365-8c55-a40a-225dff60b598",
 							"time": 0,
 							"color": -1,
-							"interpolation": "linear"
+							"interpolation": "linear",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -2255,11 +2252,14 @@
 							"time": 0,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "linear"
+							"interpolation": "linear",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				}
 			}
 		}
-	]
+	],
+	"animation_controllers": []
 }


### PR DESCRIPTION
# Summary

This PR migrates the necessary AJ blueprints to re-enable the `homing-vines` attack for Minecraft 1.21.

The models we needed to migrate were `homing-vine` and `homing-vine-blinking-lane`.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Reproducing in-game

```mcfunction
function _:attack/homing-vines
```

---

## Supplemental changes

N/A

<!--
describe what other changes this PR makes which aren't specific to its main purpose.
- does it contain a world backup? (recommended)
- does it contain other miscellaneous code cleanup?

format these extra changes with bullet points, preferrably.
-->
