### PR TITLE
⬆️ 🍱 migrate `upper-eye` model to AJ v1.0

### DIFF
--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-upper/executor/loop/pause_eye.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-upper/executor/loop/pause_eye.mcfunction
@@ -1,3 +1,3 @@
 ## as `aj.upper_eye.root`
 function animated_java:upper_eye/animations/look_around/pause
-function animated_java:upper_eye/apply_variant/colorful
+function animated_java:upper_eye/variants/colorful/apply

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-upper/executor/terminate.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-upper/executor/terminate.mcfunction
@@ -1,5 +1,5 @@
 execute as @e[tag=aj.upper_eye.root] run function animated_java:upper_eye/animations/look_around/resume
-execute as @e[tag=aj.upper_eye.root] run function animated_java:upper_eye/apply_variant/default
+execute as @e[tag=aj.upper_eye.root] run function animated_java:upper_eye/variants/default/apply
 
 execute as @e[tag=boss_fight] run function entity:hostile/omega-flowey/attack/x-bullets-upper/executor/terminate/boss_fight
 

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-upper/indicator/loop/summon_bullet.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-upper/indicator/loop/summon_bullet.mcfunction
@@ -9,8 +9,8 @@
 scoreboard players operation @s math.0 = @s attack.bullets.remaining
 scoreboard players operation @s math.0 %= #2 mathf.const
 # TODO(47): this needs to NOT be a distance check
-execute if score @s math.0 matches 0 as @e[tag=aj.upper_eye.root,sort=nearest,limit=1] run function animated_java:upper_eye/apply_variant/dark
-execute if score @s math.0 matches 1 as @e[tag=aj.upper_eye.root,sort=nearest,limit=1] run function animated_java:upper_eye/apply_variant/bright
+execute if score @s math.0 matches 0 as @e[tag=aj.upper_eye.root,sort=nearest,limit=1] run function animated_java:upper_eye/variants/dark/apply
+execute if score @s math.0 matches 1 as @e[tag=aj.upper_eye.root,sort=nearest,limit=1] run function animated_java:upper_eye/variants/bright/apply
 
 # Summon bullet
 $execute positioned $(x) $(y) $(z) run function animated_java:projectile_star/summon

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-upper/indicator/terminate.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-upper/indicator/terminate.mcfunction
@@ -1,5 +1,5 @@
 # TODO(47): this needs to NOT be a distance check
-execute as @e[tag=aj.upper_eye.root,sort=nearest,limit=1] run function animated_java:upper_eye/apply_variant/colorful
+execute as @e[tag=aj.upper_eye.root,sort=nearest,limit=1] run function animated_java:upper_eye/variants/colorful/apply
 
 # Kill the indicator
 kill @s

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon.mcfunction
@@ -40,9 +40,9 @@ tag @e[tag=aj.tv_screen.root,tag=!tv_screen.soul,tag=!tv_screen.boss_fight] add 
 
 ## Upper eyes
 # Right-eye
-execute positioned -15.5 48 -4 rotated 160 -40 run function animated_java:upper_eye/summon
+execute positioned -15.5 48 -4 rotated 160 -40 run function animated_java:upper_eye/summon { args: {} }
 # Left-eye
-execute positioned 16.5 48 -4 rotated 20 40 run function animated_java:upper_eye/summon
+execute positioned 16.5 48 -4 rotated 20 40 run function animated_java:upper_eye/summon { args: {} }
 
 ## Upper petal pipes
 # Right-upper petal pipe

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/upper-eye.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/upper-eye.ajblueprint
@@ -1,91 +1,32 @@
 {
 	"meta": {
-		"format": "animated_java/ajmodel",
-		"format_version": "0.4.8",
-		"uuid": "8d5aadfe-a7ee-1de7-2688-397a2ec477e6"
+		"format": "animated_java_blueprint",
+		"format_version": "0.5.3",
+		"uuid": "8d5aadfe-a7ee-1de7-2688-397a2ec477e6",
+		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\upper-eye.ajblueprint",
+		"last_used_export_namespace": "upper_eye"
 	},
-	"animated_java": {
-		"settings": {
-			"project_namespace": "upper_eye",
-			"project_resolution": [16, 16],
-			"target_minecraft_version": "1.20+",
-			"rig_item": "minecraft:white_dye",
-			"rig_item_model": "",
-			"rig_export_folder": "",
-			"texture_export_folder": "",
-			"enable_advanced_resource_pack_settings": false,
-			"resource_pack_mcmeta": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\pack.mcmeta",
-			"verbose": true,
-			"exporter": "animated_java:datapack_exporter"
-		},
-		"exporter_settings": {
-			"animated_java:datapack_exporter": {
-				"datapack_mcmeta": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java\\pack.mcmeta",
-				"outdated_rig_warning": true,
-				"root_entity_nbt": "{Tags:[\"omega-flowey-remastered\", \"omega-flowey\", \"omega-flowey-upper-eye\"]}",
-				"use_component_system": true,
-				"include_variant_summon_functions": true,
-				"include_apply_variant_functions": true,
-				"include_uninstall_function": true,
-				"include_pause_all_animations_function": true,
-				"include_remove_rigs_function": true,
-				"include_remove_all_function": true,
-				"include_on_load_function_tags": true,
-				"include_on_tick_function_tags": true,
-				"include_on_summon_function_tags": true,
-				"include_on_remove_function_tags": true
-			},
-			"animated_java:json_exporter": {
-				"output_file": ""
-			}
-		},
-		"variants": [
-			{
-				"name": "default",
-				"textureMap": {},
-				"uuid": "6fde0b59-c952-3d58-4087-1bfa481a613d",
-				"boneConfig": {},
-				"default": true,
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			},
-			{
-				"name": "bright",
-				"textureMap": {
-					"43c7499b-810c-e305-aa49-1e7c13c77d34": "8f35888f-5bd0-8dbc-068d-6a98237669e6",
-					"aff1612c-e069-f3fa-76b8-d53c474570a6": "744e1bb5-484c-f9d8-f20c-48e9c282e200",
-					"91f4647e-d482-ceca-1b5c-12a72e28cad1": "3728880c-0deb-e14b-f607-5b73a416df01"
-				},
-				"uuid": "e5853047-f931-6202-7fd6-db756e2fc46b",
-				"boneConfig": {},
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			},
-			{
-				"name": "colorful",
-				"textureMap": {
-					"91f4647e-d482-ceca-1b5c-12a72e28cad1": "0cf74b39-3ccc-8b65-0714-26407f430c46",
-					"43c7499b-810c-e305-aa49-1e7c13c77d34": "da05a1f4-8b7a-aaf6-2195-7ccfa8eeb23c",
-					"aff1612c-e069-f3fa-76b8-d53c474570a6": "4f855b2b-3aa9-0dbd-36dd-c1eca8045e2e"
-				},
-				"uuid": "03d99a04-118c-54c2-dc76-451ce553a312",
-				"boneConfig": {},
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			},
-			{
-				"name": "dark",
-				"textureMap": {
-					"43c7499b-810c-e305-aa49-1e7c13c77d34": "91f4647e-d482-ceca-1b5c-12a72e28cad1",
-					"aff1612c-e069-f3fa-76b8-d53c474570a6": "91f4647e-d482-ceca-1b5c-12a72e28cad1",
-					"91f4647e-d482-ceca-1b5c-12a72e28cad1": "9d53c2b6-fe34-b6b6-a01a-0b488aa8528b"
-				},
-				"uuid": "4d555fae-ccfd-1673-5fc7-b92e2af271bc",
-				"boneConfig": {},
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			}
-		]
+	"project_settings": {
+		"export_namespace": "upper_eye",
+		"show_bounding_box": false,
+		"auto_bounding_box": true,
+		"bounding_box": [48, 48],
+		"enable_plugin_mode": false,
+		"enable_resource_pack": true,
+		"enable_data_pack": true,
+		"display_item": "minecraft:white_dye",
+		"customModelDataOffset": 0,
+		"enable_advanced_resource_pack_settings": false,
+		"resource_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\",
+		"display_item_path": "",
+		"model_folder": "",
+		"texture_folder": "",
+		"enable_advanced_data_pack_settings": false,
+		"data_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java\\",
+		"summon_commands": "tag @s add omega-flowey-remastered\ntag @s add omega-flowey\ntag @s add omega-flowey-upper-eye",
+		"interpolation_duration": 1,
+		"teleportation_duration": 1,
+		"use_storage_for_animation": false
 	},
 	"resolution": {
 		"width": 16,
@@ -1111,8 +1052,11 @@
 			"ignore_inherited_scale": false,
 			"visibility": true,
 			"locked": false,
-			"entity_type": "minecraft:marker",
-			"nbt": "{}",
+			"config": {
+				"use_entity": true,
+				"entity_type": "minecraft:marker",
+				"summon_commands": "data merge entity @s {}"
+			},
 			"uuid": "86e070fd-9b56-7dd2-58bf-f619aa36f620",
 			"type": "locator"
 		}
@@ -1122,7 +1066,10 @@
 			"name": "root",
 			"origin": [0, 0, 4],
 			"color": 0,
-			"nbt": "{}",
+			"configs": {
+				"default": {},
+				"variants": {}
+			},
 			"uuid": "f13c55d0-8667-840d-3540-9fdda50cfc40",
 			"export": true,
 			"mirror_uv": false,
@@ -1135,7 +1082,10 @@
 					"name": "sclera",
 					"origin": [0, 0, 4],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "d6cd4de3-8375-b558-e3c1-76e23149ff10",
 					"export": true,
 					"mirror_uv": false,
@@ -1149,7 +1099,10 @@
 					"name": "lid",
 					"origin": [0, 0, 4],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "b68d2836-80d9-27aa-0d3a-124ba44fce75",
 					"export": true,
 					"mirror_uv": false,
@@ -1162,7 +1115,10 @@
 							"name": "dark",
 							"origin": [0, 0, 4],
 							"color": 0,
-							"nbt": "{}",
+							"configs": {
+								"default": {},
+								"variants": {}
+							},
 							"uuid": "7b7340bc-78c6-1299-de1b-edf96e09fec6",
 							"export": true,
 							"mirror_uv": false,
@@ -1185,7 +1141,10 @@
 							"name": "light",
 							"origin": [19.2, 52.8, 0],
 							"color": 0,
-							"nbt": "{}",
+							"configs": {
+								"default": {},
+								"variants": {}
+							},
 							"uuid": "32a2beec-a2be-93ec-fd62-73107f2ee6d7",
 							"export": true,
 							"mirror_uv": false,
@@ -1207,7 +1166,10 @@
 					"name": "iris",
 					"origin": [0, 0, 4],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "880e6759-b6fb-7278-fe5e-7aef4153a88a",
 					"export": true,
 					"mirror_uv": false,
@@ -1223,7 +1185,10 @@
 							"name": "diag",
 							"origin": [0, 0, 4],
 							"color": 0,
-							"nbt": "{}",
+							"configs": {
+								"default": {},
+								"variants": {}
+							},
 							"uuid": "4ae5ba92-0303-4b85-bd02-215b0b417f07",
 							"export": true,
 							"mirror_uv": false,
@@ -1242,7 +1207,10 @@
 							"name": "pupil",
 							"origin": [24, 32, 2],
 							"color": 0,
-							"nbt": "{}",
+							"configs": {
+								"default": {},
+								"variants": {}
+							},
 							"uuid": "66b0c5dd-24ab-7cf3-a0b2-e6bd91aaea37",
 							"export": true,
 							"mirror_uv": false,
@@ -1260,7 +1228,7 @@
 	"textures": [
 		{
 			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.2-pre1\\1.20.2-pre1\\assets\\minecraft\\textures\\block\\quartz_block_side.png",
-			"name": "quartz_block_side",
+			"name": "quartz_block_side.png",
 			"folder": "",
 			"namespace": "",
 			"id": "0",
@@ -1282,13 +1250,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "43c7499b-810c-e305-aa49-1e7c13c77d34",
-			"relative_path": "C:/Users/afro/AppData/Roaming/.minecraft/versions/1.20.2-pre1/1.20.2-pre1/assets/minecraft/textures/block/quartz_block_side.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAN5JREFUOE+lU9EKwjAMTKGDPez/v8sv8EHQh8Esm0UrDUxS3UyTbD7YxzZ3yd2lbgrDDH8cRwSYnwCYKhpEVLS+7aq7GHt4EzzG8mCB6N57D+DbmhAThNsA7tpfZkxRdyNQQTOgmLIiKF3Y4dMsb3LChPffErbA1EsRqJHJFyGPT1okrClYUQrNskQTfACWfpUCAIRwtj0wY5Ptlxh3JVSxJLUnXxNpE40Ou8vVdkwCJ2A+8AhX99liKQ94RwtQb5pYZQKQ+7tAEWtME7jT8VC+c855bdA0zeYH53VU9AIPBdWpk9ajcwAAAABJRU5ErkJggg==",
 			"mode": "bitmap"
 		},
 		{
 			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.2-pre1\\1.20.2-pre1\\assets\\minecraft\\textures\\block\\granite.png",
-			"name": "granite",
+			"name": "granite.png",
 			"folder": "",
 			"namespace": "",
 			"id": "1",
@@ -1310,13 +1277,39 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "a75f7ba5-2c99-eae1-002e-541b5f3809a4",
-			"relative_path": "C:/Users/afro/AppData/Roaming/.minecraft/versions/1.20.2-pre1/1.20.2-pre1/assets/minecraft/textures/block/granite.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAcNJREFUOE9dU71LQnEUvW+K0hbjFQT2hQ2ZghQlbg3VEDQU9DE5tfUHNPY3tNRQ0NISQVNFIJVLFEURaAYm+koISmxJiybjXDmvn97l/T7u79xzzz3POtreqJUeruTr51faW1vEKX1Kn+0TBM+wPrxJy/x4SGx/r5SKL3rf5vWKtbu6XEPiXb4oM9GIfFcqEgwNycnFpQsEUASBue/weuoAycecTAwHNImV8e2yOyRTeNWHkwtLsrO5pWvmg00DgEkZlwenZwoMqoj3UlnKlaqgMtpFWOuL0zUegBrWSHI+6rRHB/wyEJuQai6l7aEIgnopAxzgcbC/x63EBACBhfnQjsTkNnGs7SgDikOq7JuamOBmK9oCGJijAzrHmkg9y0h/t7aDCSEITkYKAMHy2awrTHNFPEKY4rGotb+2ohpAYXNsJgir0kR8rEYigCcQlvxVUg0F0ZgEqtGxiGTST8oC52ipr9OnorsAGBEMQjcy+b7wpjqYLsTDvfNrmQoPijU7FqphQYPgy2SCYA8m5h32c/H4/7+A/ptVRjugCvF4D63oQneM+Hkcp9hgV46O7iMA9g1Gooi4QOASYjJI2/SK6dw/1UxBFKrZrfwAAAAASUVORK5CYII=",
 			"mode": "bitmap"
 		},
 		{
 			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.2-pre1\\1.20.2-pre1\\assets\\minecraft\\textures\\block\\light_gray_concrete.png",
-			"name": "light_gray_concrete",
+			"name": "light_gray_concrete.png",
+			"folder": "",
+			"namespace": "",
+			"id": "2",
+			"width": 16,
+			"height": 16,
+			"uv_width": 16,
+			"uv_height": 16,
+			"particle": false,
+			"use_as_default": false,
+			"layers_enabled": false,
+			"sync_to_project": "",
+			"render_mode": "default",
+			"render_sides": "auto",
+			"frame_time": 1,
+			"frame_order_type": "loop",
+			"frame_order": "",
+			"frame_interpolate": false,
+			"visible": true,
+			"internal": false,
+			"saved": true,
+			"uuid": "aff1612c-e069-f3fa-76b8-d53c474570a6",
+			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAANtJREFUOE91k9sOwjAMQ9d9MvC47dNb5IgTWVZBQow0dXzJxvN81lrr0Ee/53n2s9fmnMcYo756Vl/VBMChLqgBQACyzpCqX9dr5dQdEJOTRTHQxJys/zsGLqHu3fe7AFrT5mIh/TyCHbX2QAACcv2w6Obwp+SIAbRozClZJ4WS4DGmeUjzmPEKdsXgX3w4rnOPmv6qKUYK6TzpuAduaA2QhJzgkSZljMb0XiRfVTR75sSYO9MS3HmkJGjuS8foB75Q6cH25ZKJvjBccu0uKaWUhNy4zN+dxzwkfwEZ2Arp4SZU2AAAAABJRU5ErkJggg==",
+			"mode": "bitmap"
+		},
+		{
+			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.2-pre1\\1.20.2-pre1\\assets\\minecraft\\textures\\block\\coal_block.png",
+			"name": "coal_block.png",
 			"folder": "",
 			"namespace": "",
 			"id": "3",
@@ -1337,19 +1330,18 @@
 			"visible": true,
 			"internal": false,
 			"saved": true,
-			"uuid": "aff1612c-e069-f3fa-76b8-d53c474570a6",
-			"relative_path": "C:/Users/afro/AppData/Roaming/.minecraft/versions/1.20.2-pre1/1.20.2-pre1/assets/minecraft/textures/block/light_gray_concrete.png",
-			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAANtJREFUOE91k9sOwjAMQ9d9MvC47dNb5IgTWVZBQow0dXzJxvN81lrr0Ee/53n2s9fmnMcYo756Vl/VBMChLqgBQACyzpCqX9dr5dQdEJOTRTHQxJys/zsGLqHu3fe7AFrT5mIh/TyCHbX2QAACcv2w6Obwp+SIAbRozClZJ4WS4DGmeUjzmPEKdsXgX3w4rnOPmv6qKUYK6TzpuAduaA2QhJzgkSZljMb0XiRfVTR75sSYO9MS3HmkJGjuS8foB75Q6cH25ZKJvjBccu0uKaWUhNy4zN+dxzwkfwEZ2Arp4SZU2AAAAABJRU5ErkJggg==",
+			"uuid": "91f4647e-d482-ceca-1b5c-12a72e28cad1",
+			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAQlJREFUOE+FU0EKgzAQTA6CBgSt9WAP9v9/q+ApemuZhQmTxaIg0c3uZGd2Et/r+g0hhHwcWMJ5nqFtW/ve993WYRjKHvbxIAdvnOfZALQYSUwkAGMsTF1nNQbgC5ikXfAQdsP/2Pe9AWhbz2kKOedCi8mg5OnEpmmMgm+NmpAaDwGAdmwUFJmn+UKNK0XrAIHHOFaTIAC701XBDECF8WojGYqnlCpdmFcAyJE+QFcc1T89bIxeRAKgWM1FSq9lsThNVnyAE9WFVyLqCKlJhJWBSE4ck4qmY9MJoMtCQS2Lb0xFhVNq2Ce9CkDNhOLPtlUXyusC0EsnKiV1KedfORF3gddXExi7E/YHpAf5qSjgElwAAAAASUVORK5CYII=",
 			"mode": "bitmap"
 		},
 		{
-			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.2-pre1\\1.20.2-pre1\\assets\\minecraft\\textures\\block\\coal_block.png",
-			"name": "coal_block",
+			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\upper_eye\\colorful_pupil.png",
+			"name": "colorful_pupil.png",
 			"folder": "",
 			"namespace": "",
 			"id": "4",
 			"width": 16,
-			"height": 16,
+			"height": 160,
 			"uv_width": 16,
 			"uv_height": 16,
 			"particle": false,
@@ -1365,14 +1357,13 @@
 			"visible": true,
 			"internal": false,
 			"saved": true,
-			"uuid": "91f4647e-d482-ceca-1b5c-12a72e28cad1",
-			"relative_path": "C:/Users/afro/AppData/Roaming/.minecraft/versions/1.20.2-pre1/1.20.2-pre1/assets/minecraft/textures/block/coal_block.png",
-			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAQlJREFUOE+FU0EKgzAQTA6CBgSt9WAP9v9/q+ApemuZhQmTxaIg0c3uZGd2Et/r+g0hhHwcWMJ5nqFtW/ve993WYRjKHvbxIAdvnOfZALQYSUwkAGMsTF1nNQbgC5ikXfAQdsP/2Pe9AWhbz2kKOedCi8mg5OnEpmmMgm+NmpAaDwGAdmwUFJmn+UKNK0XrAIHHOFaTIAC701XBDECF8WojGYqnlCpdmFcAyJE+QFcc1T89bIxeRAKgWM1FSq9lsThNVnyAE9WFVyLqCKlJhJWBSE4ck4qmY9MJoMtCQS2Lb0xFhVNq2Ce9CkDNhOLPtlUXyusC0EsnKiV1KedfORF3gddXExi7E/YHpAf5qSjgElwAAAAASUVORK5CYII=",
+			"uuid": "0cf74b39-3ccc-8b65-0714-26407f430c46",
+			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAACgCAYAAAAFOewUAAAAAXNSR0IArs4c6QAAD45JREFUaEOVWmusXUd1XjP7vM+5T9/EzwSHpk5IbCOn1ARCCIQEx3aiBMfEDbiqAm3TlrqoahtSQEg8BPxG4hft36hSkRAS+YHK/6C05QeJKhKQkvjt+L7vueeec/Zj2u+bWfvOOffaoWNZe+/ZM2u+9a1vzd5nr2ue/8QfuIo1MswKsUakWa9Ku16ThbWeGGNkolkXa428u9KVirW8RlvbGEheODF/f+xuV02sTLQavDFIM8nyQtb7Q14PcV04qVUSqSSWE3Gsh2vz9ScPO2uMLHU3BMfZiZbkhTcwzHJpN2qcDENorUaNyHC/KAqPADen2g2pJAkNFc4JUE22GvLucleqlURmOs0SOsbvmp2UNMvFvHDiHgfYgzSn/61aVZw4ubrcFedEmrWKNGtV6Q1SSfNcdk51aOj66rpkQPDnH7/DFfCxmsitUx2uOMhy77M1JArXrVpFrLU0hHuAD2Tm26fvcyRvmEnhCg5Ac87RJaCqVyuy1hvIxjCVW6c9AnBAF7708J00AJ/0BhA1ahVeX1ta48ozHc9RfwgyHd3CRPPi4wcdnJ1f6xHa3GSbg1Z7fUkSSySJtQwtojLRrNEtjAFX5m8evtNhAAZOd5pyaWFVjBGKqQHoGwOZbNVLncyvrJPYdhCU+cZTH3QGHGQ5ISPu8A2rwRUMzp2TlfU+ESZUbU6uMNb85UPvp5BUor3BUABhutWgoKALCAdy7jRqMr/a84JCyOtVMV/61B+Sg94wI/R9O6bo84X5Zfo61arTnX6aUVwKfa3Xl4W1DTEvnrzXFU6k0/QSVfh67PaHMtms05VatSIr6xvgnsqlDr556ogDm/ARTEOyiDF8RdI06zUm2MIqshPKrBLJWn8oGXTwxQfvYDZCIJjYRbZVEtkx0aKBBUg2L6TdqFMb0AWQzk21mXzmn44coZDQ4CdCV+0UIkMrUiv8jaGVdChSrflLnA9zn53my4cPuXbTqy4epEZjIzomXtCcO3jIWStCI7piGJF2Lc905XFERPDVDx9xWLkcCCMBMvvgTnBjbT24GLlCBPS7JlKbtDLse9/IAVqtECAhijFOwANJHLk5NrnkYmi5AG9jkYCy5ICLJR6JrqxISG6IjBKtbpdh3A4FBiG0IJnGlY+AEvdHXYj83rK6+hKgj+hgC/QxQ2U4o4iomDYRBCGNhDMidH3DR0dFpxHZPgogtOHVqYyXxEYuFEUQEq1t4/+4MuOQllGAkCbam7kAcsDJFlcid3TyqJDUfKQ2dI3IPCgzjlAppBuJCIORA2iQfIksLGheePQZl7uQMCKSiBWTWG4m2OoHWSqNapXPySxLubmgYVPBrkUDeNJUK1VsdSKFSOas5G4gFrOMiLFWEpvwqZ2mmSTY20S43ZsXPn3GDVwhVSOcgE7OM8KBeJxlfIbxicb/Bp4QSSHmK4+dcYmxfAa4PJcMszHIGmlYK3zU6qaHZNRzuu3EfOXYGYd3H/a7QvB8Gg5Tv2HSWdzDE8qnaZplHqE14opczNeOP+v4omAMH2VFkfPBEi+spHmLHgUeJnwufPWxM64whlb5hHG55A7+W6maRNIiJSpcGyskExZAKJ8LLz72rCu4RYNA4dsXGh629WoiRixfbfzLgAcAtPjPcxjA+2EuTtJBKpbxh0veDSvG6wIoQRqtMLaSZkMY+BOH9x1AwsSwBlfQlwuEq+BLgHABtFqC9ySBkE47rAbbeZGJOMPnIYZvDPtikyo1gUjhXpZn4oyj4Cikf/jUaUdJGhNE5DjYYVYhUq1YIsajHv/QvBJhLBfzj498FovTV6+gYD2Q1ajVxeap9HMfHYyyiSEakvnCsTNczFu2krlCLPwbDomIqzmRgRRSESuIEXOjZsXkMPDpZxxf00FImkoKf7GhBFXCKEjgAerPodZCEmf4GsBkKhUWkMAdrIy8QCQYc5znuY8W0IJUa8WceODzDoO0Mc7WeD8LxyRLQCSoyQuvVg02yIcBjS+5YHiggVwgHR98/5aGdYrM5w1TAuhOPHDWFVQBfPSQVbb+9c4CyDb7AVwpxJx88KwPOfeHwhvwgicPm5tdZMSv7/eDEx8766BOvx/4Y44s23SUNypVn2R5FkyS2ELMEx8/67A7heuQSOX0kjCGMnQTJDSSGDGPP3jWIU/YSeNwI+y6yA8ypCnsdyJFiqiQAx8av5niFZ9Q8xA+imczdMqPovEkhsUd3tiZdfDJGyJqhHHEq5B84EoR6KYaQhBICSoMWwkNBkvIYLp64oHPhRzz4kGWVWrYykTSNBVjKySPwJyhGjVxKaTjH/mcU6seRVg1ZCH20FInKuGQ+djFzfGPfp4y3HTRi4HG8GRCxhUFfyOWGguRYGghJJ3NrNaHRpZHmYhNtxAbth1MtFUjBt4wmcJ+INzvkPt0uIw/8IWgMBuZAw4Zy3TeRFDu+z5y3MLK5wGFtpkrXASLHXj2391wY0VqzalN2eL5GPpmJq/IcDiQpaUZyYcDSWr1kaPZ/9S/OBkuitRmZWZmSZauOZ6jL1usiW2ti21UeU5NhWucD64PA4KVt2Rmp+EqzIbVa5zE837Kcxzztf/7sZ00pDI75LUUG95A/9qbfkJYGROxIgay1WZptOi1SxTeejAwXHnLrzS5k9BpPTRMoqHarLRrK7I236chouitegTV/Lysd/1P33JiMILB8HtirlGOUW7SNbfJQbuTcEDs87jvSiDG0HBjfpSD8kZrvUSClQFbCdRI4Dppd8V8+PkfuCu/XfMWw0Q9L32N3HF5X6q3+L2CHMQGyjgHMtVXZZ/JmvfLUJY6QBgxKL65nZjURUVBA1AiYszVG1VJr4dX2aRBl3T1yq5OGWJ1cSQKah3xjY0o7GQiH1EnjPSH73gEzIUg29jf2GflR8MDtHThthM/dG4x3dR3pECdFBuNk6l79YpHMLh0dUSFelGdMAI/03xB6slOdg9yz5c2c/zkn3H729jolp3Npv9a1WpN8NjrrW1ZQO/RQDy53980hFmNhjeGpve0b8eO3UIDS0vehSLvl4Nt4j9Qoi0uXOZxenqWR9xTIyWC3vr8Fpjasby8KIcOPyQXzr9WGsDJzMwuMfd/9JiDNRgYDPpSr4dPo+EcfTOz+wg/Rthqz0npAjhQA83WtGz0lks0sUF06jXcIALlANZh9fKlN6XZbG3rjk5WHrYYYOjac7K0eHHEACaqe7ivDeE2n3j4aaf+YdB7tY2NnuzZe6AMKw1oBG5mIOYGiIAEC48YiMP2XjzAAF04cNchpwJRDhCe3/32P7d4M85FycGNXLhRCHUhGoilrLJV+PGKMRyVOcP49Gf/1i0sXBlJFGhhdscezlH1xbmhxkoD6NCURZrquWYpoOIchjWEmvLm1m98d+Qt0q5cENMtxHWsFFO3jRCZXHpH8r3vK/s4Vg3gAm1wcJ8ku0Xsq0Z0gt6DYTQ1QgO7vvzXRKCrofNmK6vR9DYn1QtGzO4vPu/G4WIQ+nTF/v23c3DsQnHUESUNpJ+5nRfaMFChKiJ1YxwtDegKvHnUSX5FpPHL8yP+xsYVMRYiB4Aas4vB6kbMh8KOETIKGjoYGT+PIYO4+usXyY0uSANqUWHGYdouInEoSwPjLsS6QATQYnQakS1hVN8xAVARocp/XKQ2xnmhQURBV4/jr0zH4VM+FAmMl1IGQQhdLKpYOPHqcX8ZhXGI8aDY91gPQD6SjeMrxsTGOYBkq/7kPENZGsAAlbSuGCs0Nq7u0sBD58667Bb/CO/96g2ZvG0vz9Gn1+P342vzwLf+ylWud2X92rysXV2UuUfuk//PNRFgMn6N9BbXZebOvZJ1UYgRGtz1wQM0jvtoQBiPN0ee+qTDRLTWrP89MN7G78fX5kPPPObaO+dKn1v33SWD198W9K1euLSFE9xnLrx9TQaLy0IOtGPpd5cIGSRhAK7hUrJ/J43CJVzX222Omf/Fr3wU4FPs82B9nTyMcwDoykml0/QItuMAA2M+bsrBdjqI41yfnS4hb6eLUgeADZ+300HM0fj9bTkY1wVIQ9OoxByVHLyXzze6b+7/wmechuX30T6UCI4gdyC6YS7cjJM4V7bkgsZ5PBcQdxXae+bCzeLOtI9yx3zhnz/pli/25fTxc2T6Z6/8SPrL/n2xMd2Q/e+fk0Evl6Xukrir++WuA3fJocOHZGVlRf77rR+LOfWnH3GYPDU1Ja/92r+Nv/o/P90y+cDkMfZPVe6mkcuXL8mePXvFPPfcc+7RRx+V8++cl9vfd7v88pVX5OLyf8kdd+/mqmj4DTInB9mv7eg9T9IIDaBTrc7L63QBA359+edyeM8xDsTk6X0NmenM0DDcRjOnTp1y+/bulbVuV1ay37ATk9948w0ZdN6Wenc/+7DA9eLVEgGMAJl5+eWX3b/+23fk7vv2kaxb7NHSFRpdWZGjf+z7fvHajwRcvLn6c04GOvPSSy85+A+CAPGRQ39BPtAAXV1SZNoPl0C++f73vk8OYGCcICUT/er3vukPkX24CLfM350755RddUMHA5FCVvIAHbzANXBHHUAwu3fNyJWrS6I/EzvdgwSE1dAQEdwD+xiv53QBvnY7r5cxVyWqS4CNpnxoOP/ojtOeA/UfljFZV9h1q5fxW7+5QgUizAgxIoIGsksXVPPp1b0UTcwH/Ec/wgriNBKUMpIJK119d56EaURUyuBCeVBFakgpZbgAhUFAmiA6UEOmK6pa4QbEBELpgkoXAyc6nRHxoA/+q5w1leE/jJiTp+7RL6iBdP9F05cDnBR5Lkkl4XfJInwm5UB+hzXeAAsv+PiKG6gvoFDgUDIK9cZQJsBlnuf6ZdV/bT75NP6Iw39W9Z9tw7fUsAzqC/FPGgxhuU2/rT5x+l7O5vd1VLzCN3aUC7W+UFZQ8BlVrfGjrRPz+Ol7WahiYSOMZAGq/Nbsq5SVii/YwoXNemMh5slnDjr+cZYYVnBYdNBP92V++o/UUbmRiCsVK4YuaL0xGPAkwwUUb1EH9D2sY6I0FNDyb7KeOH3QOXwvDsNAGoNRoOLFYiHPtZDrbTGA/hQGcO5rK5lYfsLGz7vwNxihNMYohY/yaiDH32AQAcog/sdfKSYdzbojv9aHFbW+wMKmiHn81Ac8B4SBD7P4ou8Zz1DRRH2BrvsxUKYvunnFmJOnPoDCHzs9is36AiolrORoHUrp1LCDRJ8LvtFF4zzLoadSrYjJc0lJtB+jlR5yASGVBqyvPbNwm/o/2vIB3aa+AA2Qg6fvcayV4aLIUDlgxTdQF9Jus8pT1hdYc7A+mcoKVoCC6ZAD6jGbpWKfK1p5RbUDOfS/BP4h0aa0Gn4AAAAASUVORK5CYII=",
 			"mode": "bitmap"
 		},
 		{
-			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\upper_eye\\colorful_pupil.png",
-			"name": "colorful_pupil",
+			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\upper_eye\\colorful_iris.png",
+			"name": "colorful_iris.png",
 			"folder": "",
 			"namespace": "",
 			"id": "5",
@@ -1393,14 +1384,13 @@
 			"visible": true,
 			"internal": false,
 			"saved": true,
-			"uuid": "0cf74b39-3ccc-8b65-0714-26407f430c46",
-			"relative_path": "../../../../../textures/custom/upper_eye/colorful_pupil.png",
-			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAACgCAYAAAAFOewUAAAAAXNSR0IArs4c6QAAD45JREFUaEOVWmusXUd1XjP7vM+5T9/EzwSHpk5IbCOn1ARCCIQEx3aiBMfEDbiqAm3TlrqoahtSQEg8BPxG4hft36hSkRAS+YHK/6C05QeJKhKQkvjt+L7vueeec/Zj2u+bWfvOOffaoWNZe+/ZM2u+9a1vzd5nr2ue/8QfuIo1MswKsUakWa9Ku16ThbWeGGNkolkXa428u9KVirW8RlvbGEheODF/f+xuV02sTLQavDFIM8nyQtb7Q14PcV04qVUSqSSWE3Gsh2vz9ScPO2uMLHU3BMfZiZbkhTcwzHJpN2qcDENorUaNyHC/KAqPADen2g2pJAkNFc4JUE22GvLucleqlURmOs0SOsbvmp2UNMvFvHDiHgfYgzSn/61aVZw4ubrcFedEmrWKNGtV6Q1SSfNcdk51aOj66rpkQPDnH7/DFfCxmsitUx2uOMhy77M1JArXrVpFrLU0hHuAD2Tm26fvcyRvmEnhCg5Ac87RJaCqVyuy1hvIxjCVW6c9AnBAF7708J00AJ/0BhA1ahVeX1ta48ozHc9RfwgyHd3CRPPi4wcdnJ1f6xHa3GSbg1Z7fUkSSySJtQwtojLRrNEtjAFX5m8evtNhAAZOd5pyaWFVjBGKqQHoGwOZbNVLncyvrJPYdhCU+cZTH3QGHGQ5ISPu8A2rwRUMzp2TlfU+ESZUbU6uMNb85UPvp5BUor3BUABhutWgoKALCAdy7jRqMr/a84JCyOtVMV/61B+Sg94wI/R9O6bo84X5Zfo61arTnX6aUVwKfa3Xl4W1DTEvnrzXFU6k0/QSVfh67PaHMtms05VatSIr6xvgnsqlDr556ogDm/ARTEOyiDF8RdI06zUm2MIqshPKrBLJWn8oGXTwxQfvYDZCIJjYRbZVEtkx0aKBBUg2L6TdqFMb0AWQzk21mXzmn44coZDQ4CdCV+0UIkMrUiv8jaGVdChSrflLnA9zn53my4cPuXbTqy4epEZjIzomXtCcO3jIWStCI7piGJF2Lc905XFERPDVDx9xWLkcCCMBMvvgTnBjbT24GLlCBPS7JlKbtDLse9/IAVqtECAhijFOwANJHLk5NrnkYmi5AG9jkYCy5ICLJR6JrqxISG6IjBKtbpdh3A4FBiG0IJnGlY+AEvdHXYj83rK6+hKgj+hgC/QxQ2U4o4iomDYRBCGNhDMidH3DR0dFpxHZPgogtOHVqYyXxEYuFEUQEq1t4/+4MuOQllGAkCbam7kAcsDJFlcid3TyqJDUfKQ2dI3IPCgzjlAppBuJCIORA2iQfIksLGheePQZl7uQMCKSiBWTWG4m2OoHWSqNapXPySxLubmgYVPBrkUDeNJUK1VsdSKFSOas5G4gFrOMiLFWEpvwqZ2mmSTY20S43ZsXPn3GDVwhVSOcgE7OM8KBeJxlfIbxicb/Bp4QSSHmK4+dcYmxfAa4PJcMszHIGmlYK3zU6qaHZNRzuu3EfOXYGYd3H/a7QvB8Gg5Tv2HSWdzDE8qnaZplHqE14opczNeOP+v4omAMH2VFkfPBEi+spHmLHgUeJnwufPWxM64whlb5hHG55A7+W6maRNIiJSpcGyskExZAKJ8LLz72rCu4RYNA4dsXGh629WoiRixfbfzLgAcAtPjPcxjA+2EuTtJBKpbxh0veDSvG6wIoQRqtMLaSZkMY+BOH9x1AwsSwBlfQlwuEq+BLgHABtFqC9ySBkE47rAbbeZGJOMPnIYZvDPtikyo1gUjhXpZn4oyj4Cikf/jUaUdJGhNE5DjYYVYhUq1YIsajHv/QvBJhLBfzj498FovTV6+gYD2Q1ajVxeap9HMfHYyyiSEakvnCsTNczFu2krlCLPwbDomIqzmRgRRSESuIEXOjZsXkMPDpZxxf00FImkoKf7GhBFXCKEjgAerPodZCEmf4GsBkKhUWkMAdrIy8QCQYc5znuY8W0IJUa8WceODzDoO0Mc7WeD8LxyRLQCSoyQuvVg02yIcBjS+5YHiggVwgHR98/5aGdYrM5w1TAuhOPHDWFVQBfPSQVbb+9c4CyDb7AVwpxJx88KwPOfeHwhvwgicPm5tdZMSv7/eDEx8766BOvx/4Y44s23SUNypVn2R5FkyS2ELMEx8/67A7heuQSOX0kjCGMnQTJDSSGDGPP3jWIU/YSeNwI+y6yA8ypCnsdyJFiqiQAx8av5niFZ9Q8xA+imczdMqPovEkhsUd3tiZdfDJGyJqhHHEq5B84EoR6KYaQhBICSoMWwkNBkvIYLp64oHPhRzz4kGWVWrYykTSNBVjKySPwJyhGjVxKaTjH/mcU6seRVg1ZCH20FInKuGQ+djFzfGPfp4y3HTRi4HG8GRCxhUFfyOWGguRYGghJJ3NrNaHRpZHmYhNtxAbth1MtFUjBt4wmcJ+INzvkPt0uIw/8IWgMBuZAw4Zy3TeRFDu+z5y3MLK5wGFtpkrXASLHXj2391wY0VqzalN2eL5GPpmJq/IcDiQpaUZyYcDSWr1kaPZ/9S/OBkuitRmZWZmSZauOZ6jL1usiW2ti21UeU5NhWucD64PA4KVt2Rmp+EqzIbVa5zE837Kcxzztf/7sZ00pDI75LUUG95A/9qbfkJYGROxIgay1WZptOi1SxTeejAwXHnLrzS5k9BpPTRMoqHarLRrK7I236chouitegTV/Lysd/1P33JiMILB8HtirlGOUW7SNbfJQbuTcEDs87jvSiDG0HBjfpSD8kZrvUSClQFbCdRI4Dppd8V8+PkfuCu/XfMWw0Q9L32N3HF5X6q3+L2CHMQGyjgHMtVXZZ/JmvfLUJY6QBgxKL65nZjURUVBA1AiYszVG1VJr4dX2aRBl3T1yq5OGWJ1cSQKah3xjY0o7GQiH1EnjPSH73gEzIUg29jf2GflR8MDtHThthM/dG4x3dR3pECdFBuNk6l79YpHMLh0dUSFelGdMAI/03xB6slOdg9yz5c2c/zkn3H729jolp3Npv9a1WpN8NjrrW1ZQO/RQDy53980hFmNhjeGpve0b8eO3UIDS0vehSLvl4Nt4j9Qoi0uXOZxenqWR9xTIyWC3vr8Fpjasby8KIcOPyQXzr9WGsDJzMwuMfd/9JiDNRgYDPpSr4dPo+EcfTOz+wg/Rthqz0npAjhQA83WtGz0lks0sUF06jXcIALlANZh9fKlN6XZbG3rjk5WHrYYYOjac7K0eHHEACaqe7ivDeE2n3j4aaf+YdB7tY2NnuzZe6AMKw1oBG5mIOYGiIAEC48YiMP2XjzAAF04cNchpwJRDhCe3/32P7d4M85FycGNXLhRCHUhGoilrLJV+PGKMRyVOcP49Gf/1i0sXBlJFGhhdscezlH1xbmhxkoD6NCURZrquWYpoOIchjWEmvLm1m98d+Qt0q5cENMtxHWsFFO3jRCZXHpH8r3vK/s4Vg3gAm1wcJ8ku0Xsq0Z0gt6DYTQ1QgO7vvzXRKCrofNmK6vR9DYn1QtGzO4vPu/G4WIQ+nTF/v23c3DsQnHUESUNpJ+5nRfaMFChKiJ1YxwtDegKvHnUSX5FpPHL8yP+xsYVMRYiB4Aas4vB6kbMh8KOETIKGjoYGT+PIYO4+usXyY0uSANqUWHGYdouInEoSwPjLsS6QATQYnQakS1hVN8xAVARocp/XKQ2xnmhQURBV4/jr0zH4VM+FAmMl1IGQQhdLKpYOPHqcX8ZhXGI8aDY91gPQD6SjeMrxsTGOYBkq/7kPENZGsAAlbSuGCs0Nq7u0sBD58667Bb/CO/96g2ZvG0vz9Gn1+P342vzwLf+ylWud2X92rysXV2UuUfuk//PNRFgMn6N9BbXZebOvZJ1UYgRGtz1wQM0jvtoQBiPN0ee+qTDRLTWrP89MN7G78fX5kPPPObaO+dKn1v33SWD198W9K1euLSFE9xnLrx9TQaLy0IOtGPpd5cIGSRhAK7hUrJ/J43CJVzX222Omf/Fr3wU4FPs82B9nTyMcwDoykml0/QItuMAA2M+bsrBdjqI41yfnS4hb6eLUgeADZ+300HM0fj9bTkY1wVIQ9OoxByVHLyXzze6b+7/wmechuX30T6UCI4gdyC6YS7cjJM4V7bkgsZ5PBcQdxXae+bCzeLOtI9yx3zhnz/pli/25fTxc2T6Z6/8SPrL/n2xMd2Q/e+fk0Evl6Xukrir++WuA3fJocOHZGVlRf77rR+LOfWnH3GYPDU1Ja/92r+Nv/o/P90y+cDkMfZPVe6mkcuXL8mePXvFPPfcc+7RRx+V8++cl9vfd7v88pVX5OLyf8kdd+/mqmj4DTInB9mv7eg9T9IIDaBTrc7L63QBA359+edyeM8xDsTk6X0NmenM0DDcRjOnTp1y+/bulbVuV1ay37ATk9948w0ZdN6Wenc/+7DA9eLVEgGMAJl5+eWX3b/+23fk7vv2kaxb7NHSFRpdWZGjf+z7fvHajwRcvLn6c04GOvPSSy85+A+CAPGRQ39BPtAAXV1SZNoPl0C++f73vk8OYGCcICUT/er3vukPkX24CLfM350755RddUMHA5FCVvIAHbzANXBHHUAwu3fNyJWrS6I/EzvdgwSE1dAQEdwD+xiv53QBvnY7r5cxVyWqS4CNpnxoOP/ojtOeA/UfljFZV9h1q5fxW7+5QgUizAgxIoIGsksXVPPp1b0UTcwH/Ec/wgriNBKUMpIJK119d56EaURUyuBCeVBFakgpZbgAhUFAmiA6UEOmK6pa4QbEBELpgkoXAyc6nRHxoA/+q5w1leE/jJiTp+7RL6iBdP9F05cDnBR5Lkkl4XfJInwm5UB+hzXeAAsv+PiKG6gvoFDgUDIK9cZQJsBlnuf6ZdV/bT75NP6Iw39W9Z9tw7fUsAzqC/FPGgxhuU2/rT5x+l7O5vd1VLzCN3aUC7W+UFZQ8BlVrfGjrRPz+Ol7WahiYSOMZAGq/Nbsq5SVii/YwoXNemMh5slnDjr+cZYYVnBYdNBP92V++o/UUbmRiCsVK4YuaL0xGPAkwwUUb1EH9D2sY6I0FNDyb7KeOH3QOXwvDsNAGoNRoOLFYiHPtZDrbTGA/hQGcO5rK5lYfsLGz7vwNxihNMYohY/yaiDH32AQAcog/sdfKSYdzbojv9aHFbW+wMKmiHn81Ac8B4SBD7P4ou8Zz1DRRH2BrvsxUKYvunnFmJOnPoDCHzs9is36AiolrORoHUrp1LCDRJ8LvtFF4zzLoadSrYjJc0lJtB+jlR5yASGVBqyvPbNwm/o/2vIB3aa+AA2Qg6fvcayV4aLIUDlgxTdQF9Jus8pT1hdYc7A+mcoKVoCC6ZAD6jGbpWKfK1p5RbUDOfS/BP4h0aa0Gn4AAAAASUVORK5CYII=",
+			"uuid": "4f855b2b-3aa9-0dbd-36dd-c1eca8045e2e",
+			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAACgCAYAAAAFOewUAAAAAXNSR0IArs4c6QAAEaVJREFUaEOFWmmsJFd5PbeWrurq9b1+68y88Wx2mOAYJxEk2AFrGNvEkbGQiRPbxAk/ovyIneEPKBLiT/IvP7IJBhwbgiCOjEkwIlJkIllECt6iOMx4gTFjz2LP8rZ+03t37Tc5t97tV6/fG7iaUVfd5XznO9+5VdXVTzz+R3fJNE2Rb4ZhjE/jOIVrpIgNC7vNEwSw0hjStLaBiCRGiAzINrcAgyiFZWXnBFQAjKKDkkyOAMiGEzUrHYwByEoB6NAcZPNTQ0UxRTaSZzOZqnjyM1sAUbJdi/zkAtJd0xRfeeS4YpAXLi8W+5liPu888LYUNGUy4UJ9vm3BZu4MQr22MZgsU6b01nItbp6t+Nojx6QuIUvk2IYSLd/yJU4ktjFTKeTLNJn/9cboDYKNNdgtX2qhfZE3ExfqJr786eOSVmXTdmXJeMyW94Keo/uY8jiFXyTYbgIzkAKYpK9F1HtBg7MKrEB+74w1YGd+gc5xx4LcJuPY2Ad6AUVjKfUe0Fro3ZcHVnNO/v5jMpVbshoQEKYByzSQyhRRnMCxTVDmJEwQbzpLCApsZABEsm0LavMlQASBVEYQqQQvCUIImKYJBorCBKaRbVOei5MPnpBRmoLXCC5gJ6MxCYMLLVMZRqHzk5iscJKCM8VXHzohhQmkCSCTBDHTkVKp7RgGIobSKRJVbl4kZKr6xVceOiFtk5R5LtXcIIzUVSmT0oQUEm7BVmdRHKs5wjBUQPHkH3xWRokERaE+Mk1gbOYoM1WyiggxPlOZpCkKtgnx+MMnJFltMlK5ZBoYKBgGwjTOzoVQwMIUEDILlpDBVx/+rEwTCpCJZ1vmJtUEtm2qNMgw450xUmz09ZIAQmSLoyCCaZiQMoUQm2YSWb6sEpkyOlh/CIRxTAYnZJpKSP5nHlkINUEiqwZ4QU03o2/eEwrKaMqJj0pSkjCQqiuRgOvYSjA/8CGsgkrDMjlHIGYVOJhuGulLDzwqlTi6CpDKaZIppNQkyzlWdc4IGmYmScLqffmBx1S1tCiZxOqfSsNxCuoaGcSJciQrzEqQhhLzJJ24qSjTZUEMy0AaRqA2LB9bgAQ2sqoIQ8C0DRgEOfngn2UuoiBRiEgIWGbGUdefqm96S90nuUtZB+4TtZlyhstyFIBlCFV/vY/UlkgSVSkCs9z0u/jjj/+jnJuZR6M2j43OqgJYa66Cffd98HZ86Pah6vv2d0tY7r6NM+deV2Ocf/r0jyG+8Ol/lzxZrN64YwIB9dhz//WMAlo6uFf1sRFMMTh6+BYVnZHZeE7ANy+9oPo+9qufAgGciqWO2a+ZbkuBiEEvu60xkgYkZQ10aEHixbPvjNMdp3D7TUfwb//zIi5duKIi6abzzeeuAzGI+Os/fVWS7oOfGuBvv3F1nAoXst289FuYjJoPIl75u7bMK81F+RwnGei0tFbbqvDDU99VUbmIkQmUL68+JgiFHldBLyCArkCe9qSYeg7nKwZaMF1zHXmyKppBXpcxgF6cj6zF0jpos2mDqRTyTiQTApxfETtcycX5MW08ZSS6i4O7VSOfP6lPOnKbE8mAhjr5ne+MzURn0jC65TcaHalS0J1aB6qr7at3JV06uUu5Q8Ujtz0htXUntzWj6i2tXUphyYj9ZCruOPaErNZn1QUiSXnBEEjTCIHvq0t6HCXqllwsefD9AOVKFY5Twery27AsB+LY8W9J13NhmTYGg4G6+slEIJEJXNeDZRUhZYJKdQHrq+chTBOOY8O2XfTaXYi773laeuUahv0hoqCrLs+pTDDVmMeg1+UtBQWrAMt24Y8GSJIQBdtWDK1CmQBPqccQXiCDIEQS+TCtIhzHVFfo0aAJ15uGXbARRQlcp4goDBHFIeyChDh+9z9L2zIQRol6qOT1lhdOy7LUzcMuGOh32hl1twwZhwjjERqzN8AftgjwDZkmprrb2NY0hNFXDxW8rfFOIkSC6vQi4qCHXq+l7pFeqYRiuYrmymWm8E3peQ0Mehso1aaxsXYFtlWCMCQc10GaSIRBgFKljnJ9Bp2NK+rpIYoC5S3x27/ztORjnWm6GA7aajCJQxScIiy7hCQewvcHsAxbPfNYVgGeV4FZKCIYdAnwbUnxytUpyDiC7RXRubaOgl1EQj8EQ3jFWQTROgQKMNWTm40wimCaBsRtHzkp5+b2odfrw3ELcIpFdZu7tr4Kr1RW1RkOhnBdF3EMWLZQj0P+qA+3WIG4595n1AXl2sYlVGt7YbsGIp9PoQlGQYRavYEw9CHSFH4wUjdWt9hAHHcRRxHER489KW3bQ63RQK+1pmpPCkKYsC0LURrDENQlgldqIAl7EJaJKAzgj7oQ937y+zJNMkWDIEEchzBFCqtQRCKHsA0HhVIFo15XAZdKNXR7PUCGEMKCuPe+f5WjMELBArrdJizTg+O6CPwhisUGktiHWXCVH+I4gilMjPw+alPz8AcdiPsf+oGM/JFCHw56kIkBt+QgimLlxsDvw3UriJMR4iCB45Ux6HdQrdcgYEHc84lnZBJLRMEAbsmF5y2g111D4PdQKs8hCHqwLZePV/D9EIZlgs+V/DqQJBHEo1+PpChkz4Suu/Vo6/sSMswe+4pVE3sqwN66wJW2xNUewHHlRAKogxyIHtQAHP/o+60di3cFGF89NxlpJpqFjk5wBhWP/VMi9Yn+ZCqkzMYFo26iJh+aFTi/vpXaGEBZJ5fvB5e2cuWYBiCwZsTFPBef+5dU5jsZhS0vGAG0TgzEdHRTAHqCzlMPkj5TOXclA2A7vDdbzDEFmtdAR89PmKwIg+RTHAPko2t0AmmAfP5koVNUAJyoTUTKVFqf5wF2E3TsRB0h/6kZaOEm3cnzsRO1ypNAeTdqt2q/jJ2420DeXHlwXY1x6bUGeiCfu46uTTOu5eaBMlgeYDcLc27eOBqEYrNa26qQ979WPL+J2Jefo0T8xHOvSbvoqdddrasDLByqY+VCG41FB4NujP37p7G63odXNjFdKuLsuRZ++Za9uHjuEoRZgDj+7BvScXlLNzA7W8bl88swrAIKrgGvVEAkC0ijBLFwEXZacIo2hJFiasrD1csjiOPfe1NCWCgUHcSDLooVG2GQQEgBu2ghjVJ0rkVYOlxDs+kj8UPUpky0NwKYXg3ijqdflXy8ccu2+kLNr7/+SGJ2wQGvtemgBT/lfTDF4uEaWs1Q3ZnqMxY6qy2I275+Spp2ilKjjN5aD3OHphDHUn3h3Fj1UakCwTCE7fDmyieVFINWH0ahBtscQnz4ay/L+kIVexoOinNzOHPqHAy7iKDvozzlIA4jePUKPDtFq9lBnArsna+or6/n31mBuP+5UxJeGcN2H425GvxOFyiWcPXtNo68r45WL0BnPcDU3hoGIxNz9QRBKtDbGMF2BMQfvnJeyiRFLwIKpkRzeYiZOQftXorGnjo6K23smSlitT1Ub3AMw8Kgn6C2UEVnpQdx+zdPyX031tBpJyh6/AYrMeqPMD1Xh40UF89dw9T+OaDXxEYze/vLmwvv0vVZB+KOp16WpTqfOGz4gwAL8x4GYQoLKVavDOCUCjAtgUE3gjAdeKUUME1MV21ceteHOPbM69L2TAyuLmPq4H50VjZgV6bgOjE6zRCzB6bQWQtQLAv4vSHmFyuw6nWsX1jGsBP9/xfPl8/JbiKw8t4AUb+HylwV0SjE7L4KbEPg6qW+MlTBETC8qnIjH/1i3liSAOKBl96VV9/ZwMJSEWFaQDzyMewHWFiqY/3dVYwGEkduXkR/FMC1gea1BOW6g2g4Qq8VQXzy+bdkayPGDXsdXLqwgtmlWVx5r4f9h2q4uiJx9FAJlzciBKMAfHxqN0PsWypiGAmEIx/iY8++KeNhCK9uo7PcR2OpjtbqANVpF3ECTNcMxIaNwfo1jAIbtcUq4uFAPVPXpisQdz37muy3UswfcNFt9jB7ZD8Gay0E/QHsah2WEaG1ARhyCK/iYtiPlR6lqo21iy2IE//xrPylucXJq5U6/9naMmbKVTS80rbxjeEAzX4Xb51+CeLkqZflixfPYcbztk1qDodYfv0l/O59jyggNvbpeTxunj29EyA/6fLFn+D4h+4cA/SaTQSbgQj0xivPZynoRfx0htkrD0701y7g1ps/rOjmGeh5F985nQHowffNLajJ+QnH7rx/DKDn8ZOBrlw+m6XAHCfz4yRqMLWwiH0H3j8e1/Mo7gsv/ADiL198Xr61tqIoaoGYK+kx+n8+/yx+5TfvVAC6MXplZiarAlOYFIfi6dx1NQ4cuVXpojUimEqBDC5cPK8QOZnC5ZXXeTMdgmiByXbsg1d/+oYCyJdNU87XfbIqCkAz0GVjdG2syfJ2+qtjdlqnMQCpcUI+d+arjcPobAxAxuxnWmMjcbKOQAZ5sXTe2toaQFlZO5GTdI4UVTfNID+uy64YPPy9pyQX1srzqvaLt9ym1moGZMWmx3Ul2N9vdyDu/qvPKStHfmYU2812Zf6cx7v1c574wnP/MH4N1Oyex0z1EPipnFk9NE5FH3AsHQHu6AoOtmcygLXVbAE72cLprXcmnHx0OcDPDjlqrHAtm+MOIwwvt7cA5uYPIfzpD9Hdd2AcVS9mBwG4uHrgI2oe2xige/FHY8TwA7fCKGb0yUxH52JG1Qu9fXX85HIlY6ARdXStAxnkU9MAqqSejXNn3e0aMLJuk4v9YqZLfeMiFsNFLBeWtxiQ6m6LdXS9WCvP/m0AumwcuF5kXSGWjou3pcCFur46KieynVl0VHk1i7wmYw2ut/hCvakW6vTy4hI0Pbu+JaKOoqluyZkZS5eV/QRkWXcAsEztxpaRNCgXaG10CgS1XjmdMaCR8g4jiDZQ3o3UQzuWc668trHdSLSmdqKuCIG0mGRSvXxRWdi4aXbLSNqJnEjkPGUNQEFJW+9EFYAi/skzfy6ZC71NZLYLWMJBXFKf+ca+/DiPxdN/83vSm7i1D4dDsI+fbJPjGpTj4vuPf0bedPTGbZE6wwFqXgnqc6aBTnNDjbMv386eeTtjcOuvfwA/fuM9NVYs1bKoRYnhSKjPfGMf29Gb53H6R/+9xYAAv/YbN2Vzh/6ujHTnmfMdHD1Ug2LAFOZv2IOrK7HqJO2f15jGu8tt1Gs2Vt+9usWAnTcs1hUAwXQaitAm7T0LltKBDHisAKjBwaNH1CJ2sp07t4HDhxvbiOTHNduxiARod6JtDAjGPjbS5TE/d6SgGVwPgPQJphnsSEGLuBtAPgfNgH0abIcGugpaxNGgo3yhvTCZwoUz72yVMc/gF5VxRxXoRF1GLtZW3gHkucpk1wXQ1tV1/3lMxk7Ue0FP1k7Um4n919tQp//3tUwDvVhv4+tF3m17iy99/k5Zr9iYa2S70HE9XOu0MV2rj3H4epT9bDweBQmKjqk+xwClchElp7ANIEWCyA9gOY56l2pYFkb9rlrI1u0OIZ784selWzBAgH43wL6lGXQ7Q9RrFRVNs+oNh6hVqwpgdb2HUqWMXq+TAfDFQWOmogDKVYe/NqBWryAc7QSI4wCXLzUVAF8fi2/9xT0yCOJtAMyfEfmWlF+J+WKe55XctXOjPcDllbVNDcoFzM1UMQhCRZ0/vnS6XQXA/G3bUdTdShUyisHFbGMA2wYO7p1RAIxOsQhQdLPoWjwu4ovP/nCEguVi0OtnDAhABsydDNhI2Stm6rOxIu1OD7ZdGAM0W83NKtgmiuqnIopXVr+xDIbBWHX+HJLGsfIHAajFcnMD0SjOGOxdrI6R52fq6r1JEKdjANLmIrIgMI/fu7SKUexD/P3nj8npchH16aqiVnZcFOzs2q9dSYMVvBJkGqtv9nzDQy8ogCe+eJfcN9/gH8BkLZE7ANg9NTWFVqul3NrffC3e7rUzgMZUBYNegKlGBY5lqD8RYXRtZVbHtUz4MX+Ls5X6wyiEZxc2U6i66neV+lRN1Z7Ndh21D9jUb0obTRWd1NkIUHKsDMCzLczO1FUVmJ9uZKF3IiugAWhjtvVr17Z249Le7BVAfgPp8/xW1uLSjQT4P+XjG5XEmR+7AAAAAElFTkSuQmCC",
 			"mode": "bitmap"
 		},
 		{
-			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\upper_eye\\colorful_iris.png",
-			"name": "colorful_iris",
+			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\upper_eye\\colorful_sclera.png",
+			"name": "colorful_sclera.png",
 			"folder": "",
 			"namespace": "",
 			"id": "6",
@@ -1421,19 +1411,18 @@
 			"visible": true,
 			"internal": false,
 			"saved": true,
-			"uuid": "4f855b2b-3aa9-0dbd-36dd-c1eca8045e2e",
-			"relative_path": "../../../../../textures/custom/upper_eye/colorful_iris.png",
-			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAACgCAYAAAAFOewUAAAAAXNSR0IArs4c6QAAEaVJREFUaEOFWmmsJFd5PbeWrurq9b1+68y88Wx2mOAYJxEk2AFrGNvEkbGQiRPbxAk/ovyIneEPKBLiT/IvP7IJBhwbgiCOjEkwIlJkIllECt6iOMx4gTFjz2LP8rZ+03t37Tc5t97tV6/fG7iaUVfd5XznO9+5VdXVTzz+R3fJNE2Rb4ZhjE/jOIVrpIgNC7vNEwSw0hjStLaBiCRGiAzINrcAgyiFZWXnBFQAjKKDkkyOAMiGEzUrHYwByEoB6NAcZPNTQ0UxRTaSZzOZqnjyM1sAUbJdi/zkAtJd0xRfeeS4YpAXLi8W+5liPu888LYUNGUy4UJ9vm3BZu4MQr22MZgsU6b01nItbp6t+Nojx6QuIUvk2IYSLd/yJU4ktjFTKeTLNJn/9cboDYKNNdgtX2qhfZE3ExfqJr786eOSVmXTdmXJeMyW94Keo/uY8jiFXyTYbgIzkAKYpK9F1HtBg7MKrEB+74w1YGd+gc5xx4LcJuPY2Ad6AUVjKfUe0Fro3ZcHVnNO/v5jMpVbshoQEKYByzSQyhRRnMCxTVDmJEwQbzpLCApsZABEsm0LavMlQASBVEYQqQQvCUIImKYJBorCBKaRbVOei5MPnpBRmoLXCC5gJ6MxCYMLLVMZRqHzk5iscJKCM8VXHzohhQmkCSCTBDHTkVKp7RgGIobSKRJVbl4kZKr6xVceOiFtk5R5LtXcIIzUVSmT0oQUEm7BVmdRHKs5wjBUQPHkH3xWRokERaE+Mk1gbOYoM1WyiggxPlOZpCkKtgnx+MMnJFltMlK5ZBoYKBgGwjTOzoVQwMIUEDILlpDBVx/+rEwTCpCJZ1vmJtUEtm2qNMgw450xUmz09ZIAQmSLoyCCaZiQMoUQm2YSWb6sEpkyOlh/CIRxTAYnZJpKSP5nHlkINUEiqwZ4QU03o2/eEwrKaMqJj0pSkjCQqiuRgOvYSjA/8CGsgkrDMjlHIGYVOJhuGulLDzwqlTi6CpDKaZIppNQkyzlWdc4IGmYmScLqffmBx1S1tCiZxOqfSsNxCuoaGcSJciQrzEqQhhLzJJ24qSjTZUEMy0AaRqA2LB9bgAQ2sqoIQ8C0DRgEOfngn2UuoiBRiEgIWGbGUdefqm96S90nuUtZB+4TtZlyhstyFIBlCFV/vY/UlkgSVSkCs9z0u/jjj/+jnJuZR6M2j43OqgJYa66Cffd98HZ86Pah6vv2d0tY7r6NM+deV2Ocf/r0jyG+8Ol/lzxZrN64YwIB9dhz//WMAlo6uFf1sRFMMTh6+BYVnZHZeE7ANy+9oPo+9qufAgGciqWO2a+ZbkuBiEEvu60xkgYkZQ10aEHixbPvjNMdp3D7TUfwb//zIi5duKIi6abzzeeuAzGI+Os/fVWS7oOfGuBvv3F1nAoXst289FuYjJoPIl75u7bMK81F+RwnGei0tFbbqvDDU99VUbmIkQmUL68+JgiFHldBLyCArkCe9qSYeg7nKwZaMF1zHXmyKppBXpcxgF6cj6zF0jpos2mDqRTyTiQTApxfETtcycX5MW08ZSS6i4O7VSOfP6lPOnKbE8mAhjr5ne+MzURn0jC65TcaHalS0J1aB6qr7at3JV06uUu5Q8Ujtz0htXUntzWj6i2tXUphyYj9ZCruOPaErNZn1QUiSXnBEEjTCIHvq0t6HCXqllwsefD9AOVKFY5Twery27AsB+LY8W9J13NhmTYGg4G6+slEIJEJXNeDZRUhZYJKdQHrq+chTBOOY8O2XfTaXYi773laeuUahv0hoqCrLs+pTDDVmMeg1+UtBQWrAMt24Y8GSJIQBdtWDK1CmQBPqccQXiCDIEQS+TCtIhzHVFfo0aAJ15uGXbARRQlcp4goDBHFIeyChDh+9z9L2zIQRol6qOT1lhdOy7LUzcMuGOh32hl1twwZhwjjERqzN8AftgjwDZkmprrb2NY0hNFXDxW8rfFOIkSC6vQi4qCHXq+l7pFeqYRiuYrmymWm8E3peQ0Mehso1aaxsXYFtlWCMCQc10GaSIRBgFKljnJ9Bp2NK+rpIYoC5S3x27/ztORjnWm6GA7aajCJQxScIiy7hCQewvcHsAxbPfNYVgGeV4FZKCIYdAnwbUnxytUpyDiC7RXRubaOgl1EQj8EQ3jFWQTROgQKMNWTm40wimCaBsRtHzkp5+b2odfrw3ELcIpFdZu7tr4Kr1RW1RkOhnBdF3EMWLZQj0P+qA+3WIG4595n1AXl2sYlVGt7YbsGIp9PoQlGQYRavYEw9CHSFH4wUjdWt9hAHHcRRxHER489KW3bQ63RQK+1pmpPCkKYsC0LURrDENQlgldqIAl7EJaJKAzgj7oQ937y+zJNMkWDIEEchzBFCqtQRCKHsA0HhVIFo15XAZdKNXR7PUCGEMKCuPe+f5WjMELBArrdJizTg+O6CPwhisUGktiHWXCVH+I4gilMjPw+alPz8AcdiPsf+oGM/JFCHw56kIkBt+QgimLlxsDvw3UriJMR4iCB45Ux6HdQrdcgYEHc84lnZBJLRMEAbsmF5y2g111D4PdQKs8hCHqwLZePV/D9EIZlgs+V/DqQJBHEo1+PpChkz4Suu/Vo6/sSMswe+4pVE3sqwN66wJW2xNUewHHlRAKogxyIHtQAHP/o+60di3cFGF89NxlpJpqFjk5wBhWP/VMi9Yn+ZCqkzMYFo26iJh+aFTi/vpXaGEBZJ5fvB5e2cuWYBiCwZsTFPBef+5dU5jsZhS0vGAG0TgzEdHRTAHqCzlMPkj5TOXclA2A7vDdbzDEFmtdAR89PmKwIg+RTHAPko2t0AmmAfP5koVNUAJyoTUTKVFqf5wF2E3TsRB0h/6kZaOEm3cnzsRO1ypNAeTdqt2q/jJ2420DeXHlwXY1x6bUGeiCfu46uTTOu5eaBMlgeYDcLc27eOBqEYrNa26qQ979WPL+J2Jefo0T8xHOvSbvoqdddrasDLByqY+VCG41FB4NujP37p7G63odXNjFdKuLsuRZ++Za9uHjuEoRZgDj+7BvScXlLNzA7W8bl88swrAIKrgGvVEAkC0ijBLFwEXZacIo2hJFiasrD1csjiOPfe1NCWCgUHcSDLooVG2GQQEgBu2ghjVJ0rkVYOlxDs+kj8UPUpky0NwKYXg3ijqdflXy8ccu2+kLNr7/+SGJ2wQGvtemgBT/lfTDF4uEaWs1Q3ZnqMxY6qy2I275+Spp2ilKjjN5aD3OHphDHUn3h3Fj1UakCwTCE7fDmyieVFINWH0ahBtscQnz4ay/L+kIVexoOinNzOHPqHAy7iKDvozzlIA4jePUKPDtFq9lBnArsna+or6/n31mBuP+5UxJeGcN2H425GvxOFyiWcPXtNo68r45WL0BnPcDU3hoGIxNz9QRBKtDbGMF2BMQfvnJeyiRFLwIKpkRzeYiZOQftXorGnjo6K23smSlitT1Ub3AMw8Kgn6C2UEVnpQdx+zdPyX031tBpJyh6/AYrMeqPMD1Xh40UF89dw9T+OaDXxEYze/vLmwvv0vVZB+KOp16WpTqfOGz4gwAL8x4GYQoLKVavDOCUCjAtgUE3gjAdeKUUME1MV21ceteHOPbM69L2TAyuLmPq4H50VjZgV6bgOjE6zRCzB6bQWQtQLAv4vSHmFyuw6nWsX1jGsBP9/xfPl8/JbiKw8t4AUb+HylwV0SjE7L4KbEPg6qW+MlTBETC8qnIjH/1i3liSAOKBl96VV9/ZwMJSEWFaQDzyMewHWFiqY/3dVYwGEkduXkR/FMC1gea1BOW6g2g4Qq8VQXzy+bdkayPGDXsdXLqwgtmlWVx5r4f9h2q4uiJx9FAJlzciBKMAfHxqN0PsWypiGAmEIx/iY8++KeNhCK9uo7PcR2OpjtbqANVpF3ECTNcMxIaNwfo1jAIbtcUq4uFAPVPXpisQdz37muy3UswfcNFt9jB7ZD8Gay0E/QHsah2WEaG1ARhyCK/iYtiPlR6lqo21iy2IE//xrPylucXJq5U6/9naMmbKVTS80rbxjeEAzX4Xb51+CeLkqZflixfPYcbztk1qDodYfv0l/O59jyggNvbpeTxunj29EyA/6fLFn+D4h+4cA/SaTQSbgQj0xivPZynoRfx0htkrD0701y7g1ps/rOjmGeh5F985nQHowffNLajJ+QnH7rx/DKDn8ZOBrlw+m6XAHCfz4yRqMLWwiH0H3j8e1/Mo7gsv/ADiL198Xr61tqIoaoGYK+kx+n8+/yx+5TfvVAC6MXplZiarAlOYFIfi6dx1NQ4cuVXpojUimEqBDC5cPK8QOZnC5ZXXeTMdgmiByXbsg1d/+oYCyJdNU87XfbIqCkAz0GVjdG2syfJ2+qtjdlqnMQCpcUI+d+arjcPobAxAxuxnWmMjcbKOQAZ5sXTe2toaQFlZO5GTdI4UVTfNID+uy64YPPy9pyQX1srzqvaLt9ym1moGZMWmx3Ul2N9vdyDu/qvPKStHfmYU2812Zf6cx7v1c574wnP/MH4N1Oyex0z1EPipnFk9NE5FH3AsHQHu6AoOtmcygLXVbAE72cLprXcmnHx0OcDPDjlqrHAtm+MOIwwvt7cA5uYPIfzpD9Hdd2AcVS9mBwG4uHrgI2oe2xige/FHY8TwA7fCKGb0yUxH52JG1Qu9fXX85HIlY6ARdXStAxnkU9MAqqSejXNn3e0aMLJuk4v9YqZLfeMiFsNFLBeWtxiQ6m6LdXS9WCvP/m0AumwcuF5kXSGWjou3pcCFur46KieynVl0VHk1i7wmYw2ut/hCvakW6vTy4hI0Pbu+JaKOoqluyZkZS5eV/QRkWXcAsEztxpaRNCgXaG10CgS1XjmdMaCR8g4jiDZQ3o3UQzuWc668trHdSLSmdqKuCIG0mGRSvXxRWdi4aXbLSNqJnEjkPGUNQEFJW+9EFYAi/skzfy6ZC71NZLYLWMJBXFKf+ca+/DiPxdN/83vSm7i1D4dDsI+fbJPjGpTj4vuPf0bedPTGbZE6wwFqXgnqc6aBTnNDjbMv386eeTtjcOuvfwA/fuM9NVYs1bKoRYnhSKjPfGMf29Gb53H6R/+9xYAAv/YbN2Vzh/6ujHTnmfMdHD1Ug2LAFOZv2IOrK7HqJO2f15jGu8tt1Gs2Vt+9usWAnTcs1hUAwXQaitAm7T0LltKBDHisAKjBwaNH1CJ2sp07t4HDhxvbiOTHNduxiARod6JtDAjGPjbS5TE/d6SgGVwPgPQJphnsSEGLuBtAPgfNgH0abIcGugpaxNGgo3yhvTCZwoUz72yVMc/gF5VxRxXoRF1GLtZW3gHkucpk1wXQ1tV1/3lMxk7Ue0FP1k7Um4n919tQp//3tUwDvVhv4+tF3m17iy99/k5Zr9iYa2S70HE9XOu0MV2rj3H4epT9bDweBQmKjqk+xwClchElp7ANIEWCyA9gOY56l2pYFkb9rlrI1u0OIZ784selWzBAgH43wL6lGXQ7Q9RrFRVNs+oNh6hVqwpgdb2HUqWMXq+TAfDFQWOmogDKVYe/NqBWryAc7QSI4wCXLzUVAF8fi2/9xT0yCOJtAMyfEfmWlF+J+WKe55XctXOjPcDllbVNDcoFzM1UMQhCRZ0/vnS6XQXA/G3bUdTdShUyisHFbGMA2wYO7p1RAIxOsQhQdLPoWjwu4ovP/nCEguVi0OtnDAhABsydDNhI2Stm6rOxIu1OD7ZdGAM0W83NKtgmiuqnIopXVr+xDIbBWHX+HJLGsfIHAajFcnMD0SjOGOxdrI6R52fq6r1JEKdjANLmIrIgMI/fu7SKUexD/P3nj8npchH16aqiVnZcFOzs2q9dSYMVvBJkGqtv9nzDQy8ogCe+eJfcN9/gH8BkLZE7ANg9NTWFVqul3NrffC3e7rUzgMZUBYNegKlGBY5lqD8RYXRtZVbHtUz4MX+Ls5X6wyiEZxc2U6i66neV+lRN1Z7Ndh21D9jUb0obTRWd1NkIUHKsDMCzLczO1FUVmJ9uZKF3IiugAWhjtvVr17Z249Le7BVAfgPp8/xW1uLSjQT4P+XjG5XEmR+7AAAAAElFTkSuQmCC",
+			"uuid": "da05a1f4-8b7a-aaf6-2195-7ccfa8eeb23c",
+			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAACgCAYAAAAFOewUAAAAAXNSR0IArs4c6QAAEXtJREFUaEOFWluMJNdZ/k5VV1dVX6t77jM7e/cFGww8BIkgiEIICFlYgBRFCQpCIsADEU9EfiDSCiSixDyscAgQSITAQcSAnMh58IONogRfFiXx4uDrrmd3vXPrnumevlZVV3dVHfSfqr+mpneS/NKqLuec7//+7/9OdU/1iu2/+JREGqOgh6rZAB0p6Hw+aGwYzDD1Pez2xhAEsDs8UPPoJkXRLqljzTROANK9Tn+gxvr+DK2jwTHARm0Z1+/cxHKz/iMXX1g5r+ZRZAC323cyxEcunz2RmegSk/nMq806bu0fJAwIIE+b66bF+dKoZoqyZcKxDbx6a/ekBpTpRy0eeRNUSxY2GhXFOGNAIuYFOy3z/GJKlAHk2/fjFnMHSOxrb9xMSqCb3F+umSi6kwD5zPnFdJ4BnLaYJhAABdXMkRf7xTe27jUSZebFrPZpi8mlz736vWMAciEv5gXUqnnaebEzBuQDdhjRzmcm0Hl3smMzDfLWJIdRZmaTX0xs3t3vKAs/uLF4bKQX335dqf3jFhMA70Q6f3u3A/Hmn/2OpFrIYQRC4QUBSqapjiuNZHOpVs+N0z1x+8n/lKZuAjEQRTNo0DBxJyg6FuLJDKWVJqb9Mcgs1k+dx+DFt+DUHXiOBvQ8iN2/eVYKU0fszlBaX8Bw4iJq9WEv1RFPZzA1CzN/gkq5Bk96CHoe/JGP6nId9uYSRPffvyMLF9YQXb+Dg519lBZrKDolhD0PxaUq0Kwi3GrDatYgZyHC9QZ6195EddlB/ew6xN0vfkMatgl3rwerVoLUBayVBQy2dlB2qhgEY9gzDZACZr2M2J/BWmvAP+jBDzyIw6dekH63D7tagz8aw7Jt6BUL054La70B33XhbndQPr8MceTDHYyhNy1oRxEmIoDY+dfnpTjyAMdG06rjcG8XlfVlRGsOorfuYnTQx/JD5xH4E+z8702sPHwOomQDvTH8iQfx/ce/JOuVOvSyhvLGEtpv3kHZsBELCd3UEAUxCqaO+oPnYGoGDt/cQvXcKmZjF8PtI4itz35NagWBcrOOWAdkGGOw08XSQ+dgXl6Hv3eI2cjFdO8IgTdFpVmDkED13BpGt/cgDr/6X9Ld6cK5uI5Jd4DC/WvwXr+D6uYK4pU6hi+/idVf/Tnsffu7KNtlTIaeSqIXCojCGcTtL39TmtAQdlzodRsz14eQAsZqHcFBH8VyCdO+q4zmnFtFEE4Qdj0UFkowRAFi9wvPSqNs4vaNW7j00H0Y9nowfB3G2RrCgxEQSBQsA2EUAkWB4koTlVDHwB8i9qcQO1/6prQrFWC9gcH1d1DdXEfk+9AvrsF/dQuRP4W9VEMUTFE2K/DoQ0sTCLYPETs2xM5ffV0KW8NsOoVzYQPDrT0UmmUUpMDQG6JYqcIyTUgZw2sdofrTl6H1PYz2DmCSlW//5dOyfv86OjfuIioCRqTBrNrQChoqlTp6222UyhUUHl7H5K1t+EcuZuEMznITw24fovv0t2UkBCb7HWhlE7P2CPb5BfjbPbUvyCyaH2G2aMOONFiLDrzZFJppQNvvQ2x97muyutZEMHQRRFM09Dr6wz60WgHNn3kQwZ19GLKA4VEXpUcuIry5D/dghPJGHUd3DyCufPyKdKpO8vAc9gEBOOX02usDIeDUctfUThoXQGvYgrj6B1dlq9sCNMApJQN9WhgBTiW9dvuJD+hafTfog54wlmFBXP2jq7J11IJjO+pfNoGYWLlrAqw7amF/1Ec/6MPSrKQEQlKTdSjKKuhcPfSg2KhnWiF7PKI/7qM9bENc+egVaZlWVvfxlHQxf4PScuBURtBHu9eGuPrJq7I1aKn6mbLKzgvjFJIA0ui7faVDosEfphoQQCqaWkwfkUyZSiDQFKw/6YNArAJrUEg1oHopCOC0c2JBIBoUQLtPGrCIRSfJyAsJiASlay6Jy0lb2R6QBuSDXkvR5zZyFqZMGVUQgJ4YjspINPj9FIA0SB2ZtY/LYfXmNdDzGqT2VVnSOjMv5IHyGlAJVz52RVpFK+kA1Uz1Ut0kJP07pY3KrV4qYtZG00msGkLVR8Gg6pqsbSZuJQ+QDmTARMTDdDMRizgF4F3Im4sAaa+kLVSbqWhBPP6Rx9VeIL8PJsk38bpdVxkHXnpt1VXmwXigAOp0DWDgDyD++CszKYpJnyzr2ASTiYScJgLYNR3rVWDDEdjtS+yNABqnUADqJAfCgwxA47/0cOGexacCZDsmZcRMmAVnJ3BKKj71VCT5go9UClGmoAX+MFKTLy4J3Do8Li0DUD7J1fu+zeNaaYwBCJgZ0WK6Fn/6H7HM36QsFHnBCIB1okRUDocC4AlcJw8SfSplazcBoLi0kSymMQWa14Cz5yfMd4SS5EvMAPLZGZ2AGCBfP7HgEhUATWQTEWVSmq/zAKcJmjmRM+SPzICFm3cnXWdOZJXngfJuZLeyXzInnjaQN1cenLuRtZ414IF87ZydTZP1Mj1RBssDnGZhmps3DoOQ2NStE13I+58Vz28iupefo0S874lrMpYSuhCIogjQ0me4jAFBX7IlIIQ6Ck2DjGNoPIecePmJa5I/cKSU0IQAASrhhFDPV3VNYwRAGy8mayd7RgHQQkhC1tVkWkiZUhQ1ptNYuoznKIBLn3spewWiKFMQTV3PPiLjFIypMwsCFZc+/0rySKOsUQRBC4miqj/VYa5/NJdSRcRWAWSCpWVwjSQeRa48pVFMJWmI4ohKeFnmVVXz6V8qJAOQaMcixklHiAG3UZXAAqaqU/vuKS0PpEpIGSTCkM7JtwvKdtyRpG2cNWGVtvqEiKlJFBiZijRQMqRM4pQ6H5lBqpRSXjkyNRT3V4FRkANTQXnsRBu5W9mnO5VEWfTkQcoa8TmBJQA0UaHP25XY577fcWdonp669v4nrkmiTOKJdDIZSWhkKDKSOLE/VCX5/UJdIHV503A7j5XOqlVgNJ54K1J7J3Uib1lSWT9pojQj63NiNxLgbzz3mjTsEsIwRm/PxepFB63bfSysmXCHIc6ebaJ9OEapoqNZtnFjq4eHHtnAna1tCL0I8aFn/k+aFj0DNCwtVbBzax9aoYiipaFULmImi4hnEUJhYTrowbQNCC1Go1HC3o4P8aGvvy4hCijaJkJ3CLtqYBpEyR+fdgHxLMbgaIbNS3V0OhNEkynqDR39bgC9VIf4wL99T9K+tiqG6uYsmGHiSyytmpj4QOz2MIltBG6MtUt19DpTtXmdxQIG7R7E+79yXepGjPJCBaODEZYvNhCGEkYB6LYnqNag/ug26FWhVkTBiOH2xtCKdRi6B/HzX35FOqs1rC+YsJeX8db1LWiGjWA8QaVhIpzOUHKqKBkxep0BwlhgY6UKaDpuvduC+O3nrkuUKvD6Yyws1zEZDAG7jL2bfVx+0EFvFGBwGKCxUYfr61h2IgSxwKjrwzAFxO9euyVlFGM0A4q6RGffw+Kyif4oxsK6g0Grj/VFG+2+h9mUzFOAO45QX61h0BpB/MI/X5dn7qtj0I9gl5Lnvz/20Vx2YCDGna0jNM4uA6MOuh165AFaQYfQBJwlE+IDX31F0tsavWhg4gZYXSnBncYoIEZ714VZLkIvCLjDGYRuolSOAV1Hs2Zg+70JxAef/oE0SjrcvX00LpzFoNWFUW3AMkMMOlMsnW9gcBDArghMRh5W1qooOA4Ob+/DG8wgPvnKlhxGAq27LmbjEarLNcz8KZbOVGFoAnvbY2WooimglWrKjUZRQ0hfNKMA4iMvvyf33u1iddPGNC4i9CfwxgFWNx0cvteG70pc/sk1jP0AlgF0jiJUHBMzz8eoN4P4zRfelr1uiHMbJrZvt7C0uYTduyOcvVjHXkviJy6WsdOdIfAD2DbQ70xxZtOGNxOY+hOIX37mdRl6U5QcA4P9MRY2HfTaLmpNC2EENOsaQs2Ae3gEPzBQX6sh9Fz1bKg3qxAffuY1Oe7FWDlvYdgZYenyWbgHPQRjF0bNQUGbodcFNOmhVLXgjUOlR7lm4OBOD+JPXvqn7MP1sDvC0kLyLTt/nv9opPsevd3yWji8M0oA6CYHDwaj5F1y9WztnjG6QePdG28cA1DmW9d31QICidpj6CsVlExNXdNx2tvDxuUH1DyKEwCju0MMu/vY+NkH1CBNLjbW1Tmz4sw0b+l8Fa2XthIG7+0NVE0UYWn1RFZeTPeJlVlNfmOgyAB2330nW0xAnDkvHjEiEBrnYwZAIvIEqvW0yDMhEBKx94PXjkVkoehIwUD5+ikzBZdygkG+jXzOIPPs6PqEBmyOfNZ8+/LgdJ86RmLuff+9k13IdyBfRr6VVDv5g3TIALgL3MZ8J1gD6gxlpqDsdH3nhVcgPvbskzLvMO5zng27koDZicSi8/xLCQAjs8OIJmch8Pw1O7bx0H0JADsx3x7eSJSFsnPwPuHrg//+n4QB1ZIPbRIitgqgYz7oHgWP07n4+JOPqefB2O+hWU9+X5xOk2sKu3i8nfNz6HNyOpkmAEWreI97aZBC1yMFOB+93gFW1s5A/N7fPyYJDfE0y1yxEyaUUf0VA4DuFYvH7PhaPPb5X5TNxoqiQwtmkxkMy1DlUGYGyDOgeQRAx6yEo15bLaZoNJaz+YNxR00myjzGAJmIeWq8kssgDajE9v6OYsb3eV7CYK62PF0FkHaG75/K4GhwXBeVwmX8MA1YI/HRq48qBgyQrzVp4/HrDmagWriyrERWANyyfH1cFgPQItJgvqXi0c++X+b7Pi8SAbArT/NDBsAZ5x3HDNgjNM70lQ8+8cVHJVtVWTp1JE0k2ouL9N0g2Rd5k2V7gQDa7cQk+Rp5ETGY10ZN5s30ib/7LZk3CZVywgeGPV9Vdq12o2rjHHXuCh3rlcV7AE4YaX/neTmiN5q09ytV+OMRZu4ItZV1df7D7g3be2qOeOPFv5VGOflSQQvpnI4UNOHo9g0UShU0z98HSrRw5kHsXP8W7KU1VJdWIbZvfkNSJv9wX02k4Mnz3OcTUDJx4/pTkmhSEC1mQNmZJo9xWQxE97MSiFp35+1T62cd8mWyZopBHpHZ0AQWlFjRfWaYB1IMuGYWb/WB96H1zndPCBp6YyXcvNj3MMizmRdNubVcVepTR2g80yBfJ9OlrNQZFpRLyZcm2Ej5zEyTM1KLif68VqSJKoEn5F2Xz5Z3KfuFx1UJnGnezjyJfcDGYq8oI7GV2f9sHq6TOlQ0HXj93aytnJAYZ1Zm+nQk/1PN+Xv5jXXCB2xlnlByNlQ2NtI8CGnQvHC/YqOszJspP3F+8bz6eTbiC5/+FelUDSwvJD86mFYJR4M+mvRzSRrBxFP3KejcDyLYpq6OGUC5YqNsFk8AxIgwmwQomCZ0oUMrFOCPh2qh6szQg/jHz/yatIoaCGA8DHBmcxHDgQenXlXZmNXI81Cv1RRA+3CEcrWC0WiQANCLg4XFqgKo1Oh3cB11p5r9DymizwBhGGCH/jtBtQJdxBD/8ue/LoMgPAFA9dMC+tWE/iQuaIa6rpYSHSi6fRc7rYNUg0oRy4s1uMFUUS8UTAyGQwVA9RuGqahb1eS/UdBiigzAMIALG4sKgLKTWARgW0l2Fo8W0Q8hY89HsWDBHY0TBgRADKh2YkBBlEt2oj4FdaQ/GMEwihlAp9dJu2DosEsWCjqJV1G/s7tekKluV2qIw1D5gwBIi/1OFzM/TBhsrNUy5JVFR703CcI4AyDatIhYEDCd391uww8nEH/96Q/KZsWG06wpahXTQtFI3pexK8lgxVIZMg7VX/b0hoe8oAD+4TMflmdWFtRPyyoieQ8A3W406KteT7l1nP5MRj9gK4CFRhXuKEBjoQqzkLw/p+xsZeqOVdAxCSNIaSj16X8AlIxiWkLNUu9inUZd9Z7CsEy1DyhIxE63o7ITdQoCKJuFBKBkFLC06KguUH0cxIJ3InWAAcjGFIdHR8e7cXMj+dDIbyC+zm9lFpfcSAD/D+DKXk3yYAjVAAAAAElFTkSuQmCC",
 			"mode": "bitmap"
 		},
 		{
-			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\upper_eye\\colorful_sclera.png",
-			"name": "colorful_sclera",
+			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.2-pre1\\1.20.2-pre1\\assets\\minecraft\\textures\\block\\redstone_block.png",
+			"name": "redstone_block.png",
 			"folder": "",
 			"namespace": "",
 			"id": "7",
 			"width": 16,
-			"height": 160,
+			"height": 16,
 			"uv_width": 16,
 			"uv_height": 16,
 			"particle": false,
@@ -1449,14 +1438,13 @@
 			"visible": true,
 			"internal": false,
 			"saved": true,
-			"uuid": "da05a1f4-8b7a-aaf6-2195-7ccfa8eeb23c",
-			"relative_path": "../../../../../textures/custom/upper_eye/colorful_sclera.png",
-			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAACgCAYAAAAFOewUAAAAAXNSR0IArs4c6QAAEXtJREFUaEOFWluMJNdZ/k5VV1dVX6t77jM7e/cFGww8BIkgiEIICFlYgBRFCQpCIsADEU9EfiDSCiSixDyscAgQSITAQcSAnMh58IONogRfFiXx4uDrrmd3vXPrnumevlZVV3dVHfSfqr+mpneS/NKqLuec7//+7/9OdU/1iu2/+JREGqOgh6rZAB0p6Hw+aGwYzDD1Pez2xhAEsDs8UPPoJkXRLqljzTROANK9Tn+gxvr+DK2jwTHARm0Z1+/cxHKz/iMXX1g5r+ZRZAC323cyxEcunz2RmegSk/nMq806bu0fJAwIIE+b66bF+dKoZoqyZcKxDbx6a/ekBpTpRy0eeRNUSxY2GhXFOGNAIuYFOy3z/GJKlAHk2/fjFnMHSOxrb9xMSqCb3F+umSi6kwD5zPnFdJ4BnLaYJhAABdXMkRf7xTe27jUSZebFrPZpi8mlz736vWMAciEv5gXUqnnaebEzBuQDdhjRzmcm0Hl3smMzDfLWJIdRZmaTX0xs3t3vKAs/uLF4bKQX335dqf3jFhMA70Q6f3u3A/Hmn/2OpFrIYQRC4QUBSqapjiuNZHOpVs+N0z1x+8n/lKZuAjEQRTNo0DBxJyg6FuLJDKWVJqb9Mcgs1k+dx+DFt+DUHXiOBvQ8iN2/eVYKU0fszlBaX8Bw4iJq9WEv1RFPZzA1CzN/gkq5Bk96CHoe/JGP6nId9uYSRPffvyMLF9YQXb+Dg519lBZrKDolhD0PxaUq0Kwi3GrDatYgZyHC9QZ6195EddlB/ew6xN0vfkMatgl3rwerVoLUBayVBQy2dlB2qhgEY9gzDZACZr2M2J/BWmvAP+jBDzyIw6dekH63D7tagz8aw7Jt6BUL054La70B33XhbndQPr8MceTDHYyhNy1oRxEmIoDY+dfnpTjyAMdG06rjcG8XlfVlRGsOorfuYnTQx/JD5xH4E+z8702sPHwOomQDvTH8iQfx/ce/JOuVOvSyhvLGEtpv3kHZsBELCd3UEAUxCqaO+oPnYGoGDt/cQvXcKmZjF8PtI4itz35NagWBcrOOWAdkGGOw08XSQ+dgXl6Hv3eI2cjFdO8IgTdFpVmDkED13BpGt/cgDr/6X9Ld6cK5uI5Jd4DC/WvwXr+D6uYK4pU6hi+/idVf/Tnsffu7KNtlTIaeSqIXCojCGcTtL39TmtAQdlzodRsz14eQAsZqHcFBH8VyCdO+q4zmnFtFEE4Qdj0UFkowRAFi9wvPSqNs4vaNW7j00H0Y9nowfB3G2RrCgxEQSBQsA2EUAkWB4koTlVDHwB8i9qcQO1/6prQrFWC9gcH1d1DdXEfk+9AvrsF/dQuRP4W9VEMUTFE2K/DoQ0sTCLYPETs2xM5ffV0KW8NsOoVzYQPDrT0UmmUUpMDQG6JYqcIyTUgZw2sdofrTl6H1PYz2DmCSlW//5dOyfv86OjfuIioCRqTBrNrQChoqlTp6222UyhUUHl7H5K1t+EcuZuEMznITw24fovv0t2UkBCb7HWhlE7P2CPb5BfjbPbUvyCyaH2G2aMOONFiLDrzZFJppQNvvQ2x97muyutZEMHQRRFM09Dr6wz60WgHNn3kQwZ19GLKA4VEXpUcuIry5D/dghPJGHUd3DyCufPyKdKpO8vAc9gEBOOX02usDIeDUctfUThoXQGvYgrj6B1dlq9sCNMApJQN9WhgBTiW9dvuJD+hafTfog54wlmFBXP2jq7J11IJjO+pfNoGYWLlrAqw7amF/1Ec/6MPSrKQEQlKTdSjKKuhcPfSg2KhnWiF7PKI/7qM9bENc+egVaZlWVvfxlHQxf4PScuBURtBHu9eGuPrJq7I1aKn6mbLKzgvjFJIA0ui7faVDosEfphoQQCqaWkwfkUyZSiDQFKw/6YNArAJrUEg1oHopCOC0c2JBIBoUQLtPGrCIRSfJyAsJiASlay6Jy0lb2R6QBuSDXkvR5zZyFqZMGVUQgJ4YjspINPj9FIA0SB2ZtY/LYfXmNdDzGqT2VVnSOjMv5IHyGlAJVz52RVpFK+kA1Uz1Ut0kJP07pY3KrV4qYtZG00msGkLVR8Gg6pqsbSZuJQ+QDmTARMTDdDMRizgF4F3Im4sAaa+kLVSbqWhBPP6Rx9VeIL8PJsk38bpdVxkHXnpt1VXmwXigAOp0DWDgDyD++CszKYpJnyzr2ASTiYScJgLYNR3rVWDDEdjtS+yNABqnUADqJAfCgwxA47/0cOGexacCZDsmZcRMmAVnJ3BKKj71VCT5go9UClGmoAX+MFKTLy4J3Do8Li0DUD7J1fu+zeNaaYwBCJgZ0WK6Fn/6H7HM36QsFHnBCIB1okRUDocC4AlcJw8SfSplazcBoLi0kSymMQWa14Cz5yfMd4SS5EvMAPLZGZ2AGCBfP7HgEhUATWQTEWVSmq/zAKcJmjmRM+SPzICFm3cnXWdOZJXngfJuZLeyXzInnjaQN1cenLuRtZ414IF87ZydTZP1Mj1RBssDnGZhmps3DoOQ2NStE13I+58Vz28iupefo0S874lrMpYSuhCIogjQ0me4jAFBX7IlIIQ6Ck2DjGNoPIecePmJa5I/cKSU0IQAASrhhFDPV3VNYwRAGy8mayd7RgHQQkhC1tVkWkiZUhQ1ptNYuoznKIBLn3spewWiKFMQTV3PPiLjFIypMwsCFZc+/0rySKOsUQRBC4miqj/VYa5/NJdSRcRWAWSCpWVwjSQeRa48pVFMJWmI4ohKeFnmVVXz6V8qJAOQaMcixklHiAG3UZXAAqaqU/vuKS0PpEpIGSTCkM7JtwvKdtyRpG2cNWGVtvqEiKlJFBiZijRQMqRM4pQ6H5lBqpRSXjkyNRT3V4FRkANTQXnsRBu5W9mnO5VEWfTkQcoa8TmBJQA0UaHP25XY577fcWdonp669v4nrkmiTOKJdDIZSWhkKDKSOLE/VCX5/UJdIHV503A7j5XOqlVgNJ54K1J7J3Uib1lSWT9pojQj63NiNxLgbzz3mjTsEsIwRm/PxepFB63bfSysmXCHIc6ebaJ9OEapoqNZtnFjq4eHHtnAna1tCL0I8aFn/k+aFj0DNCwtVbBzax9aoYiipaFULmImi4hnEUJhYTrowbQNCC1Go1HC3o4P8aGvvy4hCijaJkJ3CLtqYBpEyR+fdgHxLMbgaIbNS3V0OhNEkynqDR39bgC9VIf4wL99T9K+tiqG6uYsmGHiSyytmpj4QOz2MIltBG6MtUt19DpTtXmdxQIG7R7E+79yXepGjPJCBaODEZYvNhCGEkYB6LYnqNag/ug26FWhVkTBiOH2xtCKdRi6B/HzX35FOqs1rC+YsJeX8db1LWiGjWA8QaVhIpzOUHKqKBkxep0BwlhgY6UKaDpuvduC+O3nrkuUKvD6Yyws1zEZDAG7jL2bfVx+0EFvFGBwGKCxUYfr61h2IgSxwKjrwzAFxO9euyVlFGM0A4q6RGffw+Kyif4oxsK6g0Grj/VFG+2+h9mUzFOAO45QX61h0BpB/MI/X5dn7qtj0I9gl5Lnvz/20Vx2YCDGna0jNM4uA6MOuh165AFaQYfQBJwlE+IDX31F0tsavWhg4gZYXSnBncYoIEZ714VZLkIvCLjDGYRuolSOAV1Hs2Zg+70JxAef/oE0SjrcvX00LpzFoNWFUW3AMkMMOlMsnW9gcBDArghMRh5W1qooOA4Ob+/DG8wgPvnKlhxGAq27LmbjEarLNcz8KZbOVGFoAnvbY2WooimglWrKjUZRQ0hfNKMA4iMvvyf33u1iddPGNC4i9CfwxgFWNx0cvteG70pc/sk1jP0AlgF0jiJUHBMzz8eoN4P4zRfelr1uiHMbJrZvt7C0uYTduyOcvVjHXkviJy6WsdOdIfAD2DbQ70xxZtOGNxOY+hOIX37mdRl6U5QcA4P9MRY2HfTaLmpNC2EENOsaQs2Ae3gEPzBQX6sh9Fz1bKg3qxAffuY1Oe7FWDlvYdgZYenyWbgHPQRjF0bNQUGbodcFNOmhVLXgjUOlR7lm4OBOD+JPXvqn7MP1sDvC0kLyLTt/nv9opPsevd3yWji8M0oA6CYHDwaj5F1y9WztnjG6QePdG28cA1DmW9d31QICidpj6CsVlExNXdNx2tvDxuUH1DyKEwCju0MMu/vY+NkH1CBNLjbW1Tmz4sw0b+l8Fa2XthIG7+0NVE0UYWn1RFZeTPeJlVlNfmOgyAB2330nW0xAnDkvHjEiEBrnYwZAIvIEqvW0yDMhEBKx94PXjkVkoehIwUD5+ikzBZdygkG+jXzOIPPs6PqEBmyOfNZ8+/LgdJ86RmLuff+9k13IdyBfRr6VVDv5g3TIALgL3MZ8J1gD6gxlpqDsdH3nhVcgPvbskzLvMO5zng27koDZicSi8/xLCQAjs8OIJmch8Pw1O7bx0H0JADsx3x7eSJSFsnPwPuHrg//+n4QB1ZIPbRIitgqgYz7oHgWP07n4+JOPqefB2O+hWU9+X5xOk2sKu3i8nfNz6HNyOpkmAEWreI97aZBC1yMFOB+93gFW1s5A/N7fPyYJDfE0y1yxEyaUUf0VA4DuFYvH7PhaPPb5X5TNxoqiQwtmkxkMy1DlUGYGyDOgeQRAx6yEo15bLaZoNJaz+YNxR00myjzGAJmIeWq8kssgDajE9v6OYsb3eV7CYK62PF0FkHaG75/K4GhwXBeVwmX8MA1YI/HRq48qBgyQrzVp4/HrDmagWriyrERWANyyfH1cFgPQItJgvqXi0c++X+b7Pi8SAbArT/NDBsAZ5x3HDNgjNM70lQ8+8cVHJVtVWTp1JE0k2ouL9N0g2Rd5k2V7gQDa7cQk+Rp5ETGY10ZN5s30ib/7LZk3CZVywgeGPV9Vdq12o2rjHHXuCh3rlcV7AE4YaX/neTmiN5q09ytV+OMRZu4ItZV1df7D7g3be2qOeOPFv5VGOflSQQvpnI4UNOHo9g0UShU0z98HSrRw5kHsXP8W7KU1VJdWIbZvfkNSJv9wX02k4Mnz3OcTUDJx4/pTkmhSEC1mQNmZJo9xWQxE97MSiFp35+1T62cd8mWyZopBHpHZ0AQWlFjRfWaYB1IMuGYWb/WB96H1zndPCBp6YyXcvNj3MMizmRdNubVcVepTR2g80yBfJ9OlrNQZFpRLyZcm2Ej5zEyTM1KLif68VqSJKoEn5F2Xz5Z3KfuFx1UJnGnezjyJfcDGYq8oI7GV2f9sHq6TOlQ0HXj93aytnJAYZ1Zm+nQk/1PN+Xv5jXXCB2xlnlByNlQ2NtI8CGnQvHC/YqOszJspP3F+8bz6eTbiC5/+FelUDSwvJD86mFYJR4M+mvRzSRrBxFP3KejcDyLYpq6OGUC5YqNsFk8AxIgwmwQomCZ0oUMrFOCPh2qh6szQg/jHz/yatIoaCGA8DHBmcxHDgQenXlXZmNXI81Cv1RRA+3CEcrWC0WiQANCLg4XFqgKo1Oh3cB11p5r9DymizwBhGGCH/jtBtQJdxBD/8ue/LoMgPAFA9dMC+tWE/iQuaIa6rpYSHSi6fRc7rYNUg0oRy4s1uMFUUS8UTAyGQwVA9RuGqahb1eS/UdBiigzAMIALG4sKgLKTWARgW0l2Fo8W0Q8hY89HsWDBHY0TBgRADKh2YkBBlEt2oj4FdaQ/GMEwihlAp9dJu2DosEsWCjqJV1G/s7tekKluV2qIw1D5gwBIi/1OFzM/TBhsrNUy5JVFR703CcI4AyDatIhYEDCd391uww8nEH/96Q/KZsWG06wpahXTQtFI3pexK8lgxVIZMg7VX/b0hoe8oAD+4TMflmdWFtRPyyoieQ8A3W406KteT7l1nP5MRj9gK4CFRhXuKEBjoQqzkLw/p+xsZeqOVdAxCSNIaSj16X8AlIxiWkLNUu9inUZd9Z7CsEy1DyhIxE63o7ITdQoCKJuFBKBkFLC06KguUH0cxIJ3InWAAcjGFIdHR8e7cXMj+dDIbyC+zm9lFpfcSAD/D+DKXk3yYAjVAAAAAElFTkSuQmCC",
+			"uuid": "9d53c2b6-fe34-b6b6-a01a-0b488aa8528b",
+			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAQBJREFUOE+lkyESwjAQRbcziIgKRA0OJJIrILkO5+hVkEiugKzEgalAVFQwA/Ob/GS7mXaGaU3SJvv69+9u8dy6ryx4CgCaANiLCPevPlE3zu/1Od8zwC0E3rteDmWIVAoBAxwrgCMAD5rOUx4Btguc9coJwSMALkM6AO9PCkYggzTkqIRFBQzmX6d8PVdOkGaWwrX1OUPBFIQqBgNLlzwAUUufqyrTwh2kMqRA5yELBv6tgAaCeFEV0Clp+TA288BWgGnAtLr1lbHy8S3rA1tG2wvsj1OlTGQK/Csh1kxI1080kY0EA3EJB7YybOvZVuaAEIiVQ8WB0griLCyYZvkBEBqf4WyNTFoAAAAASUVORK5CYII=",
 			"mode": "bitmap"
 		},
 		{
-			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.2-pre1\\1.20.2-pre1\\assets\\minecraft\\textures\\block\\redstone_block.png",
-			"name": "redstone_block",
+			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\upper_eye\\bright_coal_block.png",
+			"name": "bright_coal_block.png",
 			"folder": "",
 			"namespace": "",
 			"id": "8",
@@ -1477,14 +1465,13 @@
 			"visible": true,
 			"internal": false,
 			"saved": true,
-			"uuid": "9d53c2b6-fe34-b6b6-a01a-0b488aa8528b",
-			"relative_path": "C:/Users/afro/AppData/Roaming/.minecraft/versions/1.20.2-pre1/1.20.2-pre1/assets/minecraft/textures/block/redstone_block.png",
-			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAQBJREFUOE+lkyESwjAQRbcziIgKRA0OJJIrILkO5+hVkEiugKzEgalAVFQwA/Ob/GS7mXaGaU3SJvv69+9u8dy6ryx4CgCaANiLCPevPlE3zu/1Od8zwC0E3rteDmWIVAoBAxwrgCMAD5rOUx4Btguc9coJwSMALkM6AO9PCkYggzTkqIRFBQzmX6d8PVdOkGaWwrX1OUPBFIQqBgNLlzwAUUufqyrTwh2kMqRA5yELBv6tgAaCeFEV0Clp+TA288BWgGnAtLr1lbHy8S3rA1tG2wvsj1OlTGQK/Csh1kxI1080kY0EA3EJB7YybOvZVuaAEIiVQ8WB0griLCyYZvkBEBqf4WyNTFoAAAAASUVORK5CYII=",
+			"uuid": "3728880c-0deb-e14b-f607-5b73a416df01",
+			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAQtJREFUOE+FUzEOgzAQSzbIBKUL/QgjIyv8/wtFYgpsrXySI+dEVSQUuNw5Z58Tt3X9hBBCPk8s4bqu0DSNfR/HYWvXdWUP+3iQgzcuy2IAWowkJhKAMRamtrUaA/AFTNIueAi74X+c59kAtK3nMIScc6HFZFDydOI0TUbBt0ZNSI2HAEA7NgqKzNN8ocaVonWAwKPvq0kQgN3pqmAGoMJ4tZEMxVNKlS7MKwDkSB+gK47qlx42Ri8iAVCs5iKl1zhanCYrPsCJ6sI7EXWE1CTCykAkJ45JRdOx6QTQZaGglsU3pqLCKTXsk14FoGZC8XvfqwvldQHorROVkrqU86+ciLvA66sJjP0T9gvOIwMYgD0psQAAAABJRU5ErkJggg==",
 			"mode": "bitmap"
 		},
 		{
-			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\upper_eye\\bright_coal_block.png",
-			"name": "bright_coal_block",
+			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\upper_eye\\bright_light_gray_concrete.png",
+			"name": "bright_light_gray_concrete.png",
 			"folder": "",
 			"namespace": "",
 			"id": "9",
@@ -1505,14 +1492,13 @@
 			"visible": true,
 			"internal": false,
 			"saved": true,
-			"uuid": "3728880c-0deb-e14b-f607-5b73a416df01",
-			"relative_path": "../../../../../textures/custom/upper_eye/bright_coal_block.png",
-			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAQtJREFUOE+FUzEOgzAQSzbIBKUL/QgjIyv8/wtFYgpsrXySI+dEVSQUuNw5Z58Tt3X9hBBCPk8s4bqu0DSNfR/HYWvXdWUP+3iQgzcuy2IAWowkJhKAMRamtrUaA/AFTNIueAi74X+c59kAtK3nMIScc6HFZFDydOI0TUbBt0ZNSI2HAEA7NgqKzNN8ocaVonWAwKPvq0kQgN3pqmAGoMJ4tZEMxVNKlS7MKwDkSB+gK47qlx42Ri8iAVCs5iKl1zhanCYrPsCJ6sI7EXWE1CTCykAkJ45JRdOx6QTQZaGglsU3pqLCKTXsk14FoGZC8XvfqwvldQHorROVkrqU86+ciLvA66sJjP0T9gvOIwMYgD0psQAAAABJRU5ErkJggg==",
+			"uuid": "744e1bb5-484c-f9d8-f20c-48e9c282e200",
+			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAANxJREFUOE91k2sOwjAMg9fd/xjAz20nbJEjvsiyChJipKnjRzae57PWWoc++j3Ps5+9Nuc8xhj11bP6qiYADnVBDQACkHWGVP26Xiun7oCYnCyKgSbmZP3fMXAJde++3wXQmjYXC+nnEeyotQcCEJDrh0U3hz8lRwygRWNOyToplASPMc1DmseMV7ArBv/iw3Gde9T0V00xUkjnScc9cENrgCTkBI80KWM0pvci+aqi2TMnxtyZluDOIyVBc186Rj/whUoPti+XTPSF4ZJrd0kppSTkxmX+7jzmIfkLQ/QUSe1QHnAAAAAASUVORK5CYII=",
 			"mode": "bitmap"
 		},
 		{
-			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\upper_eye\\bright_light_gray_concrete.png",
-			"name": "bright_light_gray_concrete",
+			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\upper_eye\\bright_quartz_block_side.png",
+			"name": "bright_quartz_block_side.png",
 			"folder": "",
 			"namespace": "",
 			"id": "10",
@@ -1533,40 +1519,55 @@
 			"visible": true,
 			"internal": false,
 			"saved": true,
-			"uuid": "744e1bb5-484c-f9d8-f20c-48e9c282e200",
-			"relative_path": "../../../../../textures/custom/upper_eye/bright_light_gray_concrete.png",
-			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAANxJREFUOE91k2sOwjAMg9fd/xjAz20nbJEjvsiyChJipKnjRzae57PWWoc++j3Ps5+9Nuc8xhj11bP6qiYADnVBDQACkHWGVP26Xiun7oCYnCyKgSbmZP3fMXAJde++3wXQmjYXC+nnEeyotQcCEJDrh0U3hz8lRwygRWNOyToplASPMc1DmseMV7ArBv/iw3Gde9T0V00xUkjnScc9cENrgCTkBI80KWM0pvci+aqi2TMnxtyZluDOIyVBc186Rj/whUoPti+XTPSF4ZJrd0kppSTkxmX+7jzmIfkLQ/QUSe1QHnAAAAAASUVORK5CYII=",
-			"mode": "bitmap"
-		},
-		{
-			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\upper_eye\\bright_quartz_block_side.png",
-			"name": "bright_quartz_block_side",
-			"folder": "",
-			"namespace": "",
-			"id": "11",
-			"width": 16,
-			"height": 16,
-			"uv_width": 16,
-			"uv_height": 16,
-			"particle": false,
-			"use_as_default": false,
-			"layers_enabled": false,
-			"sync_to_project": "",
-			"render_mode": "default",
-			"render_sides": "auto",
-			"frame_time": 1,
-			"frame_order_type": "loop",
-			"frame_order": "",
-			"frame_interpolate": false,
-			"visible": true,
-			"internal": false,
-			"saved": true,
 			"uuid": "8f35888f-5bd0-8dbc-068d-6a98237669e6",
-			"relative_path": "../../../../../textures/custom/upper_eye/bright_quartz_block_side.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAADpJREFUOE9j/P///38GCgDjABvwj4FCF1BsAAOlLqDYAIq9MAwMGA1EUCZGygv/kDI1E54MjqyOgQEAmzdKvbnxcRMAAAAASUVORK5CYII=",
 			"mode": "bitmap"
 		}
 	],
+	"variants": {
+		"default": {
+			"display_name": "default",
+			"name": "default",
+			"uuid": "6fde0b59-c952-3d58-4087-1bfa481a613d",
+			"texture_map": {},
+			"excluded_bones": []
+		},
+		"list": [
+			{
+				"display_name": "bright",
+				"name": "bright",
+				"uuid": "e5853047-f931-6202-7fd6-db756e2fc46b",
+				"texture_map": {
+					"43c7499b-810c-e305-aa49-1e7c13c77d34": "8f35888f-5bd0-8dbc-068d-6a98237669e6",
+					"aff1612c-e069-f3fa-76b8-d53c474570a6": "744e1bb5-484c-f9d8-f20c-48e9c282e200",
+					"91f4647e-d482-ceca-1b5c-12a72e28cad1": "3728880c-0deb-e14b-f607-5b73a416df01"
+				},
+				"excluded_bones": []
+			},
+			{
+				"display_name": "colorful",
+				"name": "colorful",
+				"uuid": "03d99a04-118c-54c2-dc76-451ce553a312",
+				"texture_map": {
+					"91f4647e-d482-ceca-1b5c-12a72e28cad1": "0cf74b39-3ccc-8b65-0714-26407f430c46",
+					"43c7499b-810c-e305-aa49-1e7c13c77d34": "da05a1f4-8b7a-aaf6-2195-7ccfa8eeb23c",
+					"aff1612c-e069-f3fa-76b8-d53c474570a6": "4f855b2b-3aa9-0dbd-36dd-c1eca8045e2e"
+				},
+				"excluded_bones": []
+			},
+			{
+				"display_name": "dark",
+				"name": "dark",
+				"uuid": "4d555fae-ccfd-1673-5fc7-b92e2af271bc",
+				"texture_map": {
+					"43c7499b-810c-e305-aa49-1e7c13c77d34": "91f4647e-d482-ceca-1b5c-12a72e28cad1",
+					"aff1612c-e069-f3fa-76b8-d53c474570a6": "91f4647e-d482-ceca-1b5c-12a72e28cad1",
+					"91f4647e-d482-ceca-1b5c-12a72e28cad1": "9d53c2b6-fe34-b6b6-a01a-0b488aa8528b"
+				},
+				"excluded_bones": []
+			}
+		]
+	},
 	"animations": [
 		{
 			"uuid": "64924b82-61bb-82ea-08a9-4ca50fb9d0e3",
@@ -1575,13 +1576,14 @@
 			"override": false,
 			"length": 16.8,
 			"snapping": 20,
-			"selected": false,
+			"selected": true,
+			"saved": true,
+			"path": "",
 			"anim_time_update": "",
 			"blend_weight": "",
 			"start_delay": "",
 			"loop_delay": "",
-			"affected_bones": [],
-			"affected_bones_is_a_whitelist": false,
+			"excluded_bones": [],
 			"animators": {
 				"f13c55d0-8667-840d-3540-9fdda50cfc40": {
 					"name": "root",
@@ -1604,7 +1606,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1623,7 +1627,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1642,7 +1648,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1661,7 +1669,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1680,7 +1690,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1699,7 +1711,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1718,7 +1732,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1737,7 +1753,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1756,7 +1774,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1775,7 +1795,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1794,7 +1816,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1813,7 +1837,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1832,7 +1858,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1851,7 +1879,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1870,7 +1900,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1889,7 +1921,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1908,7 +1942,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1927,7 +1963,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1946,7 +1984,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1965,7 +2005,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -1984,7 +2026,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2003,7 +2047,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2022,7 +2068,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2041,7 +2089,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2060,7 +2110,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2079,7 +2131,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2098,7 +2152,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2117,7 +2173,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2136,7 +2194,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2155,7 +2215,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2174,7 +2236,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2193,7 +2257,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2212,7 +2278,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2231,7 +2299,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2250,7 +2320,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2269,7 +2341,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2288,7 +2362,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2307,7 +2383,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2326,7 +2404,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2345,7 +2425,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2364,7 +2446,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2383,7 +2467,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2402,7 +2488,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2421,7 +2509,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2440,7 +2530,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2459,7 +2551,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2478,7 +2572,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2497,7 +2593,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2516,7 +2614,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2535,7 +2635,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2554,7 +2656,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2573,7 +2677,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2592,7 +2698,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2611,7 +2719,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2630,7 +2740,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2649,7 +2761,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -2668,7 +2782,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2687,7 +2803,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2706,7 +2824,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2725,7 +2845,9 @@
 							"bezier_left_time": [-0.00938, -0.09664, -0.1],
 							"bezier_left_value": [-0.03396, 0, 0],
 							"bezier_right_time": [0.00938, 0.09664, 0.1],
-							"bezier_right_value": [0.03396, 0, 0]
+							"bezier_right_value": [0.03396, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2744,7 +2866,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2763,7 +2887,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2782,7 +2908,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2801,7 +2929,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2820,7 +2950,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2839,7 +2971,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2858,7 +2992,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2877,7 +3013,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2896,7 +3034,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2915,7 +3055,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2934,7 +3076,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2953,7 +3097,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2972,7 +3118,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2991,7 +3139,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3010,7 +3160,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3029,7 +3181,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3048,7 +3202,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3067,7 +3223,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3086,7 +3244,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3105,7 +3265,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3124,7 +3286,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3143,7 +3307,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3162,7 +3328,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3181,7 +3349,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3200,7 +3370,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3219,7 +3391,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3238,7 +3412,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3257,7 +3433,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3276,7 +3454,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3295,7 +3475,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3314,7 +3496,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3333,7 +3517,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3352,7 +3538,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3371,7 +3559,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3390,7 +3580,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3409,7 +3601,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3428,7 +3622,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3447,7 +3643,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3466,7 +3664,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3485,7 +3685,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3504,7 +3706,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3523,7 +3727,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3542,7 +3748,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3561,7 +3769,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3580,7 +3790,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3599,7 +3811,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3618,7 +3832,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3637,7 +3853,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3656,7 +3874,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3675,7 +3895,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3694,7 +3916,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3713,7 +3937,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3732,7 +3958,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3751,7 +3979,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3770,7 +4000,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3789,7 +4021,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3808,7 +4042,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3827,7 +4063,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3846,7 +4084,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3865,7 +4105,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3884,7 +4126,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3903,7 +4147,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3922,7 +4168,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3941,7 +4189,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3960,7 +4210,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3979,7 +4231,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3998,7 +4252,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4017,7 +4273,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4036,7 +4294,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4055,7 +4315,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4074,7 +4336,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4093,7 +4357,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4112,7 +4378,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4131,7 +4399,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4150,7 +4420,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4169,7 +4441,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4188,7 +4462,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4207,7 +4483,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4226,7 +4504,9 @@
 							"bezier_left_time": [-0.08154, -0.02423, -0.1],
 							"bezier_left_value": [0, 0.14717, 0],
 							"bezier_right_time": [0.08154, 0.02423, 0.1],
-							"bezier_right_value": [0, -0.14717, 0]
+							"bezier_right_value": [0, -0.14717, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4245,7 +4525,9 @@
 							"bezier_left_time": [-0.021, -0.098, -0.1],
 							"bezier_left_value": [0.10072, 0.00043, 0],
 							"bezier_right_time": [0.021, 0.098, 0.1],
-							"bezier_right_value": [-0.10072, -0.00043, 0]
+							"bezier_right_value": [-0.10072, -0.00043, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4264,7 +4546,9 @@
 							"bezier_left_time": [-0.08154, -0.02545, -0.1],
 							"bezier_left_value": [0, -0.12453, 0],
 							"bezier_right_time": [0.08154, 0.02545, 0.1],
-							"bezier_right_value": [0, 0.12453, 0]
+							"bezier_right_value": [0, 0.12453, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4283,7 +4567,9 @@
 							"bezier_left_time": [-0.03738, -0.09664, -0.1],
 							"bezier_left_value": [-0.14151, 0, 0],
 							"bezier_right_time": [0.03738, 0.09664, 0.1],
-							"bezier_right_value": [0.14151, 0, 0]
+							"bezier_right_value": [0.14151, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -4308,7 +4594,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4327,7 +4615,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4346,7 +4636,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4365,7 +4657,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4384,7 +4678,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4403,7 +4699,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4422,7 +4720,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4441,7 +4741,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4460,7 +4762,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4479,7 +4783,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4498,7 +4804,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4517,7 +4825,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4536,7 +4846,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4555,7 +4867,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4574,7 +4888,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4593,7 +4909,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4612,7 +4930,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4631,7 +4951,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4650,7 +4972,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4669,7 +4993,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4688,7 +5014,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4707,7 +5035,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4726,7 +5056,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4745,7 +5077,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4764,7 +5098,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4783,7 +5119,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4802,7 +5140,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4821,7 +5161,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4840,7 +5182,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4859,7 +5203,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4878,7 +5224,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4897,7 +5245,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4916,7 +5266,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4935,7 +5287,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4954,7 +5308,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4973,7 +5329,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4992,7 +5350,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5011,7 +5371,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5030,7 +5392,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5049,7 +5413,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5068,7 +5434,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5087,7 +5455,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5106,7 +5476,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5125,7 +5497,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5144,7 +5518,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5163,7 +5539,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5182,7 +5560,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5201,7 +5581,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5220,7 +5602,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -5245,7 +5629,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5264,7 +5650,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5283,7 +5671,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5302,7 +5692,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5321,7 +5713,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5340,7 +5734,9 @@
 							"bezier_left_time": [-0.10503, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.10503, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5359,7 +5755,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5378,7 +5776,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5397,7 +5797,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5416,7 +5818,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5435,7 +5839,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5454,7 +5860,9 @@
 							"bezier_left_time": [-0.10503, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.10503, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5473,7 +5881,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5492,7 +5902,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5511,7 +5923,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5530,7 +5944,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5549,7 +5965,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5568,7 +5986,9 @@
 							"bezier_left_time": [-0.10503, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.10503, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5587,7 +6007,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5606,7 +6028,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5625,7 +6049,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5644,7 +6070,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5663,7 +6091,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5682,7 +6112,9 @@
 							"bezier_left_time": [-0.10503, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.10503, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5701,7 +6133,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5720,7 +6154,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5739,7 +6175,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5758,7 +6196,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5777,7 +6217,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5796,7 +6238,9 @@
 							"bezier_left_time": [-0.10503, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.10503, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5815,7 +6259,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5834,7 +6280,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5853,7 +6301,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5872,7 +6322,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5891,7 +6343,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5910,7 +6364,9 @@
 							"bezier_left_time": [-0.10503, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.10503, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5929,7 +6385,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5948,7 +6406,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5967,7 +6427,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5986,7 +6448,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6005,7 +6469,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6024,7 +6490,9 @@
 							"bezier_left_time": [-0.10503, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.10503, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6043,7 +6511,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6062,7 +6532,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6081,7 +6553,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6100,7 +6574,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6119,7 +6595,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6138,7 +6616,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [-0.00003, 0, 0]
+							"bezier_right_value": [-0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6157,7 +6637,9 @@
 							"bezier_left_time": [-0.15035, -0.1, -0.1],
 							"bezier_left_value": [-0.00003, 0, 0],
 							"bezier_right_time": [0.15035, 0.1, 0.1],
-							"bezier_right_value": [0.00003, 0, 0]
+							"bezier_right_value": [0.00003, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6177,7 +6659,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6197,7 +6681,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6217,7 +6703,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6237,7 +6725,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6257,7 +6747,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6277,7 +6769,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6297,7 +6791,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6317,7 +6813,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6337,7 +6835,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6357,7 +6857,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6377,7 +6879,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6397,7 +6901,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6417,7 +6923,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6437,7 +6945,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6457,7 +6967,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6477,7 +6989,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6497,7 +7011,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6517,7 +7033,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6537,7 +7055,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6557,7 +7077,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6577,7 +7099,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6597,7 +7121,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6617,7 +7143,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6637,7 +7165,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6657,7 +7187,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6677,7 +7209,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6697,7 +7231,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6717,7 +7253,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6737,7 +7275,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6757,7 +7297,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6777,7 +7319,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6797,7 +7341,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6817,7 +7363,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6837,7 +7385,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6857,7 +7407,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6877,7 +7429,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6897,7 +7451,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6917,7 +7473,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6937,7 +7495,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6957,7 +7517,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6977,7 +7539,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6997,7 +7561,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7017,7 +7583,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7037,7 +7605,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7057,7 +7627,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7077,7 +7649,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7097,7 +7671,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7117,7 +7693,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7137,7 +7715,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7157,7 +7737,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7177,7 +7759,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7197,7 +7781,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7217,7 +7803,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7237,7 +7825,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7257,7 +7847,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7277,7 +7869,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7297,7 +7891,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7317,7 +7913,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7337,7 +7935,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7357,7 +7957,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7377,7 +7979,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7397,7 +8001,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7417,7 +8023,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7437,7 +8045,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7457,7 +8067,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7477,7 +8089,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7497,7 +8111,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7517,7 +8133,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7537,7 +8155,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7557,7 +8177,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7577,7 +8199,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7597,7 +8221,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7617,7 +8243,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7637,7 +8265,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7657,7 +8287,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7677,7 +8309,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7697,7 +8331,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7717,7 +8353,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7737,7 +8375,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7757,7 +8397,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7777,7 +8419,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7797,7 +8441,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7817,7 +8463,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7837,7 +8485,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7857,7 +8507,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7877,7 +8529,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7897,7 +8551,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7917,7 +8573,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7937,7 +8595,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7957,7 +8617,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7977,7 +8639,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7997,7 +8661,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8017,7 +8683,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8037,7 +8705,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8057,7 +8727,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8077,7 +8749,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8097,7 +8771,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8117,7 +8793,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8137,7 +8815,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8157,7 +8837,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8177,7 +8859,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8197,7 +8881,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8217,7 +8903,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8237,7 +8925,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8257,7 +8947,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8277,7 +8969,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8297,7 +8991,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8317,7 +9013,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8337,7 +9035,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8357,7 +9057,9 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8377,7 +9079,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8397,7 +9101,9 @@
 							"bezier_left_time": [-0.09497, -0.09497, -0.09497],
 							"bezier_left_value": [0.00566, 0.00566, 0.00566],
 							"bezier_right_time": [0.09497, 0.09497, 0.09497],
-							"bezier_right_value": [-0.00566, -0.00566, -0.00566]
+							"bezier_right_value": [-0.00566, -0.00566, -0.00566],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8417,11 +9123,14 @@
 							"bezier_left_time": [-0.05301, -0.04965, -0.1],
 							"bezier_left_value": [-0.00571, 0, 0],
 							"bezier_right_time": [0.05301, 0.04965, 0.1],
-							"bezier_right_value": [0.00571, 0, 0]
+							"bezier_right_value": [0.00571, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				}
 			}
 		}
-	]
+	],
+	"animation_controllers": []
 }


### PR DESCRIPTION
# Summary

This PR migrates the `upper-eye` AJ model file so we can summon it in-game again for Minecraft 1.21.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Reproducing in-game

```mcfunction
function _:summon
```

---

## Supplemental changes

N/A

<!--
describe what other changes this PR makes which aren't specific to its main purpose.
- does it contain a world backup? (recommended)
- does it contain other miscellaneous code cleanup?

format these extra changes with bullet points, preferrably.
-->
