### PR TITLE
⬆️ ⚔️ migrate `flies` attack to AJ v1.0.0

### DIFF
--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/flies/executor/initialize/indicator/summon.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/flies/executor/initialize/indicator/summon.mcfunction
@@ -1,5 +1,5 @@
 # Summon indicator
-$execute positioned $(x) $(y) $(z) rotated $(yaw) $(pitch) run function animated_java:venus_fly_trap/summon
+$execute positioned $(x) $(y) $(z) rotated $(yaw) $(pitch) run function animated_java:venus_fly_trap/summon { args: {} }
 
 # Initialize indicator
 execute as @e[tag=attack-indicator-new] at @s run function entity:hostile/omega-flowey/attack/flies/indicator/initialize

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/flies/indicator/loop/bullet/summon.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/flies/indicator/loop/bullet/summon.mcfunction
@@ -1,5 +1,5 @@
 # Summon bullet
-$execute positioned $(x) $(y) $(z) run function animated_java:housefly/summon
+$execute positioned $(x) $(y) $(z) run function animated_java:housefly/summon { args: {} }
 
 # Initialize bullet
 execute as @e[tag=attack-bullet-new] at @s run function entity:hostile/omega-flowey/attack/flies/bullet/initialize

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/housefly.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/housefly.ajblueprint
@@ -1,55 +1,32 @@
 {
 	"meta": {
-		"format": "animated_java/ajmodel",
-		"format_version": "0.4.8",
-		"uuid": "890a34a9-3930-0214-31a3-cabe57429bb9"
+		"format": "animated_java_blueprint",
+		"format_version": "0.5.3",
+		"uuid": "890a34a9-3930-0214-31a3-cabe57429bb9",
+		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\housefly.ajblueprint",
+		"last_used_export_namespace": "housefly"
 	},
-	"animated_java": {
-		"settings": {
-			"project_namespace": "housefly",
-			"project_resolution": [16, 16],
-			"target_minecraft_version": "1.20+",
-			"rig_item": "minecraft:white_dye",
-			"rig_item_model": "",
-			"rig_export_folder": "",
-			"texture_export_folder": "",
-			"enable_advanced_resource_pack_settings": false,
-			"resource_pack_mcmeta": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\pack.mcmeta",
-			"verbose": true,
-			"exporter": "animated_java:datapack_exporter"
-		},
-		"exporter_settings": {
-			"animated_java:datapack_exporter": {
-				"datapack_mcmeta": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java\\pack.mcmeta",
-				"outdated_rig_warning": true,
-				"root_entity_nbt": "{ CustomName: '\"Flies Bullet\"', Tags: [\"omega-flowey-remastered\",\"hostile\",\"groupable\",\"omega-flowey\",\"attack\",\"attack-bullet\",\"attack-bullet-new\",\"flies\"], interpolation_duration: 1, teleport_duration: 1 }",
-				"use_component_system": true,
-				"include_variant_summon_functions": true,
-				"include_apply_variant_functions": true,
-				"include_uninstall_function": true,
-				"include_pause_all_animations_function": true,
-				"include_remove_rigs_function": true,
-				"include_remove_all_function": true,
-				"include_on_load_function_tags": true,
-				"include_on_tick_function_tags": true,
-				"include_on_summon_function_tags": true,
-				"include_on_remove_function_tags": true
-			},
-			"animated_java:json_exporter": {
-				"output_file": ""
-			}
-		},
-		"variants": [
-			{
-				"name": "default",
-				"textureMap": {},
-				"uuid": "d6a3882a-bc7c-c59b-6a97-31e1203d98c0",
-				"boneConfig": {},
-				"default": true,
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			}
-		]
+	"project_settings": {
+		"export_namespace": "housefly",
+		"show_bounding_box": false,
+		"auto_bounding_box": true,
+		"bounding_box": [48, 48],
+		"enable_plugin_mode": false,
+		"enable_resource_pack": true,
+		"enable_data_pack": true,
+		"display_item": "minecraft:white_dye",
+		"customModelDataOffset": 0,
+		"enable_advanced_resource_pack_settings": false,
+		"resource_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\",
+		"display_item_path": "",
+		"model_folder": "",
+		"texture_folder": "",
+		"enable_advanced_data_pack_settings": false,
+		"data_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java\\",
+		"summon_commands": "data merge entity @s {CustomName:\"\\\"Flies Bullet\\\"\",interpolation_duration:1,teleport_duration:1}\ntag @s add omega-flowey-remastered\ntag @s add hostile\ntag @s add groupable\ntag @s add omega-flowey\ntag @s add attack\ntag @s add attack-bullet\ntag @s add attack-bullet-new\ntag @s add flies",
+		"interpolation_duration": 1,
+		"teleportation_duration": 1,
+		"use_storage_for_animation": false
 	},
 	"resolution": {
 		"width": 16,
@@ -3159,7 +3136,10 @@
 			"name": "bone",
 			"origin": [0, 9.71622, -0.33784],
 			"color": 0,
-			"nbt": "{}",
+			"configs": {
+				"default": {},
+				"variants": {}
+			},
 			"uuid": "7e1179d4-c3be-45b0-bcf0-e77c93184e36",
 			"export": true,
 			"mirror_uv": false,
@@ -3172,7 +3152,10 @@
 					"name": "housefly",
 					"origin": [0, 9.71621, -0.33784],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "45fa307f-d17d-28e2-17c7-80ea047e50b8",
 					"export": true,
 					"mirror_uv": false,
@@ -3261,7 +3244,10 @@
 					"name": "splat",
 					"origin": [0, 9.625, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "3c85e54d-0a03-53f3-98eb-cf8aac6fe73e",
 					"export": true,
 					"mirror_uv": false,
@@ -3277,7 +3263,7 @@
 	"textures": [
 		{
 			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\attacks\\petes_fly.png",
-			"name": "petes_fly",
+			"name": "petes_fly.png",
 			"folder": "blocks",
 			"namespace": "minecraft",
 			"id": "0",
@@ -3299,13 +3285,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "f119da54-6e8d-9aea-a7cb-0217835c9af4",
-			"relative_path": "../../../../../../textures/custom/attacks/petes_fly.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAAEACAYAAAB7+X6nAAAAAXNSR0IArs4c6QAAGM1JREFUeF7tnHmQFPXdxp+5eu77YPbmXE7BQsFYlonRmFhFjgqCVtQEV0UUSRS8EjWKRlEwigbQFTWWVSYVwFSiljFqqRCiAhqMgLCAy+nu7M4903P2dM/vrWlK67Xy5tVeumemm9/+Q7H77e/v+T7PZ3p6erpbB/pzSjugO6Wnp8ODAnCKQ0ABoACc4g6c4uPTPQAF4BR34BQfn+4BKACnuAOn+Ph0D0ABUN6BRx9bRVwOF6655joKnPJ2S1pB8UA2vfgkGRgoolLh0BruRLGcxzVXL1R8XUkunMLFdQlizbrHSSaTAmNiMG3q6UjGU0jnh7Hk+mV1Wf8UzvcrR69LAGuffJSUi2WUOR42qx3dEyahWCiBZVlc2bOgLhq+0olTtKAu5q97ehVJxQriHsBstsFisaCjvROpZBq5QhaLrqXHBo3iry4ArH92NSkWquIr3usJiMcDVqsNAV8IhUIBseQglt10W120NMroZl23bqY/vmYlyec56HUGeL0+5AtZOJxuWE12CIJA3woaREjdAFj5yHJSLp5YzuNxQ6fTQeAFuFweGPQG5FgWNyxZUjc9DfK76Zatq+H3r1hOeF6A0+GG3W4DV+HA8xwMekY0JhaP4f77HqirpqZLpM6C6mr28vt+TbgSD4vNgoA/ACNjRI7NwGhkEI0Mw2q348477qqrpjr73XTL1dXsm++aTxzGCdDpGej1OthtdrjdbhRLBZiMJiRTCTAGC2659da66mq6VOooqO5G1/YCFrMV2QwLnlTg8/gQCoXBcSU47R7Ek1EcPnwQj61eV3dtdfS9aZaqu8m17wUqHEEilQJXYsFYnPB7vfD7feKnAYPBgOPHD4NDGg8uf6Lu+pommToJaYjB9yy/l7BsBvl8QTwYrP3UAAiOCkJPCFLpNDKpDO5/4MGG6KuT902xTMMM7n3qCXK4/zAqgoBMJgOLxYpgqLYnCIhvD8V8HozVgrvvuqdhGpsiIYVFNMzc667rIS6vH7lMRhyxzFURGRxCIOBFIBiCyWAAY7IiVYhg7eqnG6ZTYf8b3r4uxs6/6TIylMuDN534vI+hApDPA3Y79E4nfKjAarEgOpREuVREi8sPr8cDvpSDUAFe2LChLjobnkYDBChq7AW/uJ4USgUYLGa4ggycZgaJHIv87kF0nj0RZr8D6QyPg9v2olosw+hywmyzQs/nYTVU4MxwaPH6EPC0YuWqhxXV2gDvm2JJxUztWflLMszlxCG5Shmj/AQtfhOqegv2btmOeT0/wLQJE7Hn4H709m6GNxSCLxBE0WgBn8+K27HDCbirgDWRx/jJ7fRTgQLIKAqAwXQIDGNBulDB2FYdOrw6dI8OYc/uIQjZIhYtWIa7n3kSL7+9H5f0XISugBPRZBbJZBopVodIXI9sjIOuMIwWvQMb1/9BMb0KeKuKlooYevea35HjhUG0tR3DKCNB9LNBBMNWzOx2oaslDJsliLf+fQDb/96HPftYhGcEceUVZ8JF8uiPFEXjdg0L2B+zIB2pwOR0oxwTMFYXw9OPv6iIZlWkpYBIRcz8+YoHSF+6D9NCx3HFRd147S9bROlTO1wY23EWWjrOQFl3ELff+wa2vtOHR9f/BOfP7oQvMBvJ+A58sGsP9gwX0TdkQYE3QGe2gy+7EOL9WHPHnaLmW2/+EXn4kZcU0a+Az03bUhEDr156Izkw8B4wvBNzZk/EzoNpRFLDwDAQaNPB0+UDmImIHzJi284PMHN2O06basB0Xxv8rXpYAjw+HighlTUg1N6KYwkgnutCh60V72/+MwrpLMa3dMNSieOpDW8pMkPTJiazMMXMm/6tDmI0nDiYM1QcyHM5BDwG5CoCjh0Q8O1zzsd5s6Zh46ZX8fG+fvi7TJgymSC9i4WvQwezx4xFV56NBNOCzft1KOZbEeSC2PjcarSNCWLSuCmIHhlEx+klPLHqfcXmkNnvpmunmHHTz5tIssIwBIaBkTOATxWBFA+WBWqnA+ZecBa+M38ejuzqx++f/xMiqTScnUaMadOLkLirJnxvVgj7E3FETOMxoWsOdm/ehiOffoQff/9CWB1ebN2yFdPPbcW6h+hbwUjJUgyAmqBAu4NYPUZRG1NkMDrUgiPHj6Mt7MPkcV3IcCf+FhsaEn+fLXGwmAF4jfD6nXDobdDpbdD7jWh1n4l/vvZXzJ8/F2P1Aj757CA+PRbHqHEm/PGFDxWdY6TmqmE7xY2bOWsqKZiKyMVYhDwhZCIRMejpE8YhW0yJHs2cOAH7+o/C7etAOp9Dnqt9SRSCgXHARApwtYTQt3MvfG4Gi+ZejOH3t2BwuB8D/jAOxT7DjncPKT6HGsIciUbFjLtp6Q3E6ib/cfLm3HNmkb79+5ArcKJeh41BMBjAuI4x8IbbkEhEYTRaYTAZceRoH8KjO5HKFJE8PoDFPT8F9vbhWP+HiEYHYDv9G9gTT+Ldtz5SbI6RmKqmbepu3Nx5F5OdO7fDbvNj4qTxMBr0yLEFsIUCnDYbHE4bnE4XqkIFHFfA9l3bkE6lMXv6DHyzoxuxHW8jWogjAR6eWachkczh9b/11X0ONYX8/2mtm3GXXDqf8EIVnR1huJw+ZNkkKhUdIkMRsJk0bDYHwi0t4PkKsmwMLmcQ/9qxHelcWtQ/ZVIXHIf6UcxFxf9bZnbB0dqO53q31m0GrYT+v+eoi3m1V3045EMgEP4ieJ7nxbCNRpN4UYjDbkcunxf/LZdKYHNpvP76SxAIA95QRmvICXPiqKg9PLkDJnsARwZYvPfO/rrMoMXwazMpbt6cOd8lM2acAbfHg2Q8jnSW/eIqILONQXtLO0xmEwq5POLR2JeuDK5dM/CPLe+gzBVQ1hO4PSaE7ByI04TNr0QU167V0Ou2B7jwwgvIuHGdmDxlBio8h2gsCZ7jUAve5/aIN4UQUhW/MBqMHEOF43Dv8hVfCvbyy+eRT3b3oXvyZGzcsImGLjOVihg6/9IfkprOTRte1v1q+WJi1vtr5wNRrpTAGPTw+ULigV7tSmCH3YlEMoFkMopimcOqB3+rW7x4ITl69CheffUNUV9Pz8/Ipwf2Yeu7HyiiV2ZPVdVOdkNrYZnNBvT2Pqe75/6lhHAO1N7v7Q47HA4HTCYTGIZBPp+H3W4Xrwes3Sy6e9dOpNPZL0L/3MUlSxeScjWFI3tTePNNet5fbrpGDMDCG+cRrlzG872v/NceKx76DeE4DiajGV6vVww+y6bES7+LhTJyWRYevxexoRji6UE8S7/vlzvfr+w3YgC+qnPtZlChYkANAIfDCbPZLN4ZXDugMzM28W4ggSe4/bbbFdPwVRrp3xX8FPD5Y2H0egP8vqB4WVilUobfOwqkClQh4Kqeq2j4DaZQkQBqD4TIpMqo8BW4XV4IVR5VoYqWcBtKpZI48oIF9NEwDc5eXF4RAGoPg2DZIiwWG0xG5kuPhKl9EqCv/GaI/oQG2QF4an0vKZUzKJcE8IKAzvbR8Pn8yKSyqJIqLr/iMtnXbB471adE9jCeeaaXDEWHRCfGdHbD66udAUyBE8r0ld+EfMgOwLq1a0lF4OD3hqCDDkPxAdyyjD4AqgmzV+YtoPZIOJPehGuvXio7XM1qopp10ZDUnJ4M2ikAMpio5hYUADWnJ4N2CoAMJqq5BQVAzenJoJ0CIIOJam5BAVBzejJopwDIYKKaW1AA1JyeDNopADKYqOYWFAA1pyeDdgqADCaquQUFQM3pyaCdAiCDiWpuQQFQc3oyaKcAyGCimltQANScngzaKQAymKjmFhQANacng3YKgAwmqrkFBUDN6cmgnQIgg4lqbkEBUHN6MminAMhgoppbUADUnJ4M2ikAMpio5hYUADWnJ4N2CoAMJqq5BQVAzenJoJ0CIIOJam5BAVBzejJopwDIYKKaW1AA1JyeDNopADKYqOYWFAA1pyeDdgqADCaquQUFQM3pyaCdAiCDiWpuQQFQc3oyaKcAyGCimltQANScngzaKQAymKjmFhQANacng3YKgAwmqrkFBUDN6cmgnQIgg4lqbkEBUHN6MminAMhgoppbUADUnJ4M2ikAMpio5hYUADWnJ4N2CoAMJqq5BQVAzenJoJ0CIIOJam5BAVBzejJopwDIYKKaW1AA1JyeDNopADKYqOYWFAA1pyeDdgqADCaquQUFQM3pyaCdAiCDiWpuQQFQc3oyaKcAyGCimltQANScngzaKQAymKjmFhQANacng3YKgAwmqrkFBUDN6cmgnQIgg4lqbkEBUHN6MminAMhgoppbUADUnJ4M2ikAMpio5hYUADWnJ4N2CoAMJqq5BQVAzenJoJ0CIIOJam5BAVBzejJopwDIYKKaW1AA1JyeDNopADKYqOYWFAA1pyeDdgqADCaquQUFoA7pPfrYKuJyuHDNNdc1nd9NJ6gOedR1iU0vPkkGBoqoVDi0hjtRLOdxzdULm8b3phFS11TqvNiadY+TTCYFxsRg2tTTkYynkM4PY8n1yxruf8MF1DmLhiy39slHSblYRpnjYbPa0T1hEoqFEliWxZU9CxqaQUMXb0gaDVh03dOrSCpWEPcAZrMNFosFHe2dSCXTyBWyWHRt444NKAB1AGL9s6tJsVAVX/FeT0A8HrBabQj4QigUCoglB7HsptsakkVDFq2D5023xONrVpJ8noNeZ4DX60O+kIXD6YbVZIcgCA17K6AA1AmVlY8sJ+XiCbs9Hjd0Oh0EXoDL5YFBb0COZXHDkiV1z6PuC9bJ76Zc5v4VywnPC3A63LDbbeAqHHieg0HPiHpj8Rjuv++BumZS18WaMpU6ilp+368JV+JhsVkQ8AdgZIzIsRkYjQyikWFY7Xbcecdddc2krovV0eumXOrmu+YTh3ECdHoGer0OdpsdbrcbxVIBJqMJyVQCjMGCW269tW651G2hpkykAaJqewGL2YpshgVPKvB5fAiFwuC4Epx2D+LJKA4fPojHVq+rSzZ1WaQBPjftkrXvBSocQSKVAldiwVic8Hu98Pt94qcBg8GA48cPg0MaDy5/QvF8FF+gaZNooLB7lt9LWDaDfL4gHgzWfmoABEcFoScEqXQamVQG9z/woOL5KL5AA31u6qV7n3qCHO4/jIogIJPJwGKxIhiq7QkC4ttDMZ8HY7Xg7rvuUTQjRZs3dQINFnfddT3E5fUjl8mISspcFZHBIQQCXgSCIZgMBjAmK1KFCNauflqxnBRr3GB/m2r5+TddRoZyefCmE5/3MVQA8nnAbofe6YQPFVgtFkSHkiiXimhx+eH1eMCXchAqwAsbNiiWk2KNmyqBBom54BfXk0KpAIPFDFeQgdPMIJFjkd89iM6zJ8LsdyCd4XFw215Ui2UYXU6YbVbo+TyshgqcGQ4tXh8CnlasXPWwIlkp0rRBfjfVsj0rf0mGuZyoiauUMcpP0OI3oaq3YO+W7ZjX8wNMmzARew7uR2/vZnhDIfgCQRSNFvD5rLgdO5yAuwpYE3mMn9yuyKcCCoBC2NQAMJgOgWEsSBcqGNuqQ4dXh+7RIezZPQQhW8SiBctw9zNP4uW39+OSnovQFXAimswimUwjxeoQieuRjXHQFYbRondg4/o/yJ6X7A0V8lNVbe9e8ztyvDCItrZjGGUkiH42iGDYipndLnS1hGGzBPHWvw9g+9/7sGcfi/CMIK684ky4SB79kaI4665hAftjFqQjFZicbpRjAsbqYnj68RdlzUzWZqpKSUGxP1/xAOlL92Fa6DiuuKgbr/1li7ja1A4XxnachZaOM1DWHcTt976Bre/04dH1P8H5szvhC8xGMr4DH+zagz3DRfQNWVDgDdCZ7eDLLoR4P9bccaeY2a03/4g8/MhLJ53fSTdQ0EfVtr566Y3kwMB7wPBOzJk9ETsPphFJDQPDQKBNB0+XD2AmIn7IiG07P8DM2e04baoB031t8LfqYQnw+HighFTWgFB7K44lgHiuCx22Vry/+c8opLMY39INSyWOpza8dVIZntTGqk2oDsKnf6uDGA0nDuYMFQfyXA4BjwG5ioBjBwR8+5zzcd6sadi46VV8vK8f/i4TpkwmSO9i4evQwewxY9GVZyPBtGDzfh2K+VYEuSA2PrcabWOCmDRuCqJHBtFxeglPrHp/xDmOeMM6eKjqJaafN5FkhWEIDAMjZwCfKgIpHiwL1E4HzL3gLHxn/jwc2dWP3z//J0RSaTg7jRjTphchcVdN+N6sEPYn4oiYxmNC1xzs3rwNRz79CD/+/oWwOrzYumUrpp/binUPjfytgAKgIGaBdgexeoziCkyRwehQC44cP462sA+Tx3Uhw534W2xoSPx9tsTBYgbgNcLrd8Kht0Gnt0HvN6LVfSb++dpfMX/+XIzVC/jks4P49Fgco8aZ8McXPhxxjiPeUEHfNNV65qyppGAqIhdjEfKEkIlExKCnTxiHbDElzjpz4gTs6z8Kt68D6XwOea72JVEIBsYBEynA1RJC38698LkZLJp7MYbf34LB4X4M+MM4FPsMO949NOIcR7yhplJSYJiblt5ArG7yHydvzj1nFunbvw+5Aieu6rAxCAYDGNcxBt5wGxKJKIxGKwwmI44c7UN4dCdSmSKSxwewuOenwN4+HOv/ENHoAGynfwN74km8+9ZHI85xxBsq4Nkp0XLuvIvJzp3bYbf5MXHSeBgNeuTYAthCAU6bDQ6nDU6nC1WhAo4rYPuubUin0pg9fQa+2dGN2I63ES3EkQAPz6zTkEjm8Prf+kac44g3PCXSknHISy6dT3ihis6OMFxOH7JsEpWKDpGhCNhMGjabA+GWFvB8BVk2BpcziH/t2I50Li2qmDKpC45D/SjmouL/LTO74Ghtx3O9W08qw5PaWEZ/NN2q9qoPh3wIBMJfBM/zvBi20WgSLwpx2O3I5fPiv+VSCWwujddffwkCYcAbymgNOWFOHBV9Ck/ugMkewJEBFu+9s/+kMjypjTWdmkzDzZnzXTJjxhlwezxIxuNIZ9kvrgIy2xi0t7TDZDahkMsjHo196crg2jUD/9jyDspcAWU9gdtjQsjOgThN2PxKRJbsZGkik1eaa3PhhReQceM6MXnKDFR4DtFYEjzHoRa8z+0RbwohpCp+YTQYOYYKx+He5Su+lMnll88jn+zuQ/fkydi4YZPsecneUHMpjmCg+Zf+kNQ227ThZd2vli8mZr2/dj4Q5UoJjEEPny8kHujVrgR22J1IJBNIJqMoljmsevC3usWLF5KjR4/i1VffEPPp6fkZ+fTAPmx99wPZ85K94Qj80tQmtbDMZgN6e5/T3XP/UkI4B2rv93aHHQ6HAyaTCQzDIJ/Pw263i9cD1m4W3b1rJ9Lp7Behf27KkqULSbmawpG9Kbz55smd9/+/jKYAjBC/hTfOI1y5jOd7X/mvHq546DeE4ziYjGZ4vV4x+CybEi/9LhbKyGVZePxexIZiiKcH8awC3/d/1XgUgK9yaIR/r90MKlQMqAHgcDhhNpvFO4NrB3RmxibeDSTwBLffdntDM2jo4iP0VhWbff5YGL3eAL8vKF4WVqmU4feOAqkCVQi4queqhvvfcAGqSFOiyNoDITKpMip8BW6XF0KVR1WooiXchlKpJHZbsKCxj4b5fCQKgMRwv0557WEQLFuExWKDych86ZEwtU8CzfDKpwB8nSRHUPPU+l5SKmdQLgngBQGd7aPh8/mRSWVRJVVcfsVlTfWiayoxI/C76TZ55pleMhQdEnWN6eyG11c7A5gCJ5Sb6pVP9wAKobNu7VpSETj4vSHooMNQfAC3LGvMA6C+zoh0D/B1XJJQU3sknElvwrVXL1WFt6oQKcF/WirRAQqARMO0Vk4B0FqiEuehAEg0TGvlFACtJSpxHgqARMO0Vk4B0FqiEuehAEg0TGvlFACtJSpxHgqARMO0Vk4B0FqiEuehAEg0TGvlFACtJSpxHgqARMO0Vk4B0FqiEuehAEg0TGvlFACtJSpxHgqARMO0Vk4B0FqiEuehAEg0TGvlFACtJSpxHgqARMO0Vk4B0FqiEuehAEg0TGvlFACtJSpxHgqARMO0Vk4B0FqiEuehAEg0TGvlFACtJSpxHgqARMO0Vk4B0FqiEuehAEg0TGvlFACtJSpxHgqARMO0Vk4B0FqiEuehAEg0TGvlFACtJSpxHgqARMO0Vk4B0FqiEuehAEg0TGvlFACtJSpxHgqARMO0Vk4B0FqiEuehAEg0TGvlFACtJSpxHgqARMO0Vk4B0FqiEuehAEg0TGvlFACtJSpxHgqARMO0Vk4B0FqiEuehAEg0TGvlFACtJSpxHgqARMO0Vk4B0FqiEuehAEg0TGvlFACtJSpxHgqARMO0Vk4B0FqiEuehAEg0TGvlFACtJSpxHgqARMO0Vk4B0FqiEuehAEg0TGvlFACtJSpxHgqARMO0Vk4B0FqiEuehAEg0TGvlFACtJSpxHgqARMO0Vk4B0FqiEuehAEg0TGvlFACtJSpxHgqARMO0Vv4/4UgheX0qPjYAAAAASUVORK5CYII=",
 			"mode": "bitmap"
 		},
 		{
 			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.1\\1.20.1\\assets\\minecraft\\textures\\block\\slime_block.png",
-			"name": "slime_block",
+			"name": "slime_block.png",
 			"folder": "",
 			"namespace": "",
 			"id": "1",
@@ -3327,11 +3312,20 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "710feb26-3283-eb67-9151-529b56a5a7eb",
-			"relative_path": "C:/Users/afro/AppData/Roaming/.minecraft/versions/1.20.1/1.20.1/assets/minecraft/textures/block/slime_block.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAATZJREFUOE91UzsOwjAUe2WhCDGwoDIBYuAuHKMjK2OvVS7AijgAA6JMrVgYEKJdEPILjh6hzZTPi+NnO9F2n+YiIvdHJdNJgqnUL7fGGI/cXlgjvVjqZy0RAOJh7Is4wSFGPHCA4aiqq8yXK4myQ5oDTd61f5mvkgWZEAz7qME6SnfrfJrMlQ4Ommcj/WFf22l7ma0AAPW+hbIq9DJGksx++kYxKPOMDLB2AN8+Q8rUAC0W55Mys6K2AoQFAKcz1g3WeQblzQlDHWwboQO0HBr9Adhe/81zO2rhYqYiK4BVlpdC/3EJGoSWqo3W91ADghOY/jOtHqArcVY42kz6mgMkkYHRSH8TyV4hJu21IfN/AQDFxYXE9tiWCZ8LTPiZsuMmtyGh794B/JOO8fsbDXUrXJeo3P8A8vHhS/G8ANgAAAAASUVORK5CYII=",
 			"mode": "bitmap"
 		}
 	],
+	"variants": {
+		"default": {
+			"display_name": "default",
+			"name": "default",
+			"uuid": "d6a3882a-bc7c-c59b-6a97-31e1203d98c0",
+			"texture_map": {},
+			"excluded_bones": []
+		},
+		"list": []
+	},
 	"animations": [
 		{
 			"uuid": "e974eaae-c320-6a7a-79bc-6cee8261ba68",
@@ -3340,13 +3334,14 @@
 			"override": false,
 			"length": 0.45,
 			"snapping": 20,
-			"selected": false,
+			"selected": true,
+			"saved": true,
+			"path": "",
 			"anim_time_update": "",
 			"blend_weight": "",
 			"start_delay": "",
 			"loop_delay": "",
-			"affected_bones": [],
-			"affected_bones_is_a_whitelist": false,
+			"excluded_bones": [],
 			"animators": {
 				"45fa307f-d17d-28e2-17c7-80ea047e50b8": {
 					"name": "housefly",
@@ -3365,7 +3360,9 @@
 							"time": 0,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "linear"
+							"interpolation": "linear",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -3380,7 +3377,9 @@
 							"time": 0.25,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "linear"
+							"interpolation": "linear",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -3401,7 +3400,9 @@
 							"time": 0.25,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -3416,7 +3417,9 @@
 							"time": 0.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -3431,11 +3434,14 @@
 							"time": 0.45,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				}
 			}
 		}
-	]
+	],
+	"animation_controllers": []
 }

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/venus-fly-trap.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/venus-fly-trap.ajblueprint
@@ -1,55 +1,32 @@
 {
 	"meta": {
-		"format": "animated_java/ajmodel",
-		"format_version": "0.4.8",
-		"uuid": "738b7804-b312-52bc-9340-268c67328f74"
+		"format": "animated_java_blueprint",
+		"format_version": "0.5.3",
+		"uuid": "738b7804-b312-52bc-9340-268c67328f74",
+		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\venus-fly-trap.ajblueprint",
+		"last_used_export_namespace": "venus_fly_trap"
 	},
-	"animated_java": {
-		"settings": {
-			"project_namespace": "venus_fly_trap",
-			"project_resolution": [16, 16],
-			"target_minecraft_version": "1.20+",
-			"rig_item": "minecraft:white_dye",
-			"rig_item_model": "",
-			"rig_export_folder": "",
-			"texture_export_folder": "",
-			"enable_advanced_resource_pack_settings": false,
-			"resource_pack_mcmeta": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\pack.mcmeta",
-			"verbose": true,
-			"exporter": "animated_java:datapack_exporter"
-		},
-		"exporter_settings": {
-			"animated_java:datapack_exporter": {
-				"datapack_mcmeta": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java\\pack.mcmeta",
-				"outdated_rig_warning": true,
-				"root_entity_nbt": "{ CustomName: '\"Flies Indicator\"', Tags: [\"omega-flowey-remastered\",\"hostile\",\"groupable\",\"omega-flowey\",\"attack\",\"attack-indicator\",\"attack-indicator-new\",\"flies\"] }",
-				"use_component_system": true,
-				"include_variant_summon_functions": true,
-				"include_apply_variant_functions": true,
-				"include_uninstall_function": true,
-				"include_pause_all_animations_function": true,
-				"include_remove_rigs_function": true,
-				"include_remove_all_function": true,
-				"include_on_load_function_tags": true,
-				"include_on_tick_function_tags": true,
-				"include_on_summon_function_tags": true,
-				"include_on_remove_function_tags": true
-			},
-			"animated_java:json_exporter": {
-				"output_file": ""
-			}
-		},
-		"variants": [
-			{
-				"name": "default",
-				"textureMap": {},
-				"uuid": "c0d926f5-2fce-7be5-1e89-439fe587d4f8",
-				"boneConfig": {},
-				"default": true,
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			}
-		]
+	"project_settings": {
+		"export_namespace": "venus_fly_trap",
+		"show_bounding_box": false,
+		"auto_bounding_box": true,
+		"bounding_box": [48, 48],
+		"enable_plugin_mode": false,
+		"enable_resource_pack": true,
+		"enable_data_pack": true,
+		"display_item": "minecraft:white_dye",
+		"customModelDataOffset": 0,
+		"enable_advanced_resource_pack_settings": false,
+		"resource_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\",
+		"display_item_path": "",
+		"model_folder": "",
+		"texture_folder": "",
+		"enable_advanced_data_pack_settings": false,
+		"data_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java\\",
+		"summon_commands": "data merge entity @s {CustomName:\"\\\"Flies Indicator\\\"\"}\ntag @s add omega-flowey-remastered\ntag @s add hostile\ntag @s add groupable\ntag @s add omega-flowey\ntag @s add attack\ntag @s add attack-indicator\ntag @s add attack-indicator-new\ntag @s add flies",
+		"interpolation_duration": 1,
+		"teleportation_duration": 1,
+		"use_storage_for_animation": false
 	},
 	"resolution": {
 		"width": 16,
@@ -2154,7 +2131,10 @@
 			"origin": [0, 20, 0],
 			"rotation": [0, 90, 0],
 			"color": 0,
-			"nbt": "{}",
+			"configs": {
+				"default": {},
+				"variants": {}
+			},
 			"uuid": "9b9d3855-d682-8bfe-1162-2bb70b15c859",
 			"export": true,
 			"mirror_uv": false,
@@ -2167,7 +2147,10 @@
 					"name": "lower_lobe",
 					"origin": [-36.5, 20, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "5df3e100-8feb-f979-09c5-61d9aead3202",
 					"export": true,
 					"mirror_uv": false,
@@ -2209,7 +2192,10 @@
 					"origin": [-36.5, 26, 0],
 					"rotation": [0, 0, 20],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "ba5ee458-f8b5-974c-c61f-c586dc675dac",
 					"export": true,
 					"mirror_uv": false,
@@ -2251,7 +2237,7 @@
 	"textures": [
 		{
 			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.1\\1.20.1\\assets\\minecraft\\textures\\block\\lime_terracotta.png",
-			"name": "lime_terracotta",
+			"name": "lime_terracotta.png",
 			"folder": "",
 			"namespace": "",
 			"id": "0",
@@ -2273,13 +2259,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "e81de70c-24e5-4a48-bff6-c9540a4b99a2",
-			"relative_path": "C:/Users/afro/AppData/Roaming/.minecraft/versions/1.20.1/1.20.1/assets/minecraft/textures/block/lime_terracotta.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAdlJREFUOE9NU9GO2zAMoyQnvfueu/V+6LBs2J42FMW+fNfYkjbKaTcXKBLHIimKlu3ymp6J+zIIxAzNBOmJWww8tQaeGH1gRNRRAWCqEAJwY2ltYgQwIIjoEAILICowNUQCvQ+YshwgsWyXc+4ZWHgwszarTgATQTPDeOibBLKwmkoC8uV6TiJ6JNIdgzRIiCqeRNGr+GhRWTPZC4kKCNBUipV/DmDfO6iS5yGGkMTzQlqgj1FwJCChfP/1lmSV6pvyHUr9U8dDPH34f2UElmaQb9dzhkwFSfnppcKgWNhCjvkucpippT6QcCr4en3LCH/IP5kV0c0dJzJA0MuwEj5HqNw9ngnAXsnS+36MK6BSDtQ0RA1NgKxJ3TelRnooCGQmImdIWKX0BAkrIH4/GG0Cr6aVC9kuL0k5CYXHKJrn01JT+H37gLS1xDKZ/DY4hYk5g/T+4yXNZkdEJGujqTrNWliogNOmIw+VRCY2AvL552tN65jcNCunJ2zjtK5QH/hwhydKmRA05lRku56P7ng5pJKo7K/3SifHx7XDYfUjmcBWgzDW2+VTFixfxo5+5P+eygmgoJfVZgQ8Axww70ldppnZf4vSafZg3CuPLJ13hQnkrIx5+evTH197CDvWqhWdAAAAAElFTkSuQmCC",
 			"mode": "bitmap"
 		},
 		{
 			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.1\\1.20.1\\assets\\minecraft\\textures\\block\\pink_terracotta.png",
-			"name": "pink_terracotta",
+			"name": "pink_terracotta.png",
 			"folder": "",
 			"namespace": "",
 			"id": "1",
@@ -2301,11 +2286,20 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "25a5846d-5ac6-51b0-7fc8-7257ad985a43",
-			"relative_path": "C:/Users/afro/AppData/Roaming/.minecraft/versions/1.20.1/1.20.1/assets/minecraft/textures/block/pink_terracotta.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAd5JREFUOE89U+1ymzAQ3DsJu3m21Db1C9bjZKaP2Bh0t5k9IPgHBkm3n9jjciVJHJfB0FpDa4YksY6B89SRAMY6kKF/gBlg7jANcAB96jCtJDBoCK6ABhvQ3ODeIaB1WdFcJ4AgYY/rjSuJSadJMAnx0aO5obeGPF4Qxap1A4pJwj7mmdrISDACg5pDuDvO7hjadkh0wFk8AUbJso/bjQcKmYW+LCtcGmtnA414O031JE+Cm6zIhP273zkiYOYYmUDGj0buIw7TyrlCJyJZ5trnPFMLYqmJEAshmGOyhjUXBAxmVqjWHFYyE2OEBtyZMSDyOjj1tlMNTFODwzAiywffGVSEtiVRAzSytL+W6gClbY+qXFAvDJB/Qhdj/eSHfc5/mLkh6ODRElFWGso85ffuvrcN+dS8zLTn5TdFRzoVo7x/O2+Of72+4P1U3nX3YhljbLNyL9Lf9wvLHHVj70BXL8yRSZy6l4FyfRMKuNZVqkjY4/1KbKzqlkZ48sf5X6cTLAb+R1RLBVQyuIHa8zbTypnt41AXqljLUm1VS53EC4GOrlrVPldCGvK83pgFDbR1wWoOb1rMHxaCKpkgMsQu0Qh479vHdOQr+ro6vA4MSWFWqapgEVtaitabzMA3V6wtC94eusYAAAAASUVORK5CYII=",
 			"mode": "bitmap"
 		}
 	],
+	"variants": {
+		"default": {
+			"display_name": "default",
+			"name": "default",
+			"uuid": "c0d926f5-2fce-7be5-1e89-439fe587d4f8",
+			"texture_map": {},
+			"excluded_bones": []
+		},
+		"list": []
+	},
 	"animations": [
 		{
 			"uuid": "059e51fb-a50b-325d-93b0-74941af33254",
@@ -2314,13 +2308,14 @@
 			"override": false,
 			"length": 0.5,
 			"snapping": 20,
-			"selected": false,
+			"selected": true,
+			"saved": true,
+			"path": "",
 			"anim_time_update": "",
 			"blend_weight": "",
 			"start_delay": "",
 			"loop_delay": "",
-			"affected_bones": [],
-			"affected_bones_is_a_whitelist": false,
+			"excluded_bones": [],
 			"animators": {
 				"5df3e100-8feb-f979-09c5-61d9aead3202": {
 					"name": "lower_lobe",
@@ -2338,7 +2333,9 @@
 							"uuid": "f80d1b1d-2819-5600-8e46-8443bb1a6baf",
 							"time": 0,
 							"color": -1,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2352,7 +2349,9 @@
 							"uuid": "bbecb4f7-bfdf-869e-85db-1b54681cbacf",
 							"time": 0.4,
 							"color": -1,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2366,7 +2365,9 @@
 							"uuid": "8677127f-734f-f668-929e-9fb485616b5f",
 							"time": 0.5,
 							"color": -1,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -2386,7 +2387,9 @@
 							"uuid": "286822eb-a379-81ec-b61d-9e65cf201d43",
 							"time": 0,
 							"color": -1,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2400,7 +2403,9 @@
 							"uuid": "56316c4c-42ab-9279-14f9-58679372ce5c",
 							"time": 0.4,
 							"color": -1,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2414,11 +2419,14 @@
 							"uuid": "ad47eae0-4c08-131c-eee7-803f5f3b4ee3",
 							"time": 0.5,
 							"color": -1,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				}
 			}
 		}
-	]
+	],
+	"animation_controllers": []
 }


### PR DESCRIPTION
# Summary

This PR migrates the necessary AJ blueprints to re-enable the `flies` attack for Minecraft 1.21.

The models we needed to migrate were `housefly` and `venus-fly-trap`.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Reproducing in-game

```mcfunction
function _:attack/flies
```

---

## Supplemental changes

N/A

<!--
describe what other changes this PR makes which aren't specific to its main purpose.
- does it contain a world backup? (recommended)
- does it contain other miscellaneous code cleanup?

format these extra changes with bullet points, preferrably.
-->
