### PR TITLE
⬆️ 🍱 migrate `tv-screen` model to AJ v1.0

### DIFF
--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/vanilla/initialize.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/vanilla/initialize.mcfunction
@@ -1,7 +1,7 @@
 ## Initializes the boss fight
 
 # Summon Omega Flowey entity if it doesn't exist
-execute unless entity @e[tag=aj.tv_screen.root] run function entity:hostile/omega-flowey/summon
+execute unless entity @e[tag=aj.tv_screen.root] run function entity:hostile/omega-flowey/summon { args: {} }
 
 # Set all attack parameters to default
 function entity:hostile/omega-flowey/attack/reset_scores

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/vanilla/phase/soul/loop/next_event.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/vanilla/phase/soul/loop/next_event.mcfunction
@@ -2,7 +2,7 @@
 execute if score @s boss-fight.progress.phase.i matches 0 run function entity:directorial/boss_fight/vanilla/phase/soul/loop/next_event/0
 
 # Change tv screen variant
-execute as @e[tag=aj.tv_screen.root,tag=tv_screen.soul] run function animated_java:tv_screen/apply_variant/default
+execute as @e[tag=aj.tv_screen.root,tag=tv_screen.soul] run function animated_java:tv_screen/variants/default/apply
 
 # Summon and begin animating soul heart model in front of soul screen
 execute store result storage animate:soul soul_index int 1 run scoreboard players get @s boss-fight.progress.phase.i

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/vanilla/phase/soul/static/as_root.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/vanilla/phase/soul/static/as_root.mcfunction
@@ -1,4 +1,4 @@
 # Play static sound
 playsound omega-flowey:boss-fight.static ambient @a ~ ~ ~ 10
 
-function animated_java:tv_screen/apply_variant/static
+function animated_java:tv_screen/variants/static/apply

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate/soul/tv_screen.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate/soul/tv_screen.mcfunction
@@ -1,2 +1,2 @@
 function animated_java:tv_screen/animations/move/play
-function animated_java:tv_screen/apply_variant/default
+function animated_java:tv_screen/variants/default/apply

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate/tv-screen/default.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate/tv-screen/default.mcfunction
@@ -1,3 +1,3 @@
 function animated_java:tv_screen/animations/move/play
-function animated_java:tv_screen/apply_variant/default
+function animated_java:tv_screen/variants/default/apply
 execute on passengers as @s[tag=aj.tv_screen.bone.screen] run data remove entity @s brightness

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate/warning/tv_screen.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate/warning/tv_screen.mcfunction
@@ -1,2 +1,2 @@
-function animated_java:tv_screen/apply_variant/warning
+function animated_java:tv_screen/variants/warning/apply
 execute on passengers if entity @s[tag=aj.tv_screen.bone.screen] run data merge entity @s { brightness: { block: 15, sky: 0 } }

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/friendliness-pellets/indicator/loop.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/friendliness-pellets/indicator/loop.mcfunction
@@ -5,7 +5,7 @@ scoreboard players add @s attack.clock.i 1
 # TODO(45): refactor repeated `attack.clock.i` conditionals into separate functions
 # Change ring variant at tick index
 execute if score @s attack.clock.i = @s attack.indicator.animation.index run function entity:group/start
-execute if score @s attack.clock.i = @s attack.indicator.animation.index as @e[tag=friendliness-pellet-ring,scores={group.id=0}] run function animated_java:friendliness_pellet_ring/apply_variant/finished_blinking
+execute if score @s attack.clock.i = @s attack.indicator.animation.index as @e[tag=friendliness-pellet-ring,scores={group.id=0}] run function animated_java:friendliness_pellet_ring/variants/finished_blinking/apply
 execute if score @s attack.clock.i = @s attack.indicator.animation.index run function entity:group/end
 
 # Play blinking sound before we summon bullets

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon.mcfunction
@@ -35,7 +35,7 @@ tag @e[tag=aj.petal_pipe_middle.root,tag=!petal_pipe.right] add petal_pipe.left
 execute positioned 0 37 -13 rotated 0 10 run function animated_java:nose/summon
 
 ## TV-screen
-execute positioned 0 49 -6 rotated 0 45 run function animated_java:tv_screen/summon
+execute positioned 0 49 -6 rotated 0 45 run function animated_java:tv_screen/summon { args: {} }
 tag @e[tag=aj.tv_screen.root,tag=!tv_screen.soul,tag=!tv_screen.boss_fight] add tv_screen.boss_fight
 
 ## Upper eyes

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/soul/tv_screen.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/soul/tv_screen.mcfunction
@@ -1,2 +1,2 @@
-execute positioned 0 49 -81 rotated 0 45 run function animated_java:tv_screen/summon
+execute positioned 0 49 -81 rotated 0 45 run function animated_java:tv_screen/summon { args: {} }
 tag @e[tag=aj.tv_screen.root,tag=!tv_screen.soul,tag=!tv_screen.boss_fight] add tv_screen.soul

--- a/package-scripts/watch.js
+++ b/package-scripts/watch.js
@@ -3,8 +3,8 @@ const { watch } = require('chokidar');
 const dotenv = require('dotenv');
 const findProcess = require('find-process');
 const { copy, remove, readFile, writeFile } = require('fs-extra');
-const { glob } = require('glob');
-const { difference, findKey, uniq } = require('lodash');
+// const { glob } = require('glob');
+const { findKey, uniq } = require('lodash');
 const minimist = require('minimist');
 const { spawn } = require('node:child_process');
 const { resolve, parse } = require('path');
@@ -408,28 +408,28 @@ const watchModels = async () => {
  * Gets the list of the current `.ajmodel`s, the list of exported files (the cache; `last_exported_hashes.json`),
  * and deletes entries found in the cache whose corresponding `.ajmodel` files were not found
  */
-const deleteStaleExportFiles = async () => {
-  const log = (...args) => {
-    const prefix = chalk.bgYellow(chalk.bold('[initializing]'));
-    console.log(prefix, ...args);
-  };
+const deleteStaleExportFiles = async () => void 0;
+// TODO: this needs to be updated to the AJ v1.0 format
+// const log = (...args) => {
+//   const prefix = chalk.bgYellow(chalk.bold('[initializing]'));
+//   console.log(prefix, ...args);
+// };
 
-  const ajmodels = await glob(`${ajmodelDir}/**/*.ajmodel`);
-  const lastExported = Object.values(parseLastExportedHashes(ajmodelDir));
-  const validExportedModels = lastExported.filter(({ path }) =>
-    ajmodels.some((ajmodelPath) =>
-      path.endsWith(ajmodelPath.replaceAll('\\', '/')),
-    ),
-  );
-  const staleExportedModels = difference(lastExported, validExportedModels);
-  if (staleExportedModels.length > 0) {
-    const modelNames = staleExportedModels.map(({ path }) => parse(path).name);
-    log('deleting stale export files for:', modelNames);
-    await Promise.all(
-      staleExportedModels.map(({ path }) => deleteExportedFiles(path)),
-    );
-  }
-};
+// const ajmodels = await glob(`${ajmodelDir}/**/*.ajmodel`);
+// const lastExported = Object.values(parseLastExportedHashes(ajmodelDir));
+// const validExportedModels = lastExported.filter(({ path }) =>
+//   ajmodels.some((ajmodelPath) =>
+//     path.endsWith(ajmodelPath.replaceAll('\\', '/')),
+//   ),
+// );
+// const staleExportedModels = difference(lastExported, validExportedModels);
+// if (staleExportedModels.length > 0) {
+//   const modelNames = staleExportedModels.map(({ path }) => parse(path).name);
+//   log('deleting stale export files for:', modelNames);
+//   await Promise.all(
+//     staleExportedModels.map(({ path }) => deleteExportedFiles(path)),
+//   );
+// }
 
 const main = async () => {
   const argv = minimist(process.argv.slice(2));

--- a/package-scripts/watch.js
+++ b/package-scripts/watch.js
@@ -409,7 +409,7 @@ const watchModels = async () => {
  * and deletes entries found in the cache whose corresponding `.ajmodel` files were not found
  */
 const deleteStaleExportFiles = async () => void 0;
-// TODO: this needs to be updated to the AJ v1.0 format
+// TODO(103): this needs to be updated to the AJ v1.0 format
 // const log = (...args) => {
 //   const prefix = chalk.bgYellow(chalk.bold('[initializing]'));
 //   console.log(prefix, ...args);

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/tv-screen.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/tv-screen.ajblueprint
@@ -1,75 +1,32 @@
 {
 	"meta": {
-		"format": "animated_java/ajmodel",
-		"format_version": "0.4.8",
-		"uuid": "de143d69-7d25-8ad1-c9e8-f45f431753b9"
+		"format": "animated_java_blueprint",
+		"format_version": "0.5.3",
+		"uuid": "de143d69-7d25-8ad1-c9e8-f45f431753b9",
+		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\tv-screen.ajblueprint",
+		"last_used_export_namespace": "tv_screen"
 	},
-	"animated_java": {
-		"settings": {
-			"project_namespace": "tv_screen",
-			"project_resolution": [16, 16],
-			"target_minecraft_version": "1.20+",
-			"rig_item": "minecraft:white_dye",
-			"rig_item_model": "",
-			"rig_export_folder": "",
-			"texture_export_folder": "",
-			"enable_advanced_resource_pack_settings": false,
-			"resource_pack_mcmeta": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\pack.mcmeta",
-			"verbose": true,
-			"exporter": "animated_java:datapack_exporter"
-		},
-		"exporter_settings": {
-			"animated_java:datapack_exporter": {
-				"datapack_mcmeta": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java\\pack.mcmeta",
-				"outdated_rig_warning": true,
-				"root_entity_nbt": "{Tags:[\"omega-flowey-remastered\", \"omega-flowey\", \"omega-flowey-tv-screen\"]}",
-				"use_component_system": true,
-				"include_variant_summon_functions": true,
-				"include_apply_variant_functions": true,
-				"include_uninstall_function": true,
-				"include_pause_all_animations_function": true,
-				"include_remove_rigs_function": true,
-				"include_remove_all_function": true,
-				"include_on_load_function_tags": true,
-				"include_on_tick_function_tags": true,
-				"include_on_summon_function_tags": true,
-				"include_on_remove_function_tags": true
-			},
-			"animated_java:json_exporter": {
-				"output_file": ""
-			}
-		},
-		"variants": [
-			{
-				"name": "default",
-				"textureMap": {},
-				"uuid": "59805ee0-d249-bf4c-f01a-67b2cd10bd88",
-				"boneConfig": {},
-				"default": true,
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			},
-			{
-				"name": "static",
-				"textureMap": {
-					"32717bc3-fe35-1fc8-9bbf-54407fe854d1": "ace7b2d9-46d0-50f0-a1f8-0a1722e76aa2"
-				},
-				"uuid": "45118c10-b51f-36c7-a1ca-37d0f846c2ed",
-				"boneConfig": {},
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			},
-			{
-				"name": "warning",
-				"textureMap": {
-					"32717bc3-fe35-1fc8-9bbf-54407fe854d1": "69769926-e76c-4d11-b4f8-82ddedcfad5e"
-				},
-				"uuid": "585fe02c-c7d9-99ae-1095-3e2099d4a99d",
-				"boneConfig": {},
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			}
-		]
+	"project_settings": {
+		"export_namespace": "tv_screen",
+		"show_bounding_box": false,
+		"auto_bounding_box": true,
+		"bounding_box": [48, 48],
+		"enable_plugin_mode": false,
+		"enable_resource_pack": true,
+		"enable_data_pack": true,
+		"display_item": "minecraft:white_dye",
+		"customModelDataOffset": 0,
+		"enable_advanced_resource_pack_settings": false,
+		"resource_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\",
+		"display_item_path": "",
+		"model_folder": "",
+		"texture_folder": "",
+		"enable_advanced_data_pack_settings": false,
+		"data_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java\\",
+		"summon_commands": "tag @s add omega-flowey-remastered\ntag @s add omega-flowey\ntag @s add omega-flowey-tv-screen",
+		"interpolation_duration": 1,
+		"teleportation_duration": 1,
+		"use_storage_for_animation": false
 	},
 	"resolution": {
 		"width": 16,
@@ -430,8 +387,11 @@
 			"ignore_inherited_scale": false,
 			"visibility": true,
 			"locked": false,
-			"entity_type": "minecraft:marker",
-			"nbt": "{}",
+			"config": {
+				"use_entity": true,
+				"entity_type": "minecraft:marker",
+				"summon_commands": "data merge entity @s {}"
+			},
 			"uuid": "1d42e3f8-19ee-bf07-fd0b-28fe3e44877c",
 			"type": "locator"
 		},
@@ -442,8 +402,11 @@
 			"ignore_inherited_scale": false,
 			"visibility": true,
 			"locked": false,
-			"entity_type": "minecraft:marker",
-			"nbt": "{}",
+			"config": {
+				"use_entity": true,
+				"entity_type": "minecraft:marker",
+				"summon_commands": "data merge entity @s {}"
+			},
 			"uuid": "ef11bc42-2b8d-f574-45ea-f5eb20bd1a98",
 			"type": "locator"
 		}
@@ -453,7 +416,10 @@
 			"name": "root",
 			"origin": [6, 0, -28.8],
 			"color": 0,
-			"nbt": "{}",
+			"configs": {
+				"default": {},
+				"variants": {}
+			},
 			"uuid": "9afbce00-c281-2321-0204-49c52e10c4a5",
 			"export": true,
 			"mirror_uv": false,
@@ -466,7 +432,10 @@
 					"name": "box",
 					"origin": [6, 0, 31.2],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "a392135b-a4c6-2b9e-d88f-f3b3746d5270",
 					"export": true,
 					"mirror_uv": false,
@@ -488,7 +457,10 @@
 					"name": "screen",
 					"origin": [6, 0, 43.2],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "45a8a5ff-3119-128b-1359-00ba45ae630e",
 					"export": true,
 					"mirror_uv": false,
@@ -504,7 +476,7 @@
 	"textures": [
 		{
 			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.2-pre1\\1.20.2-pre1\\assets\\minecraft\\textures\\block\\netherite_block.png",
-			"name": "netherite_block",
+			"name": "netherite_block.png",
 			"folder": "",
 			"namespace": "",
 			"id": "0",
@@ -526,13 +498,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "370b8b73-4e6c-b936-26ae-cafa974e6fc9",
-			"relative_path": "C:/Users/afro/AppData/Roaming/.minecraft/versions/1.20.2-pre1/1.20.2-pre1/assets/minecraft/textures/block/netherite_block.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAWpJREFUOE+Fk09Lw0AQxWehoUnTiEawB0tQVFBv9tzv/wEEKYKCLb3kEqVr/rGByNt2trMS6FyS7M789r2ZjVouFn1ZNxRHIZ0KmYd3XZakXp6e+9k8ozRNT9WT3mlKzhKbh/fV2yspKMgeHmm9WVMy3W8Go8DBqrqiIAho1Bm71h32kOMB8jz3ElU4sQWmMw7YNxXVPVHTNpSepz6gKAoyxlCkiFCMZIawHMCQ0+6+aXp5RR/vq6MFVsAQSIVMeIZfDlhiQL7d+ABOgmfZB0CgkEP/atsvTwFbYH//R8LyAQdgsAfyVG4gT4WnAYs4BAo8C+yTPaNAWkKhhR0UOAAu0vzmziVz9yUAmzgVodraPi9m1/4YoYCL8cQU4BURjkMPoKuastv7PYAVFD+Fu4nW/8GrBOB0FCMGAUjox5GzIwvkVJJJZC1svz6PCjAm1zTxL8irLCFYt/cAFvBbeifEsf2U68nAGnL+AK7IFKyaYaryAAAAAElFTkSuQmCC",
 			"mode": "bitmap"
 		},
 		{
 			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.2-pre1\\1.20.2-pre1\\assets\\minecraft\\textures\\block\\black_concrete.png",
-			"name": "black_concrete",
+			"name": "black_concrete.png",
 			"folder": "",
 			"namespace": "",
 			"id": "1",
@@ -554,13 +525,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "32717bc3-fe35-1fc8-9bbf-54407fe854d1",
-			"relative_path": "C:/Users/afro/AppData/Roaming/.minecraft/versions/1.20.2-pre1/1.20.2-pre1/assets/minecraft/textures/block/black_concrete.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAPtJREFUOE99k9kSwiAMRUv7oK2Oy/9/a4tzooeJyMhLINwkN1s5b/c6z/PE2fd9KqXEHXkcx+Qfd3T5v9Y6le36rBguy9IMeHM0BqhTZBiW8pYwUIkTwUTkLSv1P4zWy6PqEUc91Qj9SQlcxsb9tN5qzqsHE9EUM5uWAjUwsqnkfBswFfeLKQyIAtDicUdnF5DWwDqhi0A4yMpR2wTr1A61LvQ1sJAWUCbORsYHg+zZnPsZEOM/0SN12mikvkUA0GVGGoptbezT0FAndsh3wzsHUhuN7Gg2WitJ4R9FC+gU5smM5eodjLbQOXFjfUdgi5jn3LXNi5W7ox75AoSGFC+2epdnAAAAAElFTkSuQmCC",
 			"mode": "bitmap"
 		},
 		{
 			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\tv_screen\\warning.png",
-			"name": "warning",
+			"name": "warning.png",
 			"folder": "",
 			"namespace": "",
 			"id": "2",
@@ -582,13 +552,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "69769926-e76c-4d11-b4f8-82ddedcfad5e",
-			"relative_path": "../../../../../textures/custom/tv_screen/warning.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKAAAAFACAYAAAA7/HcbAAAAAXNSR0IArs4c6QAADmFJREFUeF7tncuSHDUQRWfsBc/guWXJiv//FlYs2fIMwHjhMVEOmmjKqrpX6lSPpDxspc7KvPcoJVW3h8cH878PP/78rZr64sULNUWOv3nzRs55fHyUc5wJKs7T05MME1Hz9hD1LJXrFsOZIwsy4rx9K1F4ePXnr5ZJ1qQtaQAsWweAZV0A0FjqqmOorrQ9AgAB0ECtPAUA23RhC+YMWCRHLSh3pao4AAiA+QD8+NMv5dXHucG+fPnydCFGnbucXFRHiDrfOR1D5aK6kvr8ZdzJRT3LifH3X79ZF1xr0pY8ALoWvz/PMUxFV1CozwPgvwrQAV1U/j8PANmC28h5eHigAx5LxxZ8ghVnwLI4zoLiDGh8padaGgACYFEBBwxuwe3wqPPms3RA57tg1VG2cZW8uqQ4MZw8tjnqlY+TiwO6MjSqJmdhOtooXZx6wrdgACxbB4BlXQDQWOpqpdMByyLSAY3foxn8sQUfiKQWJgACYPPlLGJhAiAA5gPwo0++kD9GUDfcTTVn9ahVqrYI9zkRuahc3XGVi6OtM0c9x8nXeU74JQQAHWva5ygwHNOdOeo5TgXOcwDQ+M1ghBmOYc4clYtjujNHPcfJ1XkOAAJgkSUANMBQq5AzYL+v2ZT27rc2dEAD9Ihu4BjmzFG5ONueM0c9x8nVeU44gB989Jm8BUcUFxHDvQUrIdX49hzn+1fn6zr1rYsTw9HOqUnFcWK8fvW79VM/a9ImNACWewMAlnUBQGMLVitZjdMBjzdsAATAIh3OomILdk7CYo4S0bnNOWaxBbMFN7/vUoCpcbbgO27Bzr8LdhqX8w5PxXHAUDHcm7KKE9Fp75mLqmcbVx45NYf/dSwALFvnmOEsGCeOgiciBgAqlY1/V2KEeDclwjAnBgAeO2K/B6QD0gEvCjiLji3YaIOOkCqME4MOSAdsvikD4PsKOIuODqjI4Qx4qNCQt2Dnu2DnpaxaPc6X7gZb1gVD5auMcN8DOnGcbVrVrX7QsH3eeY6Tr8rlWb6KU4Y6N08AVNYejwOg8f8JoQOWAXI6k0ITAAGwyIizpQGgWF6cAcsCOccOAAx4DQOAAKiOANfjz3IJiTiDON3C6TqOWOpZ6rzqXKq2Oeo5Tq5OzRHPcW72znHhWf5NCACWUYoAAwCNf5QEgAB4UYAOaOxrqjOxBbe/MgJAADQUaLtYcQY03jc66tMBJwLQ+RvRzpalwIiI4d48o56lalKgOzdPJ1fnOU4cVY8T468/frF+a2pN2hICQGXL8bgDhrrlOqY7z3HiqEqdGAD49KR0tH4xI4MYExwwAFAISQc0SDuYAoDH2rEFt3NlfxIAAbCogHOWsSk7mQiAAQBG/RjBMUOZ7oDjvKtS5y6VxzbuPMeJo3JxdIvSRdWkct3qDf83IQBYxkiZ5cDnvIYBQOO7YGdlOEIq06JWupOvygUAywrRAY3/mQ0AtnV1RzcABMAiXU7HVnMAMOCPTzrnLrX9cgk5VogOSAdcqwM6/6sup2OoOar9b593LiHqOU73crYaJ1/n4hVRk5NLRE1OruEdEADbDuzbpwAw4EU0AALgRQE6oHEJYQsuK8AWLMhwzjHOCgRAAHQYeG8OADbJ9u5DjnbTdkDnu2CnMzlzlAURMRzDnMtDhKGqXidX972mA2mEvuG3YADst6UBoKEAAAKggcl/U+iAhlpqO2ILNkQ8mAKAhnYAWBaJM6CAJ0Ig52BPBzRW8WodUHUlV5IISJ1cIp6z1aTiOLk4c5xbu9LYWZjP8rdhlIhRQiuBnOc4MRxDnZqdZ6k4Ti7OHAAUX6M5IkYY6sRwclHgOM9xFoyTizMHAAGwyKQC2YHLmQOAAAiAVwrYfxnhXi+inVXsbGuqozgxnFwinsMWbLjh/B7QuR1FGOaA4Ww1Ko6Tq1NzRC4qV8NCe4qqW41vDwp/EQ2AZf8AsKwLABp/RVV1FWelAyAAFhWI2PYAsP2rOjogHdA+8+0nqoWnxjkDPjw80AGb+ZNfCwJg0D865wzYtsWmB9ARIOpyoPpI1HOcmlQuzv/s29kZVC5OzeE/RhjpNYwSaDPKEckxQ5ke9RynJpULAN7pL9M7ZkWBoUyPeo5Tk8oFAAGw+ZUQAIrlxRbc95sQAARAtcMVx9mCy7I9yyXEcVC9+lDjzi9HouY4uTg1O5CqDujk4lyqnDiqJifG61e/W7+0siZtCTlbsEp8G1fJq/EouJw4Ti5OzQB4rBIAnhAEgGVxHF3ogMafcIvY9uiAZQUAEACLZDjdSy0qJwYAAuBaAKpVwTgKtChgX0JagvMZFFAKAKBSiPGuCgBgV3kJrhQAQKUQ410VAMCu8hJcKQCASiHGuyoAgF3lJbhSAACVQox3VQAAu8pLcKUAACqFGO+qAAB2lZfgSgEAVAox3lUBAOwqL8GVAgCoFGK8qwIA2FVegisFAFApxHhXBQCwq7wEVwoAoFKI8a4KAGBXeQmuFABApRDjXRUAwK7yElwpAIBKIca7KgCAXeUluFIAAJVCjHdVAAC7yktwpQAAKoUY76oAAHaVl+BKAQBUCjHeVQEA7CovwZUCAKgUYryrAgDYVV6CKwUAUCnEeFcFALCrvARXCgCgUojxrgoAYFd5Ca4UAEClEONdFQDArvISXCkAgEohxrsqAIBd5SW4UgAAlUKMd1UAALvKS3ClAAAqhRjvqgAAdpWX4EoBAFQKMd5VAQDsKi/BlQIAqBRivKsCANhVXoIrBQBQKcR4VwUAsKu8BFcKAKBSiPGuCgBgV3kJrhQAQKUQ410VAMCu8hJcKQCASiHGuyoAgF3lJbhSAACVQox3VQAAu8pLcKUAACqFGO+qAAB2lZfgSgEbwJ+++fatCsY4ClwU+PrHHyy2rElbUAAErhoFALBGLeaGKwCA4ZISsEYBAKxRi7nhCgBguKQErFEAAGvUYm64AgAYLikBaxQAwBq1mBuuAACGS0rAGgUAsEYt5oYrAIDhkhKwRgEArFGLueEKAGC4pASsUQAAa9RibrgCABguKQFrFADAGrWYG64AAIZLSsAaBQCwRi3mhisAgOGSErBGAQCsUYu54QoAYLikBKxRAABr1GJuuAIAGC4pAWsUAMAatZgbrgAAhktKwBoFALBGLeaGKwCA4ZLWB/zq+x/efejn776t/3DDJy7P23/0Xs+/fi4A/qvGtSn3NmIP4C1Abp89y/8IvgsU9659SgBrDHLmlkw5MqKmezjP3ow/ArC2KzqLSAFY+8yGBvy/jywN4K2G7CFU5p3Nd7vSZZ4L77Wb+/xU/tfj6rO3gnb0+dQA1gB1BvORea6ppdgt27J6nlqQarwHhAAoVK3pSGdb6dnWdg8AFZwXGVo67y1gTgdgzSqt7VpnZ0HHmP3znLOl6p77BeCCvJ9Xo9stQNV+FgCvXn/cCuD+QuFcWFoAPILwrMsBYO3SOJjvdKL9dlIy7MgQBYTbgbbO1RNAVRMdMAi4fRgXQHXmuQVAVVpp29x/5mjO0ZnzFpivO/O9X7MorabdgtULU/f8576qOALgCKy96Rfj1TnRAfC6u7qvUlw97g1oegDVClXdrGUhnMFcC+A1MK1nQOeypHRqHV8CwNK2XLPiz8RTAKqO4W71lxxcAPcXnqOO65yHr+t3jzitwO0/lx7A1i14f8lwvro72y5vAbC0vbdeQgBQLK1SRznrgCUwarrj2WVBXXTU4b/mtY/qpKVb9xHwzteC6miRvgOWzj7uS9teAJa245pntdTknCfVQqjdpqPg2+JMuwW3mOUKfdZlj7bKa1OOtvWabXrf1dWLZHWRuLVbR0J3HWtqAB1Rarfgo27h3jDPuuDIACrAHa1b5kwHoAtICYRbOqDaxpyttieATm0t7zJboKr5zLIAOgftI0jVgV+d9c7gd82p3YL3ADqwl3K51+Xj8uwpAXRNPJt379cNETmvGCMtgCuaOWNNADijawvlDIALmTljKQA4o2sL5QyAC5k5YykAOKNrC+UMgAuZOWMpADijawvlDIALmTljKQA4o2sL5QyAC5k5YykAOKNrC+UMgAuZOWMpADijawvlDIALmTljKQA4o2sL5QyAC5k5YykAOKNrC+UMgAuZOWMpADijawvlDIALmTljKQA4o2sL5QyAC5k5YykAOKNrC+UMgAuZOWMpADijawvlDIALmTljKQA4o2sL5QyAC5k5YykAOKNrC+UMgAuZOWMpADijawvlDIALmTljKQA4o2sL5QyAC5k5YykAOKNrC+UMgAuZOWMpADijawvlDIALmTljKQA4o2sL5QyAC5k5YykAOKNrC+UMgAuZOWMpADijawvlDIALmTljKQA4o2sL5QyAC5k5YykAOKNrC+UMgAuZOWMpADijawvlDIALmTljKQA4o2sL5RwO4ELaUMpACjwOlAupJFQAABOaPlLJADiSGwlzAcCEpo9UMgCO5EbCXAAwoekjlQyAI7mRMBcATGj6SCUD4EhuJMwFABOaPlLJADiSGwlzAcCEpo9UMgCO5EbCXAAwoekjlQyAI7mRMBcATGj6SCUD4EhuJMwFABOaPlLJADiSGwlzAcCEpo9UMgCO5EbCXAAwoekjlQyAI7mRMBcATGj6SCUD4EhuJMwFABOaPlLJADiSGwlzAcCEpo9UMgCO5EbCXAAwoekjlQyAI7mRMBcATGj6SCUD4EhuJMwFABOaPlLJADiSGwlzAcCEpo9UMgCO5EbCXAAwoekjlQyAI7mRMBcATGj6SCUD4EhuJMwFABOaPlLJADiSGwlzAcCEpo9UMgCO5EbCXAAwoekjlQyAI7mRMBcATGj6SCUD4EhuJMwFABOaPlLJADiSGwlzAcCEpo9UMgCO5EbCXAAwoekjlQyAI7mRMBcATGj6SCUD4EhuJMwFABOaPlLJADiSGwlz+QcpFx71p4XS8QAAAABJRU5ErkJggg==",
 			"mode": "bitmap"
 		},
 		{
 			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\tv_screen\\static.png",
-			"name": "static",
+			"name": "static.png",
 			"folder": "",
 			"namespace": "",
 			"id": "3",
@@ -610,11 +579,39 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "ace7b2d9-46d0-50f0-a1f8-0a1722e76aa2",
-			"relative_path": "../../../../../textures/custom/tv_screen/static.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAAGACAYAAABlSWp/AAAAAXNSR0IArs4c6QAAIABJREFUeF7tndty60avhP+8/0Nn13JIb7j9dQNEZCusYm6yLGmGM0CfhrLkv/63/O/vv//+2w3966+//vfn6T////Pf+VL6maap4+s8da567fP1fx7TsbTGcx26trpOXX+9hl6nXuMcV/9/vv58HT0XyvltT2b9/xT74n+rQUfhLAAma6CmuQZS8c/mucakNTggpia7BhHgaoO06QRirYUDZq2P7u8vuuigEf8KAKn4jmW1IOe/tSHKbh3jCkbzTJrqmqhMdfXUvTpFItCS2nXqY1Rt1cvVoKoASa4J7U6SadMElgoatRZljmPfVWtyDVZw0doIzGo1wOZvZVIFgjWterkadAKgFlL/TV7omO7sQC2hY5ACLilCUiiXBRRQyRacWkxyRiVVArHko1UvV4MqAAiZLgBeDTpT33VMPAFUgXNFlQhQdU1T4DqlcgRS1RjWbdXL1SAFAHkoyRoBw0l6B6xkD1U5CASdBKe1KwDcOlI+0jW5n93piWzlzwHIqU56fDWIFCD56lWApKNUOl7VjU4C3GRdFaAd6JyXE2gSqxNAnA295RTQIW7i+YTmlB+qLCevpALr6/+NnDuVCQ36eKqzg/SaZA2/DoB/9vLPzZ4uDE0ll4KZFprY4YDogh41vvNzugapkVOoSa0caCsonGW+xQIm3iVJ9QtYHINVdlNRqTEESrKozmoIfAlsU0XplJOa3CnOWwBQGab+65jbJdoT7amJ9JqrR9K6vnQkdL7fJXinZkqaiU121zrmXOW51aCjKB+3gpVF5NGEXieJrvGdhCbVcEWmZpBipTWpLysRyFq0oclCnUpBTVe9XA06mvzlvYDOQ5M8Kss0nXcNoCMX+aaTVpXk1CCXeWjNTj2mFuCIY9R11cvVoFMBNNxN0E7Ndo9RYq6qU8fptel1bmxVAmpO2ie9ngDplMWpKD2uSiF7XvVyNcgpgBZYN+2eJ3l3R7ZOPqfF7xqnjCapT0c6d0JwlpGykSqXZq/jWqtergZVBaBC0QKVZZNkryBwVkFSSerg1uqOhdVGupB5BVBubRN1ozoej616uRqkFmA86UtNKMykcOYKqo932YJkszZWGalyr+xzP+u6aG/6mFM5V0/dqwB01cvVILUA8l8tsgtq1Aw3nyrAhnWVZcl6aqNVCQgkKYhOgiPVS9fqlO4tFqC/EuaSu2MCHR9rQ93x0hWzFidZUPJtd32ae+LZpArdcZZUwQVcsYMVmVeDTgXoWN0h37FMH1fmO7Bpo9IZuhbP2VMCYV3TdJ8k7Q5cLnNI0+t7C6tergYdm/92IygxRVlZ5S1JLMl+dxKozEs+SxaiwKCCJ8tLDHbPEcDdvt3p4tffDDotwMlTxwpCuALBNagLaunaDmxOEaoaTWWflNGF0UoEdxoZHilXZF4NchbgGkaPp2yQ5pkw2jXAjXVrmTanU75kRV2mcUoJgF31cjWoWgBJlXqdFrhThwSYymB9nWaD9LyTXVWXal0UIGk9zqJSs8m2FFhO+Y7XrXq5GnQqgMpj8jh3XteNJ8RTQx0gKCgSWF3Yomal0NsxtTnD29+pSDWWOVe9XA2qACDWEWsmaNY8cUqnSrFjugKwNjzNTVJPr1dlmzTHAcnZC0j7x2W0FnDtVS9Xg46Lf74bOAlHV/w3WUAjg9+YlAJZWlO6zlS1HIgUSPq6BEjKK2+xgPNXwkiW0+1X54+KaMe2pCRkBwkAyjZaA7G8Xqfz9aqGzq5SDd142NeKzKtBpwVQuJsWxyGZ2OWkXF9bZVKLOrnZ4+Zzd+8CG60SdfZVAZekH1Rk1cvVoNMCOumfNpkK7AKXNjncGPn0TlfUbi5nRZ0N1XEuxzjWO4A42ygKserlatCpALQJUgBSigSelMA1YJJEdiGUADGRf/eaztYckJxlJfWqQJC9r3q5GqQAoDClRUnWoKinBuo1qi1QgbVQBDjn3y68OWApOx3ASBE7S5iC6223gpM0TSSWiu2yhYLoys+J4dqwCi5VmOrLk/05cCZbOmuqIE+A/fVfC/9zCtBCXWFZLUzyeyef6b45NZTO0Y5drtCd5dXG0R3FV2SmYEMrNV8NUgtwckt+7RL1hCndjSHyx67opGAJ2CnPTOVam+gs0IGWwPXrCkC/EJIkq8sJqghV3ieSmMJhUqYuB3S+X9etqqT1cNkgsDreIhb7XJF5NehYsP1soAtRTkId47p5yDrIGpwlUOEpqDl1cuCYWgipD91E647JxzpWvVwNOi2gS8tJwlz6nXh+8uIUKk9VcdaUbIjWS6rmLEVvRFWF06DpQJDs6m0WkBpJ3kYyOUE4FUUbltijKqMNSA1yEq225SyArlVtjbKNWsvAilZkXg2qFkBsnCR0LUDHalfE5J+TMVUVFIiO4RPr6IihaqTBzl3D5Zm3KIDKbS14klMHGi24sjYdrVIeoHSuj9VrJWZrY9KpoNtnJYEC0RHE2dev3wiq9wGcnE4AQQXU+ag5XXo/C+ikncA2kfAk3QT6ZIMO8DpPd5R9awi86lUuAyTFmCZzAkXHfmJ7UrYN8BSMxPaqLKp8zsokPK7sfDXoWODnrQBqUJJkYhF5oCu2Ns0VqBZeC1yv18kvZYHO/kiqnVK6ENwpqKxh1cvVoGNh+F3BU/ZQSCJfdvLnxie5dEBNAFKfnjaRQENqo8pHiuXAK/OterkapABwgSpJndu4yt/E/9TnE6Pq/KoQjunERAIgSb3usx75aK8Ti9E5j+uuerkaRACgmz6EXFUIah5Jt9pGnZuOnVSkyRwptOl+HFiv2l9dq1pTpziFZKtergadAEih6wpriDkpE5DNkNpM2ESAVHC5IOnO5O5ML5KN369EwE33VQpgV71cDeosoCtMYu8E8anZkoy/fDFjpxRd6HRzV2Uh4CvA3R1LVxenZgKoVS9Xg44Lf/lwqMqYpmCVdfVbkkHd+KRBKQ+4EDhhbNfEjb2opaR1DPa+6uVqUAUAsTEhNkmugoR+ns6dVGYaLLv1pKTv7DHJeQd4FzyPda56uRp0AqCTMvI8ZUpXqHQscmDoQEbg6Ma4ZquqDJj6xfsngJ7M+bb3AnQDUzl1kppYpY2jMNjdB9BjWMorxLgULKsaOkubAs2RxxHo198L+HMb0G1Gi9Sx3ElfYlfKEOd8EzAQEN11O0DQmpQQScZdJkjAL8+t1Hw1qGYAt8HUVHczxG2UbMBZQ2qeY6iy1QG2AmuiBJWtaSwR6dzHuWZlPtR31cvVoGNRn7eCabHkbclHE5BSsfUG1ER9CJykGpO5rkh6aqpeP6mJAuuowaqXq0EKACejmnjdJpX5V36urO7O+cSiFLC68OXWGXz6y8e8ld2TE4KzkLdmAJVdAgTJuzIx3f2byGlnC7XgdY11HTqHjqn7IFmf5ACnjq4eCbhFVVZkXg0iBaBNuSJ3BSdmTNiYQmNSFWpy8mV3kpgSQa1gokJpb8dzq16uBh3F/Pb7AMSwxKB6144aRB6skq+NSiynBikY070NUhiXazobcIRJtuLW+hYA6DGwW/i0UR07UuDsVIJY5ADaAaOqm5N9Akf3WFIXIkyp+4rMq0HVAiZptbv12oHHeWCSbgJDBU9VkqRS59q6G0b1dRrUSMlq3pmAkBRD9rPq5WpQBUBtnspzWjQd3+rrpwVyrO8AQCeU7i4mWYDun2qQbCIpTWdZcu1VL1eDFACK+CqP+m8FBUk+sTM12rE52U6ykokiXXmNq0EKdq6GAdirXq4GkQU4tndBL40jddHCa5PTvQACqmOwY2a6no6p0t7lkwlR6GZZueaql6tBJwCS1zm5dE1IbHVso2s4vyU51UxwXqeCVq9RX0NgrE0/m+qAkEDh1utuFr3l3cC6QS1MakQXqNxRzAGu88rpWjpbuNqwpGBbWwjKtCLzapAqgFsUMYA27grv5NaFqonET08kdZ3Bdz+33r0noVZHYCZ1IZKRbf66ApwfDUtn0wkAEqv1JKBSSqpzvsZZEBXPNdiBxQHQZYAETKcSEysTgqzIvBp0LPrLl4Q4D9diUQMURDSXjqNjYpJwasJE8tXTSRkSgBJY1LrcGl2wlblXvVwNOi1Ai1HZl875dLeLCuVksmOmyubk9VNl6ABAzCVpd/YWPP7bbzj/JxSgsiixJTWF5khsmEq2MkzzB81TJdkpU8fcJN8UcCtAnJK67FTItCLzatCpABNvc4jWQtMGJ6xMKtGtbwKy2mwn5w6QlEc0FyUQaj6oBANrXfVyNahagNuQ2xj5bvLJLVAcoLShalsKWCq6ApNA4l5DKqmNphs+4fz/OZwI0z22BkA9BXS+6KTXMXQi8U6GScKrxF6xgYkCDaQZfw3cZR4CpCONgHPVy9WgpAAEBofCLgh1Eq5sdbdKp0dVpwZJzdJNrU4dJwSY5JTjOqtergadAHAeWgtJEpq81xUtya4DQgJjZztd0Evq4ICtc3brdnXUGr0FAGoBzsfqYqlo7s2iKttUuAkz9DVVStUWtBkVuElpdJ7OvhT87me1li5nvOWXQrXpxHYn/25sl6gN+r/57KQR1OSh3377aLezgnSN9DsJTmECMFdqvhp0LO7zq2KrVLk3ckjC01u3iXXJ6yuwqMDdWvV5ZxUElKlSTMYqmTpF+nUFqH80Km1oItUJ7WoF+lata7IWzNlBYmEaQz7vrGqjjAnIeif1eO2KzKtBqgB621f9K7Gfity9CaQKUG1BPdkVsq6RWK4NdgykvekaXPgjX6eArPszuWnVy9WgoxhfviXMMT0l4sk9egpuqgrT5pDSJPDotbv3MBJwncrRm1pJEeka/wkFqIUkRSAmduxPeSIxhRRiytTpXbhuvs4+6vi03gtWsyLzalC1ACf3rkFJkmtROkVJ4FEwTmzAXbvLMKo+k32fY5wF1Dk1X4Uxq16uBnUA6EIhSbg+pirSMcrdK5+oUacm6uH6+gQSBz7HbAp4XcY61rfq5WrQmQEoPF2R+g2LyWquHifduoldqgwq3R3jySq67JPAEfLBqperQScAJpKtIatDc5JvlVsFmzaQlEYTNLFZizxRkWqFSQEJUHS0VdXR+SEMrnq5GlQB0AW56ndOpqmxTma7xwlwxJpJLrgi0w5sjrEExDpHtz6Yd9XL1aDj4l+OgU7WOsnuGjYNg9qsCqouyNHanR24EJaUjdamoHeqQRZDr/31O4Hnb4RO5I7kzHljpyh0NHTWQHJbFak+rzI8AVDau+aMicpRTUhBjW2tyLwadFrApADO8xwAOrm+IrWqPqnA7rpdUE37cBaiIHQhVolDoCpzrXq5GnQCQJubbOBshm6WfI/mTSqSJNZJ6CTY0VgCSrIpx3xVGFKmyQ2tAvJVL1eDFABXWUJgOAub/HrCUuOPn0MpcSfV0bVOLK8qD7G9sweXMxrQrHq5GuQA4CQrSW8ak5g1ZQc1MLHfgXOqQJ3NVAA5K1CApNvTZb5VL1eDKgCoME46nSfq3S89InVWMwFKZeUWPBUcTvW0wcpaOL9/wQw1W22E9vu2U8AVOTcL/yiAK8wmVxCgHIg68BBjVeIrk53FuL0TGJPaOIX59Q+Hnl8SpZtPgCCvJb9Lsn3lfoMy57y+KlRSJvJznWeyZyfrpCpXMlWZd6Xmq0FHAb79Shgxo2uCFoAk0+WEKXichDqrIru4qiDdHAQsF2DTMbEoyKqXq0HE5Oexe1bgAcA9+/ayVT8AeFkp7znRA4B79u1lq34A8LJS3nOiBwD37NvLVv0A4GWlvOdEDwDu2beXrfoBwMtKec+JHgDcs28vW/UDgJeV8p4TPQC4Z99etuoHAC8r5T0negBwz769bNUPAF5WyntO9ADgnn172aofALyslPec6AHAPfv2slU/AHhZKe850QOAe/btZat+APCyUt5zogcA9+zby1b9AOBlpbznRA8A7tm3l636AcDLSnnPiR4A3LNvL1v1A4CXlfKeEz0AuGffXrbqfwOAzw+Hui9Yok/E0gc9/+zmypc0dZ/uPefTKrmPgm9f92dc+tQvPX9ey33KufsIffjuhVUvV4OOAn98Tdz0Sx+0Ke6LJahA3eflp01wjdY91DVQwd3a3fcg0jeb0Xcl6fca6DqIKGXMqperQcfCPgBw5ds83Ldn6Mei9WPfBB5i0ORz9fQatw/3cW2nMCch6vOd6qSPqOt8bu1HP1a9XA2qCkBm5GRs8gVNEwmcFJiaVwtam54ARuBMoCcQOKV0r53WVCxm1cvVIAVAkkT6EgfHVMcWN4cCITG581yyMmqcWhTZR/pSp3N8Z2vS3E9MuO8QettXxCgbkp/WzZMHkrQ6BlaWJMVxBXfyPlEpBUbHZLI+B6TJXqiOv/4lUecfjXIe1m1EGeAYqExI3t8py5VGaJFdLqH963W6byVz6yYrUEAX1Vup+WrQaQGuiU7eXLFq+u38VYsykdLOUwl8zo46QKa50loJnO67gUwNVr1cDaoZIDHXSX5C9mRMBZLaBkl7lWhnM1e+pq4DjAOPEqADhFM7s+dVL1eDjiadXxj+pZ+uAYTaTs7VJ8n3tRn1NS6fdErUndt1HbUhzhJdFnFWU6T98zsUNWvI3le9XA2qCjBhc5JtZbNjtN4kmchjAmNnU64xDhxOCUkNaF3ude70AjVd9XI1SAGQJI8kl2SemOyOPBSqXB5x/q+sVbVJVqInBVWdCSnqeieqQdnoP6EA2vzUyKmEayg8pc+FRQ1Q9DptSnd87dZASkAgcvOk9SRA0F6P+qzIvBpEGWASzOiM7SzASWoFw5RpdM/BWcpUiTQ0pqOeyykEQvX+VFfJFatergZVC+i8K0mzs45pkyfSSVI/zQ9Tv0/2URtaXzdZO60zZI1VL1eDCAAuVKUwlQLS5IQwSevqtZRJtmt3DXUsFsZ+ClhSKBcCYV+rXq4GnQCgwrlMkGTwZLwWrj7eFVWLSxI9tRVipz6mIZH2reqTcocSRfNSB9y33wru/HgabLRxdV46FSQ518Dkivhv1EaZ2M1FaV6bnfKJqk4hxorMq0HHIvBGUPVvYo2Tu+T7Lvkm1ifpnIDGBTQF0SQD0UlA99uFYVIvqcuql6tBmgGIWVdQnVjjCkXzp8eS/Kt6pXA6kWqdz4W5ams0pgOX7HfVy9WgUwGqHHUWQJ5GHkkK4sCUQmDyZBf6XH7p1MkdAV1G0n2rrDv1SnX49QygfzLGST+pQ5e6J6x3bE/hTGU2+bFTAZo/KWAHgqQ2TrV0DUe9VmReDVIL6HzdIdz5WieZJ0CqhG4CYpcF3PNJKUgtEuA1RKotOJACEFe9XA06AUCL12Y7ma9NTFaiIKnMnxyrOvtI4WoCAG2us54k810+6QLgUYdVL1eDqgKcG0splpo2bXodS9dKN1GITXUOVZC6B6dCU39WWzCy/flb1W6tKQgKAVe9XA3qLOCKJTjJTOxLqqL2QA2v13TAVeXQhrp5FaROgQjYdA+ELICA+pYQSJughqrcdyyisKbXStZAANGiObZP9uSCnTvvuznTnhxwwv2JFZlXgzoLSMei7gZNlUqSUTc3FdOx1rHUya3Ovd0DgTDZlCpVWsfbFIBCUF3olO3UlEmuUNmkn5O3n9et7K2PqaJ1lkHKlHKKk/gKjC6MHj1YkXk1qCrAFQBMA42CoWsgFVgbOz0xJJY6ye6SP7F8evpwtYDHV71cDSIL6Hyu83VJtPiLkBO2JiVRXyWQ0GscwCqoTDAbferZHQOJMASI47FVL1eDjgt++3BoClZJKbSQyhiSQ80KTjIdMFPRz7lU/tWT3VFR15IaOSFOXQ8B/FjXqperQaoA0w0Sy7vQl+QzZYTuKEqJ3YFCVcHZSVIxso9OgSbgKPtY9XI1aGIBE19MTJuyLzWt89lJw51tKCtTvqHmu2Cn+6ZQSQrzlg+HEjMmjxHyk31U2VPQdPZAKfsssrONVHRdi7t+dwNnIutpnRBWV2ReDZpYQJV2CkuJ4bpxkkKXAdLYFNRqYx1oOibrHMRmB+C67gRMAs4xdtXL1aATANPQp2CgJql/pkI5RUhKMb3NWpvmgmt3b8Op4JWT0JU5jnWuerkapApASE9B6eqdtID6jzq5U0QHtMTYiQ24JpG6deowHeMU7q13ArWhyhySt6msT5qv8zsJpWumdVwNaikIuufo+kSe+jpzt3NF5tUgtQBlwvmz3l5Nt1sDsu0XURHQaC0pg5DVKOic1XUWWBuV7lbqGvSI2p0w3moB7iw+kbSugTQHZYXE+JQt3BopwFZQk5w7O6D8M7UOl50oz7zlGNil6o45nSQT8mvTUqjqgqfOTUCuwNJ/kzV1TFXgJAK42pJaHDVZqflq0GkBdUPqUW5zCdXKVne3jmSbgqAqQ5LsBMakIh2Q0roUzGQ9Tt1gTatergYpALR4LgRS+u9kjlhDwFAwqv/qmib+3TF6ai9OySagI+UhULzlFJAKVJ9LLOmOhKQyDkjpBg6pC3lxUi6nSC5kTr1es0iyNsofx5pXZF4NOhbx8W7g+V93o4U2NckITk2cXLr1ONVw4HTKQ0pz1VqcGnWAdMB4GwCm5+TEhCnDdQ4FQGDGl98tONlG0kr7cUqWFC5dw63b2QFdh6zn108B9YsiK+uIDY792gR338ABjfIDAUGL6zzZWdqkaV3G0LWS8qiidrYlpFip+WoQWYCCoBYtFbyCoLvHTg3vGOpAUh8nK3OK4m7uEMjS3qYZichlrGLVy9WgY2N/d8VP0t95r5P8CXsn8pyCpFOMpDi0XqeMnf04MCmgRFlXvVwNOgHgGuykNKV0ZZw2MRXNhbDOP1Oju9OJk/BJLiJpVwvpFAXsYtXL1aDTAtK5Pt1/nxTJeTnlCS1WKp5Tlm4Oen4C0isW5wDZXfvP879+H+AMgcfFY9JOxSXku8dSRiBPd2+qXLGuTiUIBM63XVB09XFgV8U75l2ReTWoWoCT+xP5jsn1cWIJybrz/wrCFBT1OWcR6dSh9zsmtqbr624cpazhrOfXj4H6BUFODqey1qHdybp64VnsCsAk1XQDi8BbQUpzqwIRMJzPd/6fSFTqtiLzalBVgKl3TgNZCkh6rcSkpBZqW+6aV08KCSS0duftLjcoSeR6q16uBl0BQFIGknmXKbqmafGVxUkZHFhcVqhznU1M9wcm80+Vsr5OALHq5WrQsYjPTwaRB7u7elSwhHh9bpoDKACqXRDzq9wSiAiI6VSj8k1y77IJ+b1eq+xp1cvVoFMB0gLJ0ydqoA2oTSCfnRR4KrWdTalidWAkwKlSpDld4FNrOuqy6uVqkAOANoN+vrKpFKRINaghjuWT4OUA2wE5rY3GKkC7m1CmrqtergZVADiZJNaRVVRLINVQyXVsNqz4fLmCqQuJCbwujJ1rJZtLTXUWWPc6APeql6tBJwAmfpg291MspHU5oBFwND8o6NSKdI+J5XRyIUCp9bmQWday6uVq0FGQUQicHKVSATQgOZtxjHXy2imAerMDe8oNEyuYkMCpoFx71cvVIAUAbYIal0Jc2qQrpLIkFdwBh9aU1ql7dT9PbCBZnhsfALfq5WqQAwBJYWVgklvn4ZM3lZStzi9dAlevrcByyhKOYx9D3F6TUnU5JhHh128F/9kjMVAlV71Xi0OIrkWiYpIcK9A6UExUi2xAG+gCoYIwKWKXQ1LNzlr8OgDqewFdQnUMq01IUqwqMAGVAjGdArQ5zpddbujyhO6fblLRkdeRSUlzvG6l5qtBpwW4o01laJJjYil5HylNBwpXUMdMd88hPa5KpWt3jScrSmMJCFC7VS9Xg04AaGOoKXR8oSY4VjjJJZsgmdXiOelPYE7X0izQzdPlk9Rs2kup26qXq0FH4z8yQCooSbwLdXUu8n2SvQ5cnbTr+ibz1dc41mpNrlgKrVnJYUC96uVqULWA1GT1amJL56tX8oWqBUkwybZjLeWSyXhXk2qNpCq63pMIKvekim8JgclP3WZI4rQwk1C1VZeJROsaHetJQVSpJoo3CYA0r9R4RebVILUAl7BdMUjiHTucLFP+UBtJVpIaReDVuab2UudywZXmdkfDYLurXq4GnQBQiXQFdw0nNZiGtOTfHThScZNtkMVcCXVdFqhSn/ZgTiarXq4GHYX4uBXgNtVJPdlHd6ycMHrKbF2fC1+dV5NyGY+2X3VDa3G1DSBZ9XI1qFrAhDEODNOxbtO1+Ek5XIhKIFXppqaSvztg6xp0vQpAdz1SoaMOq16uBqkCTEJMpwjEJGVzZyWuyOe1u7TfHQND8T+3V5mbFCuxvvN/2sfbPxhCRU5pvvPOibUktp3F74JoWmOSd7UGbfaVtTmFumJnvw6A8w9HGjTiX8NK9wFI5icg2ZwSHEs7MJACpCY5W1KykHIlezH2sVLz1SDKAFSI5PGdVzq5PVm5tYNkAwrQeg0FaG3ihKkOXK4OlAH0mrK+VS9Xg04ATKWL5LFrIGUGygRV6lX2u9c79Zp497RxLvsoOVxOScCTOVa9XA06Lvztz8eTjLsCOPCo76ZCTzLGKZcuEzg5rutwEp0UjpQq5RFSG62dkf7Tble9XA1yALiKam12LZoWJMkfyaU7mdQiVnCQehArO9DVGly54eSuldYlNVr1cjXouPC3bwhxbDd3rr792lRtpMqwyxikEMSmyfhpCCSgaxhNAZbCYVIcIgoo5aqXq0EVAIRct2BYNIIgSZ2TRQc+ZRCpRX0NAU8fc4qT9tc1fTJWay2Wu+rlatCxkM8M4NDuCqcMojdJ9FbolOkd+K40k0CV9lpfXxVB53FvCnVK2eSmVS9Xg04FoEaeDegkXJlJm+vC10Syr4BzKtsumLqQN33P5EowhvquerkaVC1gc9uySmjdyJTlXeOvPq8nBQU2gZXkuD7mModTP0cYCq3/iVvB386Ax6+HTZJv54eOYVVd1LedP6r8Jpapt9PP4rvf3uHb5hdnGVOCveVWcPXbf4t4xzoQlZUvAAATyElEQVRVC2UZebprEnm682O6Dnk5AYxUTVWGgKIZILEfxq/UfDWoZoDE5knBKoiUcROvdXZCUlsVxN0SpvUo0Al07npJgVS1HJiGoF/1cjXoBMBETrviOb9ONtA192yQqlJqHAXOOo82YfImmDbYqeREPUkhZU2rXq4GVQUgWXWspIYklXCpWhtD/jl906dTHX3eKQTVITWcQDqZmxT3eGzVy9UgBUD1t8qylK6psAocnUsb7e4fOFBO1MaFuDpnsg9iavJ2R5arwHtbCHSoTZLascXZRieVZBsORGkNnf1MpJwaq6GO7g+4cJjqfFxrRebVoGQBlFzFqz5v/yaPVlWpcyTb0UJVINIcbg2kak5+6ZdSnBLo2lUlad/0Cyywr1UvV4MIAIk1VDgq0FRmgw9+A5cqUZLWxL5O2snunAU6K3KqlIBb9rfq5WrQCQDaCCmA/qYNebljBvlnxzi1EPd6ZZGu0ymNMvK0GZL4K1bj1u3kX16/6uVqkAKACpn8mljpJNf55DQQuiYnoE6UIFkE5Q4Ch1MCR6z0BtnbQ6Buuv6s8ukUwIHGyXhSjcQ8Wk9qepJyuk53O5x8XuvVEQjqvSLzalAXwp7n71OBBwD36dWPrPQBwI+U9T6TPgC4T69+ZKUPAH6krPeZ9AHAfXr1Iyt9APAjZb3PpA8A7tOrH1npA4AfKet9Jn0AcJ9e/chKHwD8SFnvM+kDgPv06kdW+gDgR8p6n0kfANynVz+y0gcAP1LW+0z6AOA+vfqRlT4A+JGy3mfSBwD36dWPrPQBwI+U9T6TPgC4T69+ZKUPAH6krPeZ9AHAfXr1Iyt9APAjZb3PpA8A7tOrH1npA4AfKet9Jn0AcJ9e/chKHwD8SFnvM+kDgPv06kdWugYA/cUQ+kBj+qTrnx25TwqnD5D+GUcf+XYfz06fwj2rqvPpunSOK5/xp326D7xeuY7Ue9XL1aCjAR9/O7jbXG1Wfe0Uzumj5N33BKTP/9e1K6Dq2ui7Da42Tz9dnMDTEULrVl6/6uVq0LGI0R+MSIiePneVFWdDO+Y7FaEviui+Fk6/yKI2KqmJqqYShohiQLLq5WqQKoBulljvlCB9J4CTeiquKhGBYPIdAMlaql2kz++Tukxe36liUp5f/+PRf2y4Fln/7ZCsTTgbV4tbH6NvxaC5U9aga3ag7ZqYmDltZL1G+l7DjgjH/lZkXg3qFCB9j17nfwqErpjpecd4B8Ir3/+Xvk/IfUPIJDh2mceB+de/IuafIP7/fztYJVeDj/NEajjJZZ2P1KYDDq0nqdGUkdV6OtXoskyS+JoxKDf8ugWcx8BU+BTCumPcFWZfUYmO/S6w0ePO5tx6CABKHAVUsi8BwkrNV4OODX5mgOmG6+bqxmpxK6CcitBYUhhiZ80XkwY61jaB7Mt9Cq0PWQQBgdaqtSoqvOrlahBlgE7enAV0383XfDXatz9RW4tGN3fqOvTo5hiqoOyOhA5YZGPVNuieg9aN1vKWEHhmAPI9RXwXfjrvmyhMkm61KeOhHy9zzdXnpvlhmj2cgtHezZwrMq8GnRag7CT2dYx0d/OoSYkhThqdwlxZ+5VTjbK8SjvJvO6zO4kES1r1cjVILSAxnJ5T9tDP1CDHBkrIV9bkXusySKdwaT5daweKk0Dd/ZC3HAMV3UlCib1X0O9e20l/yhAdoKg5qfkKGPL8jhBkh84iBRwrMq8GVQXomEag6DzYyZzLG05BKEBVy3G+Plmzm8d5/gSILlc46xPbW/VyNUgtQBujoatjGt1QolDUsacLTInRSY0SA9PeEmCdxSU7TED4T94IIrms4HCBKTVSmVdfS8c6fd6tiY6MV8IfNTtliNroThFPqae9lGusyLwadCwE3w5W9rvAR/JLJwIqlCvshMXim1+OfSTBtbHuvoJTsIliiYx/u4HU3Rso4Fj1cjXotABtDnlnRe/EB6ngNIeyfaoajYziHTx3VHVgugLELm849kPgXPVyNegEgC4uFYqk98rrKRM4sKTX1qbR6+hUQTZTG+cyglOAZGPnvE75gs2terkaVBWgu3GhTVLJS4XsThh0/p9crxaZ1j9p6ET9kqWQYqnSXSHYW+4DuBsw2lRqciefJKMpjSewuGI72+iOXV3zzucVXA40iRSTtR/zrsi8GqQK4BLtFdl3YXGSxAkY6bEEPvXk5OdVbbTptJ8U6MDTv/1lclUIAc6ql6tBFQBasOTLLvGS1BErqMgUBjfW4RQnNXYS9mpjO+shwqT61rX9ugW4XwihDTvkEhOVCfU1+m/H5FrIzja6AlPocsfVSR5ScHY/T/Z4vGZF5tWgo8Cf9wGoaalZzhqcDThPnRRHWUpzJZBMbYwkvI69YmV6TUcUsZRVL1eDCAB0xq+SV5k29dUr8u6Y1GWBallO7lUlnL8726Jj3/R+BKmZrvmo06qXq0FHQewng9Ki6+IdKyhUJo+mtO0eI0XoZH4C5AQkes5Zj6sP5RrZy6qXq0EKAIPITxzocbEWdCKNWpSpZCcgOdtS63JzpAZe9XVVR5q7s5hffzNIfy28WoAyxhXLNdKhnTzVJX4NoyTvJMOTHNJZmFvTCS5dS6eKWicC76+fAs5PBk3QWxtH9nC1YKnpna100qsKUH9WULnTQG1wp1Y0JykI1VkeW6n5atCxwS8fDSMFIGtwjyXWT2xiUugrxzfXbAJIZbZeg9jb3RBK4Teo5qqXq0EnALTpzttd8ErFpGaReqisKlPcPOTtqlRqB506OEuhQOpUcbJes45VL1eDHAC6GyGEXscQ8nCan5rkipuY6oDk/Dcd44jBUxucZBqjZKtergYdLPuwgFog8ld9vvqjNsSFqy506TomElut6MrrCUTKSFIXqpPzesoQZJ1Sl1UvV4MUAF3jHSNSwytjKuLpWp0vE+jS2V+tRm3FrSEBgexlqpikHgCeVS9XgyoAHCO0iJPNEvK7xJ9YdCVH0HqrDZGPd37tgEdsVgtS0J+gc+ry6/cB6i8ETv06yRipAdlHamqSXrIrZXZVhc52umwwCZnEbKcUg2ywIvNq0LHIL78UqmxxC9ZGXEnIqWEVXOkYNSn6VL3SHt11SLGcOrrQrHMf+131cjXIAcCl9O64SBtNjE3S3DG989MUapMqEBhUBVx2qK/THOGsCTLMqperQWcGcP7rQptutGOJK2piTPXK7tioDVXPTmrhxqpKUa7RptJ1OwtSO/31DFDfC3CJmoqkalB/ngQtzRt07Vrgia93QHas7Hy+s4gQ6D62oHmnsdUVmVeDTgUg31UGOnlXBJubG/h5/c7HuzDYMZtYTEBK0p3A0Smb2pAqBNnUr78ZdCZAbXDyc8dM9W3HWpJOd1w651QJdsVMayDAOHUDaf7C5iT/LvQ5lRSQrci8GnRs4ttHw6iI3WNaXCdzrjipoVpsOh04ead1qbrpWPLttB8C1lT2wbZWvVwNOi1gEupSmCHvnbK/5oWOjamZBJL0WM0gaQ1d9lCLqLZD6jVQoVUvV4NOAFS5S+zSzakqKIun7KOiJNZPAOv21IHVrYX82jVTH+9OMXWtbzkF1Ma50NMl4YkEO2klYHXzJStxJxRielI2BVGyiu45IoNZz4rMq0FqASRfEy/rkrICrLtj1rHf3Z+ghhGQKPXXvadAXNem9pDm6ABQ1r7q5WrQcdFvnwsgGyDPnIaliex2pw5qOqlS5+0TxjvrmhDEKQGRhKzsrcdAZwV1U24jjtWOgSp/xB7nx92cDgQTmXZg7dbiwFHXcr6Gwm55bkXm1aDTAs7C0CbqoitAqCCUiLvxhgX2ix67I6DLKinDuIBHVjCpkbujWi0qgGHVy9WgCoDa0EnKJqaogiRVqKBL47rw6WyAbkdT0R2QXXLXmzmJzRPFUfL9ugXoV8W6xmihkv9PfNYBiG4lT67tbIqATXaTpJ+Uzd1STgBx1iUEWJF5NSgpgEvarhgO7U5eh3L48bKUF7TBXYCtr09gS8qiCkk/T2+Eqa3+ugLoewEOpUkSVcaoKSB133x+49/deqcWoQpCFjLx9u5eA9VKFHNF5tWgo1H4G0GOSd0ZXJkNCP/ExyTQkW93FuPkfGpbEwCn7ODWlwBe5lv1cjXotABNu0lWO0mvAHAS27EyNZiuT2mdbmCpnbi1OtBO7kWkcKzzquocz696uRpUFeD0sVqk6TEo3RFTpuh1HCtTExQEqbGqIFfBRYo2sUOyC6qtgvBtGYC8FBb35QuPHBunICLQ6TqmuWAi+26PpIDuuqkmqcGkNud6Kkh//c0g/GWAakh//YXfctUVs7MCPU241OwsJylWLWySXWU32UaX5juVnNpdmWel5qtB1QIc8xyz1L/+zQ2SBCaVdwUONTipmVrSFMh1XAdepwR1XLjuqperQQkAWqiOiYkpHVtTU6YM0gbRcUwl18lykvk0b5cNqKb1saOGq16uBlUAuEIrA51skiLoa4nNLkCmtJ+u5ZSMGAzFb/+cPYGmswEHKALtr4fA+reDK0OctBJbXaO7k4W7RlfQSTCkYNcBpwOs2/vkZGGa/fGwHC9XZF4NOi7+t/O0xH6SOyep7qjnbgSRVLqAlpidcokqRWouKZeCtzs1JOIIMFe9XA06FvX5t4Odh9XNapChjVXmE8sJcI6djslJiknJziY6tqaskUJfvZbmg1qbdItY5l/1cjXoVIDEBkquKluJyXSKSMpCRZtYibtFPQFb1yiqTyJCl6casK16uRqkAFCmd0ka/OtjCmcP7hjUMSzJc7IGB5wNyIjdG8VMdngAbdXL1aDTApzHUULX4hHDO79Osk7McsBR+Z2uJVnadG1XrKTalVObspdVL1eDSAFqcLoi9bpJsgUnx+rntQnq3R0YNPg5j1ZV6YIwranOTbWq13DAVhX59WMgfTaQZDzJqfNfbezkZ2Kgk83KZG2GAkeb0dkU2Y7u011D1ztR2FKbFZlXg04LABR+PHUl3J0NoLk2R0YXPrXprrEUtHSN0yCn7Kc1OOA6MqlNvg0A7s2gqdROgmIF00RdVG2SJSTr6fxc7U5ZrxnIHeXIppLCOGId+16ReTXoVAD1r9SwVFTyPFeclPxdwCJZfsVjV9hLKtI1u44hZaqA/8+9HUwF7pjlZLprbJJkApe78UKZZBrCJiB2a3GqqfVKa3l7CEwNn6B/4r1X5kmgocKmPKN7o2DrFMU1MYFd1e/cNz3+tgygbwZVT3VBRX333zLeFSqFRweilMBTsOxOMno9knWR8k8suaO1IdvKzleDjsJ/vBnkjjgEiClIEkOdF1IwmwChgtBZVGdBV/aqoE/KpwBP6/vPZIDOz1ywcYVw0qqySEyrrzmLeWUcKVltQifVde3Ov+u6SJ2cSsJrV2ReDToVQJGvTZwwygGCiqdgoOOWU6U69qK0fgyd3qfogpvKvbvzmazFWNKql6tBRzHx7wZSkypQHKKnSZ5Y4gJcZahK/WQd1CxSmq6pLkOQfRLYSLWUOL9uAfrh0HREgcV+ssqphJN0B4B6fU3p+ty08DTOAXWidrTGcGfvk0uUZdSKfh0AdCeQLECZ1938cHOksJnAl+ZT5jrFIAWrr+1OPcRgsgqdJwVEUL2Vmq8G1QyQwhv5cfVf/bf6Pt1CpWwwLZzLLE4xnE3oPGp79HwKgSr7WreUPwqQVr1cDaoAUHl3TSUmTs7QVFyVv+6459bYhUhl/mRvIM1fpJxIMQGa1kHJ8Z+wANes6Qa7RipTU06YynaSZ1IbsjRSQcoELj9o3Sb2AFloRebVIFIA8kRYZHyrmCQ6FXzq752VJJWpAKE9Opu7upeJrSiAJMOserkadAIgSXFK0OR508dSiKyNTGrSsdN5cMd03UPX1JSRJsFSFGrVy9WgqgDJ2zsFSClXm0mySOqgsu3uEdANmIltUGCkZhHInNSrDZHV1Voa5Vv1cjUoAYDk1DUlnSCoGanQCjaSYBf6HHN1DQ40ybN17921aB+kpkCuVS9Xg9QCuuITKMg+Ems6tSCfTxmBGnM2Z8LeKcAGzP2YKimVKgRd+9dPAfonYyYgSJlBN+VAQ7LfMXACHufv9XrdmhRADmQ6TxdS0+mh7H1F5tUgUoDEcnouSbwDA6VglfV6rW1hHVCdailIVLJTw5NCKIDSft7yG0FDZH77nQH10ivKMLEJAkpiZwKokdvRbz4n7ybZV1JQZnHreZsFXGF3OvYkqXVAS9I+ueXchSvKEHT3slsHsVyTflIdVTUiwa8rAH1VrJMs13gFT9foWrTKIMd4V7jaEAdg19RzbHf97j6EUyQXXJNiHGta2flq0JkByMddQSdy1qkJHcOSL3e3lrvmO7tJ4AgSbZO+gsEFUlWfqppvU4Apu6kwlAU6b6Q3ZLosQvaizaWfXWPIOlSd9JqpqSnXkH0YFVqReTXoVABt/kT2BLX43Tok0VOgTfyYrIfY5e4tVGAQYFN20L3RvsgeBiBZ9XI1KEn189y9KvAA4F79evlqHwC8vKT3mvABwL369fLVPgB4eUnvNeEDgHv16+WrfQDw8pLea8IHAPfq18tX+wDg5SW914QPAO7Vr5ev9gHAy0t6rwkfANyrXy9f7QOAl5f0XhM+ALhXv16+2gcALy/pvSZ8AHCvfr18tQ8AXl7Se034AOBe/Xr5ah8AvLyk95rwAcC9+vXy1T4AeHlJ7zXhA4B79evlq30A8PKS3mvCBwD36tfLV/sA4OUlvdeEDwDu1a+Xr/YBwMtLeq8JHwDcq18vX+3/AbFSLHy2F7EQAAAAAElFTkSuQmCC",
 			"mode": "bitmap"
 		}
 	],
+	"variants": {
+		"default": {
+			"display_name": "default",
+			"name": "default",
+			"uuid": "59805ee0-d249-bf4c-f01a-67b2cd10bd88",
+			"texture_map": {},
+			"excluded_bones": []
+		},
+		"list": [
+			{
+				"display_name": "static",
+				"name": "static",
+				"uuid": "45118c10-b51f-36c7-a1ca-37d0f846c2ed",
+				"texture_map": {
+					"32717bc3-fe35-1fc8-9bbf-54407fe854d1": "ace7b2d9-46d0-50f0-a1f8-0a1722e76aa2"
+				},
+				"excluded_bones": []
+			},
+			{
+				"display_name": "warning",
+				"name": "warning",
+				"uuid": "585fe02c-c7d9-99ae-1095-3e2099d4a99d",
+				"texture_map": {
+					"32717bc3-fe35-1fc8-9bbf-54407fe854d1": "69769926-e76c-4d11-b4f8-82ddedcfad5e"
+				},
+				"excluded_bones": []
+			}
+		]
+	},
 	"animations": [
 		{
 			"uuid": "5d4ff565-0c0b-7e82-7698-c3bd1a792bfa",
@@ -623,13 +620,14 @@
 			"override": false,
 			"length": 0.6,
 			"snapping": 20,
-			"selected": false,
+			"selected": true,
+			"saved": true,
+			"path": "",
 			"anim_time_update": "",
 			"blend_weight": "",
 			"start_delay": "",
 			"loop_delay": "",
-			"affected_bones": [],
-			"affected_bones_is_a_whitelist": false,
+			"excluded_bones": [],
 			"animators": {
 				"9afbce00-c281-2321-0204-49c52e10c4a5": {
 					"name": "root",
@@ -652,7 +650,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -671,7 +671,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -690,11 +692,14 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				}
 			}
 		}
-	]
+	],
+	"animation_controllers": []
 }


### PR DESCRIPTION
# Summary

This PR migrates the `tv-screen` AJ model file so we can summon it in-game again for Minecraft 1.21.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Reproducing in-game

```mcfunction
function _:summon
```

---

## Supplemental changes

- https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/5fd330bfee7a728dfe7bbacc09a878a130df3b99: 🗑️ Disable deleteStaleExportFiles 
- https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/5d60eaabd1645aedffa61c020627685850e56be3: 🐛 Update missed `friendliness_pellet_ring` variant syntax 

<!--
describe what other changes this PR makes which aren't specific to its main purpose.
- does it contain a world backup? (recommended)
- does it contain other miscellaneous code cleanup?

format these extra changes with bullet points, preferrably.
-->
