### PR TITLE
⬆️ 🍱 migrate `lower-eye` model to AJ v1.0

### DIFF
--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/executor/loop/pause_eye.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/executor/loop/pause_eye.mcfunction
@@ -1,3 +1,3 @@
 ## as `aj.lower_eye.root`
 function animated_java:lower_eye/animations/look_around/pause
-function animated_java:lower_eye/apply_variant/colorful
+function animated_java:lower_eye/variants/colorful/apply

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/executor/terminate.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/executor/terminate.mcfunction
@@ -1,5 +1,5 @@
 execute as @e[tag=aj.lower_eye.root] run function animated_java:lower_eye/animations/look_around/resume
-execute as @e[tag=aj.lower_eye.root] run function animated_java:lower_eye/apply_variant/default
+execute as @e[tag=aj.lower_eye.root] run function animated_java:lower_eye/variants/default/apply
 
 execute as @e[tag=boss_fight] run function entity:hostile/omega-flowey/attack/x-bullets-lower/executor/terminate/boss_fight
 

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/indicator/loop/summon_bullet.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/indicator/loop/summon_bullet.mcfunction
@@ -9,8 +9,8 @@
 scoreboard players operation @s math.0 = @s attack.bullets.remaining
 scoreboard players operation @s math.0 %= #2 mathf.const
 # TODO(47): this needs to NOT be a distance check
-execute if score @s math.0 matches 0 as @e[tag=aj.lower_eye.root,sort=nearest,limit=1] run function animated_java:lower_eye/apply_variant/dark
-execute if score @s math.0 matches 1 as @e[tag=aj.lower_eye.root,sort=nearest,limit=1] run function animated_java:lower_eye/apply_variant/bright
+execute if score @s math.0 matches 0 as @e[tag=aj.lower_eye.root,sort=nearest,limit=1] run function animated_java:lower_eye/variants/dark/apply
+execute if score @s math.0 matches 1 as @e[tag=aj.lower_eye.root,sort=nearest,limit=1] run function animated_java:lower_eye/variants/bright/apply
 
 # Summon bullet
 $execute positioned $(x) $(y) $(z) run function animated_java:projectile_star/summon

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/indicator/terminate.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/indicator/terminate.mcfunction
@@ -1,5 +1,5 @@
 # TODO(47): this needs to NOT be a distance check
-execute as @e[tag=aj.lower_eye.root,sort=nearest,limit=1] run function animated_java:lower_eye/apply_variant/colorful
+execute as @e[tag=aj.lower_eye.root,sort=nearest,limit=1] run function animated_java:lower_eye/variants/colorful/apply
 
 # Kill the indicator
 kill @s

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon.mcfunction
@@ -10,9 +10,9 @@ tag @e[tag=aj.large_side_vine.root,tag=!large_side_vine.right] add large_side_vi
 
 ## Lower eyes
 # Right-eye
-execute positioned -5 42 -7 rotated 170 -20 run function animated_java:lower_eye/summon
+execute positioned -5 42 -7 rotated 170 -20 run function animated_java:lower_eye/summon { args: {} }
 # Left-eye
-execute positioned 5 42 -7 rotated 10 20 run function animated_java:lower_eye/summon
+execute positioned 5 42 -7 rotated 10 20 run function animated_java:lower_eye/summon { args: {} }
 
 ## Lower petal pipes
 # Right-lower petal pipe

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/lower-eye.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/lower-eye.ajblueprint
@@ -1,94 +1,32 @@
 {
 	"meta": {
-		"format": "animated_java/ajmodel",
-		"format_version": "0.4.8",
-		"uuid": "2d31b9db-c641-46e6-a875-94380ff05f63"
+		"format": "animated_java_blueprint",
+		"format_version": "0.5.3",
+		"uuid": "2d31b9db-c641-46e6-a875-94380ff05f63",
+		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\lower-eye.ajblueprint",
+		"last_used_export_namespace": "lower_eye"
 	},
-	"animated_java": {
-		"settings": {
-			"project_namespace": "lower_eye",
-			"project_resolution": [16, 16],
-			"target_minecraft_version": "1.20+",
-			"rig_item": "minecraft:white_dye",
-			"rig_item_model": "",
-			"rig_export_folder": "",
-			"texture_export_folder": "",
-			"enable_advanced_resource_pack_settings": false,
-			"resource_pack_mcmeta": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\pack.mcmeta",
-			"verbose": true,
-			"exporter": "animated_java:datapack_exporter"
-		},
-		"exporter_settings": {
-			"animated_java:datapack_exporter": {
-				"datapack_mcmeta": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java\\pack.mcmeta",
-				"outdated_rig_warning": true,
-				"root_entity_nbt": "{Tags:[\"omega-flowey-remastered\", \"omega-flowey\", \"omega-flowey-lower-eye\"]}",
-				"use_component_system": true,
-				"include_variant_summon_functions": true,
-				"include_apply_variant_functions": true,
-				"include_uninstall_function": true,
-				"include_pause_all_animations_function": true,
-				"include_remove_rigs_function": true,
-				"include_remove_all_function": true,
-				"include_on_load_function_tags": true,
-				"include_on_tick_function_tags": true,
-				"include_on_summon_function_tags": true,
-				"include_on_remove_function_tags": true
-			},
-			"animated_java:json_exporter": {
-				"output_file": ""
-			}
-		},
-		"variants": [
-			{
-				"name": "default",
-				"textureMap": {},
-				"uuid": "6fde0b59-c952-3d58-4087-1bfa481a613d",
-				"boneConfig": {},
-				"default": true,
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			},
-			{
-				"name": "bright",
-				"textureMap": {
-					"43c7499b-810c-e305-aa49-1e7c13c77d34": "6a66d687-6cf4-c706-b428-fa07ee115882",
-					"aff1612c-e069-f3fa-76b8-d53c474570a6": "d24c4edd-98f9-71e3-31f3-bc89d06b79ba",
-					"91f4647e-d482-ceca-1b5c-12a72e28cad1": "d24c4edd-98f9-71e3-31f3-bc89d06b79ba",
-					"430ffeff-a100-d7bc-2362-4a3980e59ff5": "d24c4edd-98f9-71e3-31f3-bc89d06b79ba"
-				},
-				"uuid": "0463c19a-d0e3-3f38-c2fa-9e3b26443e96",
-				"boneConfig": {},
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			},
-			{
-				"name": "colorful",
-				"textureMap": {
-					"43c7499b-810c-e305-aa49-1e7c13c77d34": "4c654000-464a-16cc-1468-37e092fa9283",
-					"aff1612c-e069-f3fa-76b8-d53c474570a6": "8ea9aaaa-6fd6-ff19-df07-073e7ac43c4d",
-					"91f4647e-d482-ceca-1b5c-12a72e28cad1": "ae3d3116-819d-9cbe-6043-ff4b64e46b3f",
-					"430ffeff-a100-d7bc-2362-4a3980e59ff5": "4c654000-464a-16cc-1468-37e092fa9283"
-				},
-				"uuid": "6659e3dc-75cd-b379-5cc7-3bc2cc56a15a",
-				"boneConfig": {},
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			},
-			{
-				"name": "dark",
-				"textureMap": {
-					"43c7499b-810c-e305-aa49-1e7c13c77d34": "d47619a9-94ae-577b-9b1c-5212504c43a5",
-					"aff1612c-e069-f3fa-76b8-d53c474570a6": "d47619a9-94ae-577b-9b1c-5212504c43a5",
-					"91f4647e-d482-ceca-1b5c-12a72e28cad1": "7af71311-1188-adbb-0391-ffa2173d1081",
-					"430ffeff-a100-d7bc-2362-4a3980e59ff5": "d47619a9-94ae-577b-9b1c-5212504c43a5"
-				},
-				"uuid": "b91ac4d2-5302-2bde-859e-84985699299b",
-				"boneConfig": {},
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			}
-		]
+	"project_settings": {
+		"export_namespace": "lower_eye",
+		"show_bounding_box": false,
+		"auto_bounding_box": true,
+		"bounding_box": [48, 48],
+		"enable_plugin_mode": false,
+		"enable_resource_pack": true,
+		"enable_data_pack": true,
+		"display_item": "minecraft:white_dye",
+		"customModelDataOffset": 0,
+		"enable_advanced_resource_pack_settings": false,
+		"resource_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\",
+		"display_item_path": "",
+		"model_folder": "",
+		"texture_folder": "",
+		"enable_advanced_data_pack_settings": false,
+		"data_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java\\",
+		"summon_commands": "tag @s add omega-flowey-remastered\ntag @s add omega-flowey\ntag @s add omega-flowey-lower-eye",
+		"interpolation_duration": 1,
+		"teleportation_duration": 1,
+		"use_storage_for_animation": false
 	},
 	"resolution": {
 		"width": 16,
@@ -2033,8 +1971,11 @@
 			"ignore_inherited_scale": false,
 			"visibility": true,
 			"locked": false,
-			"entity_type": "minecraft:marker",
-			"nbt": "{}",
+			"config": {
+				"use_entity": true,
+				"entity_type": "minecraft:marker",
+				"summon_commands": "data merge entity @s {}"
+			},
 			"uuid": "49f3d396-14a1-9064-26d7-32b47055e719",
 			"type": "locator"
 		}
@@ -2044,7 +1985,10 @@
 			"name": "root",
 			"origin": [0, 0, 2.95],
 			"color": 0,
-			"nbt": "{}",
+			"configs": {
+				"default": {},
+				"variants": {}
+			},
 			"uuid": "f13c55d0-8667-840d-3540-9fdda50cfc40",
 			"export": true,
 			"mirror_uv": false,
@@ -2057,7 +2001,10 @@
 					"name": "sclera",
 					"origin": [0, 0, 2.95],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "d6cd4de3-8375-b558-e3c1-76e23149ff10",
 					"export": true,
 					"mirror_uv": false,
@@ -2071,7 +2018,10 @@
 					"name": "lid",
 					"origin": [0, 0, 2.95],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "b68d2836-80d9-27aa-0d3a-124ba44fce75",
 					"export": true,
 					"mirror_uv": false,
@@ -2084,7 +2034,10 @@
 							"name": "dark",
 							"origin": [0, 0, 2.95],
 							"color": 0,
-							"nbt": "{}",
+							"configs": {
+								"default": {},
+								"variants": {}
+							},
 							"uuid": "7b7340bc-78c6-1299-de1b-edf96e09fec6",
 							"export": true,
 							"mirror_uv": false,
@@ -2107,7 +2060,10 @@
 							"name": "light",
 							"origin": [12.96, 35.64, 0.25],
 							"color": 0,
-							"nbt": "{}",
+							"configs": {
+								"default": {},
+								"variants": {}
+							},
 							"uuid": "32a2beec-a2be-93ec-fd62-73107f2ee6d7",
 							"export": true,
 							"mirror_uv": false,
@@ -2129,7 +2085,10 @@
 					"name": "iris",
 					"origin": [0, 0, 2.95],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "880e6759-b6fb-7278-fe5e-7aef4153a88a",
 					"export": true,
 					"mirror_uv": false,
@@ -2145,7 +2104,10 @@
 							"name": "diag",
 							"origin": [0, 0, 2.95],
 							"color": 0,
-							"nbt": "{}",
+							"configs": {
+								"default": {},
+								"variants": {}
+							},
 							"uuid": "4ae5ba92-0303-4b85-bd02-215b0b417f07",
 							"export": true,
 							"mirror_uv": false,
@@ -2164,7 +2126,10 @@
 							"name": "pupil",
 							"origin": [-21.6, 16.2, 0.25],
 							"color": 0,
-							"nbt": "{}",
+							"configs": {
+								"default": {},
+								"variants": {}
+							},
 							"uuid": "66b0c5dd-24ab-7cf3-a0b2-e6bd91aaea37",
 							"export": true,
 							"mirror_uv": false,
@@ -2180,7 +2145,10 @@
 					"name": "outer_lid",
 					"origin": [0, -10.8, 2.95],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "8762d93c-9910-956b-1cb8-18d4d7378ff6",
 					"export": true,
 					"mirror_uv": false,
@@ -2206,7 +2174,10 @@
 							"name": "black",
 							"origin": [-69.3, -10.8, 2.95],
 							"color": 0,
-							"nbt": "{}",
+							"configs": {
+								"default": {},
+								"variants": {}
+							},
 							"uuid": "5d40d45a-2378-802c-df67-a649b180003c",
 							"export": true,
 							"mirror_uv": false,
@@ -2229,7 +2200,7 @@
 	"textures": [
 		{
 			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.2-pre1\\1.20.2-pre1\\assets\\minecraft\\textures\\block\\quartz_block_side.png",
-			"name": "quartz_block_side",
+			"name": "quartz_block_side.png",
 			"folder": "",
 			"namespace": "",
 			"id": "0",
@@ -2251,13 +2222,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "43c7499b-810c-e305-aa49-1e7c13c77d34",
-			"relative_path": "C:/Users/afro/AppData/Roaming/.minecraft/versions/1.20.2-pre1/1.20.2-pre1/assets/minecraft/textures/block/quartz_block_side.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAN5JREFUOE+lU9EKwjAMTKGDPez/v8sv8EHQh8Esm0UrDUxS3UyTbD7YxzZ3yd2lbgrDDH8cRwSYnwCYKhpEVLS+7aq7GHt4EzzG8mCB6N57D+DbmhAThNsA7tpfZkxRdyNQQTOgmLIiKF3Y4dMsb3LChPffErbA1EsRqJHJFyGPT1okrClYUQrNskQTfACWfpUCAIRwtj0wY5Ptlxh3JVSxJLUnXxNpE40Ou8vVdkwCJ2A+8AhX99liKQ94RwtQb5pYZQKQ+7tAEWtME7jT8VC+c855bdA0zeYH53VU9AIPBdWpk9ajcwAAAABJRU5ErkJggg==",
 			"mode": "bitmap"
 		},
 		{
 			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.2-pre1\\1.20.2-pre1\\assets\\minecraft\\textures\\block\\light_gray_concrete.png",
-			"name": "light_gray_concrete",
+			"name": "light_gray_concrete.png",
 			"folder": "",
 			"namespace": "",
 			"id": "1",
@@ -2279,13 +2249,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "aff1612c-e069-f3fa-76b8-d53c474570a6",
-			"relative_path": "C:/Users/afro/AppData/Roaming/.minecraft/versions/1.20.2-pre1/1.20.2-pre1/assets/minecraft/textures/block/light_gray_concrete.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAANtJREFUOE91k9sOwjAMQ9d9MvC47dNb5IgTWVZBQow0dXzJxvN81lrr0Ee/53n2s9fmnMcYo756Vl/VBMChLqgBQACyzpCqX9dr5dQdEJOTRTHQxJys/zsGLqHu3fe7AFrT5mIh/TyCHbX2QAACcv2w6Obwp+SIAbRozClZJ4WS4DGmeUjzmPEKdsXgX3w4rnOPmv6qKUYK6TzpuAduaA2QhJzgkSZljMb0XiRfVTR75sSYO9MS3HmkJGjuS8foB75Q6cH25ZKJvjBccu0uKaWUhNy4zN+dxzwkfwEZ2Arp4SZU2AAAAABJRU5ErkJggg==",
 			"mode": "bitmap"
 		},
 		{
 			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.2-pre1\\1.20.2-pre1\\assets\\minecraft\\textures\\block\\coal_block.png",
-			"name": "coal_block",
+			"name": "coal_block.png",
 			"folder": "",
 			"namespace": "",
 			"id": "2",
@@ -2307,13 +2276,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "91f4647e-d482-ceca-1b5c-12a72e28cad1",
-			"relative_path": "C:/Users/afro/AppData/Roaming/.minecraft/versions/1.20.2-pre1/1.20.2-pre1/assets/minecraft/textures/block/coal_block.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAQlJREFUOE+FU0EKgzAQTA6CBgSt9WAP9v9/q+ApemuZhQmTxaIg0c3uZGd2Et/r+g0hhHwcWMJ5nqFtW/ve993WYRjKHvbxIAdvnOfZALQYSUwkAGMsTF1nNQbgC5ikXfAQdsP/2Pe9AWhbz2kKOedCi8mg5OnEpmmMgm+NmpAaDwGAdmwUFJmn+UKNK0XrAIHHOFaTIAC701XBDECF8WojGYqnlCpdmFcAyJE+QFcc1T89bIxeRAKgWM1FSq9lsThNVnyAE9WFVyLqCKlJhJWBSE4ck4qmY9MJoMtCQS2Lb0xFhVNq2Ce9CkDNhOLPtlUXyusC0EsnKiV1KedfORF3gddXExi7E/YHpAf5qSjgElwAAAAASUVORK5CYII=",
 			"mode": "bitmap"
 		},
 		{
 			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\black.png",
-			"name": "black",
+			"name": "black.png",
 			"folder": "",
 			"namespace": "",
 			"id": "3",
@@ -2335,13 +2303,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "d47619a9-94ae-577b-9b1c-5212504c43a5",
-			"relative_path": "../../../../../textures/custom/black.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAB5JREFUOE9jZGBg+M9AAWAcNYBhNAwYRsOAYViEAQBOThABC541RwAAAABJRU5ErkJggg==",
 			"mode": "bitmap"
 		},
 		{
 			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\lower_eye\\bright_light_gray_concrete.png",
-			"name": "bright_light_gray_concrete",
+			"name": "bright_light_gray_concrete.png",
 			"folder": "",
 			"namespace": "",
 			"id": "4",
@@ -2363,13 +2330,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "d24c4edd-98f9-71e3-31f3-bc89d06b79ba",
-			"relative_path": "../../../../../textures/custom/lower_eye/bright_light_gray_concrete.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAB5JREFUOE9jPHvh7H8GCgDjqAEMo2HAMBoGDMMiDABiOzah39ajbgAAAABJRU5ErkJggg==",
 			"mode": "bitmap"
 		},
 		{
 			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\lower_eye\\bright_quartz_block_side.png",
-			"name": "bright_quartz_block_side",
+			"name": "bright_quartz_block_side.png",
 			"folder": "",
 			"namespace": "",
 			"id": "5",
@@ -2391,13 +2357,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "6a66d687-6cf4-c706-b428-fa07ee115882",
-			"relative_path": "../../../../../textures/custom/lower_eye/bright_quartz_block_side.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAB5JREFUOE9jfPHq+X8GCgDjqAEMo2HAMBoGDMMiDAABCDuRfbRKywAAAABJRU5ErkJggg==",
 			"mode": "bitmap"
 		},
 		{
 			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.2-pre1\\1.20.2-pre1\\assets\\minecraft\\textures\\block\\redstone_block.png",
-			"name": "redstone_block",
+			"name": "redstone_block.png",
 			"folder": "",
 			"namespace": "",
 			"id": "6",
@@ -2419,13 +2384,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "7af71311-1188-adbb-0391-ffa2173d1081",
-			"relative_path": "C:/Users/afro/AppData/Roaming/.minecraft/versions/1.20.2-pre1/1.20.2-pre1/assets/minecraft/textures/block/redstone_block.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAQBJREFUOE+lkyESwjAQRbcziIgKRA0OJJIrILkO5+hVkEiugKzEgalAVFQwA/Ob/GS7mXaGaU3SJvv69+9u8dy6ryx4CgCaANiLCPevPlE3zu/1Od8zwC0E3rteDmWIVAoBAxwrgCMAD5rOUx4Btguc9coJwSMALkM6AO9PCkYggzTkqIRFBQzmX6d8PVdOkGaWwrX1OUPBFIQqBgNLlzwAUUufqyrTwh2kMqRA5yELBv6tgAaCeFEV0Clp+TA288BWgGnAtLr1lbHy8S3rA1tG2wvsj1OlTGQK/Csh1kxI1080kY0EA3EJB7YybOvZVuaAEIiVQ8WB0griLCyYZvkBEBqf4WyNTFoAAAAASUVORK5CYII=",
 			"mode": "bitmap"
 		},
 		{
 			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\lower_eye\\colorful_iris.png",
-			"name": "colorful_iris",
+			"name": "colorful_iris.png",
 			"folder": "",
 			"namespace": "",
 			"id": "7",
@@ -2447,13 +2411,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "8ea9aaaa-6fd6-ff19-df07-073e7ac43c4d",
-			"relative_path": "../../../../../textures/custom/lower_eye/colorful_iris.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAACgCAYAAAAFOewUAAAAAXNSR0IArs4c6QAAEaVJREFUaEOFWmmsJFd5PbeWrurq9b1+68y88Wx2mOAYJxEk2AFrGNvEkbGQiRPbxAk/ovyIneEPKBLiT/IvP7IJBhwbgiCOjEkwIlJkIllECt6iOMx4gTFjz2LP8rZ+03t37Tc5t97tV6/fG7iaUVfd5XznO9+5VdXVTzz+R3fJNE2Rb4ZhjE/jOIVrpIgNC7vNEwSw0hjStLaBiCRGiAzINrcAgyiFZWXnBFQAjKKDkkyOAMiGEzUrHYwByEoB6NAcZPNTQ0UxRTaSZzOZqnjyM1sAUbJdi/zkAtJd0xRfeeS4YpAXLi8W+5liPu888LYUNGUy4UJ9vm3BZu4MQr22MZgsU6b01nItbp6t+Nojx6QuIUvk2IYSLd/yJU4ktjFTKeTLNJn/9cboDYKNNdgtX2qhfZE3ExfqJr786eOSVmXTdmXJeMyW94Keo/uY8jiFXyTYbgIzkAKYpK9F1HtBg7MKrEB+74w1YGd+gc5xx4LcJuPY2Ad6AUVjKfUe0Fro3ZcHVnNO/v5jMpVbshoQEKYByzSQyhRRnMCxTVDmJEwQbzpLCApsZABEsm0LavMlQASBVEYQqQQvCUIImKYJBorCBKaRbVOei5MPnpBRmoLXCC5gJ6MxCYMLLVMZRqHzk5iscJKCM8VXHzohhQmkCSCTBDHTkVKp7RgGIobSKRJVbl4kZKr6xVceOiFtk5R5LtXcIIzUVSmT0oQUEm7BVmdRHKs5wjBUQPHkH3xWRokERaE+Mk1gbOYoM1WyiggxPlOZpCkKtgnx+MMnJFltMlK5ZBoYKBgGwjTOzoVQwMIUEDILlpDBVx/+rEwTCpCJZ1vmJtUEtm2qNMgw450xUmz09ZIAQmSLoyCCaZiQMoUQm2YSWb6sEpkyOlh/CIRxTAYnZJpKSP5nHlkINUEiqwZ4QU03o2/eEwrKaMqJj0pSkjCQqiuRgOvYSjA/8CGsgkrDMjlHIGYVOJhuGulLDzwqlTi6CpDKaZIppNQkyzlWdc4IGmYmScLqffmBx1S1tCiZxOqfSsNxCuoaGcSJciQrzEqQhhLzJJ24qSjTZUEMy0AaRqA2LB9bgAQ2sqoIQ8C0DRgEOfngn2UuoiBRiEgIWGbGUdefqm96S90nuUtZB+4TtZlyhstyFIBlCFV/vY/UlkgSVSkCs9z0u/jjj/+jnJuZR6M2j43OqgJYa66Cffd98HZ86Pah6vv2d0tY7r6NM+deV2Ocf/r0jyG+8Ol/lzxZrN64YwIB9dhz//WMAlo6uFf1sRFMMTh6+BYVnZHZeE7ANy+9oPo+9qufAgGciqWO2a+ZbkuBiEEvu60xkgYkZQ10aEHixbPvjNMdp3D7TUfwb//zIi5duKIi6abzzeeuAzGI+Os/fVWS7oOfGuBvv3F1nAoXst289FuYjJoPIl75u7bMK81F+RwnGei0tFbbqvDDU99VUbmIkQmUL68+JgiFHldBLyCArkCe9qSYeg7nKwZaMF1zHXmyKppBXpcxgF6cj6zF0jpos2mDqRTyTiQTApxfETtcycX5MW08ZSS6i4O7VSOfP6lPOnKbE8mAhjr5ne+MzURn0jC65TcaHalS0J1aB6qr7at3JV06uUu5Q8Ujtz0htXUntzWj6i2tXUphyYj9ZCruOPaErNZn1QUiSXnBEEjTCIHvq0t6HCXqllwsefD9AOVKFY5Twery27AsB+LY8W9J13NhmTYGg4G6+slEIJEJXNeDZRUhZYJKdQHrq+chTBOOY8O2XfTaXYi773laeuUahv0hoqCrLs+pTDDVmMeg1+UtBQWrAMt24Y8GSJIQBdtWDK1CmQBPqccQXiCDIEQS+TCtIhzHVFfo0aAJ15uGXbARRQlcp4goDBHFIeyChDh+9z9L2zIQRol6qOT1lhdOy7LUzcMuGOh32hl1twwZhwjjERqzN8AftgjwDZkmprrb2NY0hNFXDxW8rfFOIkSC6vQi4qCHXq+l7pFeqYRiuYrmymWm8E3peQ0Mehso1aaxsXYFtlWCMCQc10GaSIRBgFKljnJ9Bp2NK+rpIYoC5S3x27/ztORjnWm6GA7aajCJQxScIiy7hCQewvcHsAxbPfNYVgGeV4FZKCIYdAnwbUnxytUpyDiC7RXRubaOgl1EQj8EQ3jFWQTROgQKMNWTm40wimCaBsRtHzkp5+b2odfrw3ELcIpFdZu7tr4Kr1RW1RkOhnBdF3EMWLZQj0P+qA+3WIG4595n1AXl2sYlVGt7YbsGIp9PoQlGQYRavYEw9CHSFH4wUjdWt9hAHHcRRxHER489KW3bQ63RQK+1pmpPCkKYsC0LURrDENQlgldqIAl7EJaJKAzgj7oQ937y+zJNMkWDIEEchzBFCqtQRCKHsA0HhVIFo15XAZdKNXR7PUCGEMKCuPe+f5WjMELBArrdJizTg+O6CPwhisUGktiHWXCVH+I4gilMjPw+alPz8AcdiPsf+oGM/JFCHw56kIkBt+QgimLlxsDvw3UriJMR4iCB45Ux6HdQrdcgYEHc84lnZBJLRMEAbsmF5y2g111D4PdQKs8hCHqwLZePV/D9EIZlgs+V/DqQJBHEo1+PpChkz4Suu/Vo6/sSMswe+4pVE3sqwN66wJW2xNUewHHlRAKogxyIHtQAHP/o+60di3cFGF89NxlpJpqFjk5wBhWP/VMi9Yn+ZCqkzMYFo26iJh+aFTi/vpXaGEBZJ5fvB5e2cuWYBiCwZsTFPBef+5dU5jsZhS0vGAG0TgzEdHRTAHqCzlMPkj5TOXclA2A7vDdbzDEFmtdAR89PmKwIg+RTHAPko2t0AmmAfP5koVNUAJyoTUTKVFqf5wF2E3TsRB0h/6kZaOEm3cnzsRO1ypNAeTdqt2q/jJ2420DeXHlwXY1x6bUGeiCfu46uTTOu5eaBMlgeYDcLc27eOBqEYrNa26qQ979WPL+J2Jefo0T8xHOvSbvoqdddrasDLByqY+VCG41FB4NujP37p7G63odXNjFdKuLsuRZ++Za9uHjuEoRZgDj+7BvScXlLNzA7W8bl88swrAIKrgGvVEAkC0ijBLFwEXZacIo2hJFiasrD1csjiOPfe1NCWCgUHcSDLooVG2GQQEgBu2ghjVJ0rkVYOlxDs+kj8UPUpky0NwKYXg3ijqdflXy8ccu2+kLNr7/+SGJ2wQGvtemgBT/lfTDF4uEaWs1Q3ZnqMxY6qy2I275+Spp2ilKjjN5aD3OHphDHUn3h3Fj1UakCwTCE7fDmyieVFINWH0ahBtscQnz4ay/L+kIVexoOinNzOHPqHAy7iKDvozzlIA4jePUKPDtFq9lBnArsna+or6/n31mBuP+5UxJeGcN2H425GvxOFyiWcPXtNo68r45WL0BnPcDU3hoGIxNz9QRBKtDbGMF2BMQfvnJeyiRFLwIKpkRzeYiZOQftXorGnjo6K23smSlitT1Ub3AMw8Kgn6C2UEVnpQdx+zdPyX031tBpJyh6/AYrMeqPMD1Xh40UF89dw9T+OaDXxEYze/vLmwvv0vVZB+KOp16WpTqfOGz4gwAL8x4GYQoLKVavDOCUCjAtgUE3gjAdeKUUME1MV21ceteHOPbM69L2TAyuLmPq4H50VjZgV6bgOjE6zRCzB6bQWQtQLAv4vSHmFyuw6nWsX1jGsBP9/xfPl8/JbiKw8t4AUb+HylwV0SjE7L4KbEPg6qW+MlTBETC8qnIjH/1i3liSAOKBl96VV9/ZwMJSEWFaQDzyMewHWFiqY/3dVYwGEkduXkR/FMC1gea1BOW6g2g4Qq8VQXzy+bdkayPGDXsdXLqwgtmlWVx5r4f9h2q4uiJx9FAJlzciBKMAfHxqN0PsWypiGAmEIx/iY8++KeNhCK9uo7PcR2OpjtbqANVpF3ECTNcMxIaNwfo1jAIbtcUq4uFAPVPXpisQdz37muy3UswfcNFt9jB7ZD8Gay0E/QHsah2WEaG1ARhyCK/iYtiPlR6lqo21iy2IE//xrPylucXJq5U6/9naMmbKVTS80rbxjeEAzX4Xb51+CeLkqZflixfPYcbztk1qDodYfv0l/O59jyggNvbpeTxunj29EyA/6fLFn+D4h+4cA/SaTQSbgQj0xivPZynoRfx0htkrD0701y7g1ps/rOjmGeh5F985nQHowffNLajJ+QnH7rx/DKDn8ZOBrlw+m6XAHCfz4yRqMLWwiH0H3j8e1/Mo7gsv/ADiL198Xr61tqIoaoGYK+kx+n8+/yx+5TfvVAC6MXplZiarAlOYFIfi6dx1NQ4cuVXpojUimEqBDC5cPK8QOZnC5ZXXeTMdgmiByXbsg1d/+oYCyJdNU87XfbIqCkAz0GVjdG2syfJ2+qtjdlqnMQCpcUI+d+arjcPobAxAxuxnWmMjcbKOQAZ5sXTe2toaQFlZO5GTdI4UVTfNID+uy64YPPy9pyQX1srzqvaLt9ym1moGZMWmx3Ul2N9vdyDu/qvPKStHfmYU2812Zf6cx7v1c574wnP/MH4N1Oyex0z1EPipnFk9NE5FH3AsHQHu6AoOtmcygLXVbAE72cLprXcmnHx0OcDPDjlqrHAtm+MOIwwvt7cA5uYPIfzpD9Hdd2AcVS9mBwG4uHrgI2oe2xige/FHY8TwA7fCKGb0yUxH52JG1Qu9fXX85HIlY6ARdXStAxnkU9MAqqSejXNn3e0aMLJuk4v9YqZLfeMiFsNFLBeWtxiQ6m6LdXS9WCvP/m0AumwcuF5kXSGWjou3pcCFur46KieynVl0VHk1i7wmYw2ut/hCvakW6vTy4hI0Pbu+JaKOoqluyZkZS5eV/QRkWXcAsEztxpaRNCgXaG10CgS1XjmdMaCR8g4jiDZQ3o3UQzuWc668trHdSLSmdqKuCIG0mGRSvXxRWdi4aXbLSNqJnEjkPGUNQEFJW+9EFYAi/skzfy6ZC71NZLYLWMJBXFKf+ca+/DiPxdN/83vSm7i1D4dDsI+fbJPjGpTj4vuPf0bedPTGbZE6wwFqXgnqc6aBTnNDjbMv386eeTtjcOuvfwA/fuM9NVYs1bKoRYnhSKjPfGMf29Gb53H6R/+9xYAAv/YbN2Vzh/6ujHTnmfMdHD1Ug2LAFOZv2IOrK7HqJO2f15jGu8tt1Gs2Vt+9usWAnTcs1hUAwXQaitAm7T0LltKBDHisAKjBwaNH1CJ2sp07t4HDhxvbiOTHNduxiARod6JtDAjGPjbS5TE/d6SgGVwPgPQJphnsSEGLuBtAPgfNgH0abIcGugpaxNGgo3yhvTCZwoUz72yVMc/gF5VxRxXoRF1GLtZW3gHkucpk1wXQ1tV1/3lMxk7Ue0FP1k7Um4n919tQp//3tUwDvVhv4+tF3m17iy99/k5Zr9iYa2S70HE9XOu0MV2rj3H4epT9bDweBQmKjqk+xwClchElp7ANIEWCyA9gOY56l2pYFkb9rlrI1u0OIZ784selWzBAgH43wL6lGXQ7Q9RrFRVNs+oNh6hVqwpgdb2HUqWMXq+TAfDFQWOmogDKVYe/NqBWryAc7QSI4wCXLzUVAF8fi2/9xT0yCOJtAMyfEfmWlF+J+WKe55XctXOjPcDllbVNDcoFzM1UMQhCRZ0/vnS6XQXA/G3bUdTdShUyisHFbGMA2wYO7p1RAIxOsQhQdLPoWjwu4ovP/nCEguVi0OtnDAhABsydDNhI2Stm6rOxIu1OD7ZdGAM0W83NKtgmiuqnIopXVr+xDIbBWHX+HJLGsfIHAajFcnMD0SjOGOxdrI6R52fq6r1JEKdjANLmIrIgMI/fu7SKUexD/P3nj8npchH16aqiVnZcFOzs2q9dSYMVvBJkGqtv9nzDQy8ogCe+eJfcN9/gH8BkLZE7ANg9NTWFVqul3NrffC3e7rUzgMZUBYNegKlGBY5lqD8RYXRtZVbHtUz4MX+Ls5X6wyiEZxc2U6i66neV+lRN1Z7Ndh21D9jUb0obTRWd1NkIUHKsDMCzLczO1FUVmJ9uZKF3IiugAWhjtvVr17Z249Le7BVAfgPp8/xW1uLSjQT4P+XjG5XEmR+7AAAAAElFTkSuQmCC",
 			"mode": "bitmap"
 		},
 		{
 			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\lower_eye\\colorful_pupil.png",
-			"name": "colorful_pupil",
+			"name": "colorful_pupil.png",
 			"folder": "",
 			"namespace": "",
 			"id": "8",
@@ -2475,13 +2438,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "ae3d3116-819d-9cbe-6043-ff4b64e46b3f",
-			"relative_path": "../../../../../textures/custom/lower_eye/colorful_pupil.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAACgCAYAAAAFOewUAAAAAXNSR0IArs4c6QAAD45JREFUaEOVWmusXUd1XjP7vM+5T9/EzwSHpk5IbCOn1ARCCIQEx3aiBMfEDbiqAm3TlrqoahtSQEg8BPxG4hft36hSkRAS+YHK/6C05QeJKhKQkvjt+L7vueeec/Zj2u+bWfvOOffaoWNZe+/ZM2u+9a1vzd5nr2ue/8QfuIo1MswKsUakWa9Ku16ThbWeGGNkolkXa428u9KVirW8RlvbGEheODF/f+xuV02sTLQavDFIM8nyQtb7Q14PcV04qVUSqSSWE3Gsh2vz9ScPO2uMLHU3BMfZiZbkhTcwzHJpN2qcDENorUaNyHC/KAqPADen2g2pJAkNFc4JUE22GvLucleqlURmOs0SOsbvmp2UNMvFvHDiHgfYgzSn/61aVZw4ubrcFedEmrWKNGtV6Q1SSfNcdk51aOj66rpkQPDnH7/DFfCxmsitUx2uOMhy77M1JArXrVpFrLU0hHuAD2Tm26fvcyRvmEnhCg5Ac87RJaCqVyuy1hvIxjCVW6c9AnBAF7708J00AJ/0BhA1ahVeX1ta48ozHc9RfwgyHd3CRPPi4wcdnJ1f6xHa3GSbg1Z7fUkSSySJtQwtojLRrNEtjAFX5m8evtNhAAZOd5pyaWFVjBGKqQHoGwOZbNVLncyvrJPYdhCU+cZTH3QGHGQ5ISPu8A2rwRUMzp2TlfU+ESZUbU6uMNb85UPvp5BUor3BUABhutWgoKALCAdy7jRqMr/a84JCyOtVMV/61B+Sg94wI/R9O6bo84X5Zfo61arTnX6aUVwKfa3Xl4W1DTEvnrzXFU6k0/QSVfh67PaHMtms05VatSIr6xvgnsqlDr556ogDm/ARTEOyiDF8RdI06zUm2MIqshPKrBLJWn8oGXTwxQfvYDZCIJjYRbZVEtkx0aKBBUg2L6TdqFMb0AWQzk21mXzmn44coZDQ4CdCV+0UIkMrUiv8jaGVdChSrflLnA9zn53my4cPuXbTqy4epEZjIzomXtCcO3jIWStCI7piGJF2Lc905XFERPDVDx9xWLkcCCMBMvvgTnBjbT24GLlCBPS7JlKbtDLse9/IAVqtECAhijFOwANJHLk5NrnkYmi5AG9jkYCy5ICLJR6JrqxISG6IjBKtbpdh3A4FBiG0IJnGlY+AEvdHXYj83rK6+hKgj+hgC/QxQ2U4o4iomDYRBCGNhDMidH3DR0dFpxHZPgogtOHVqYyXxEYuFEUQEq1t4/+4MuOQllGAkCbam7kAcsDJFlcid3TyqJDUfKQ2dI3IPCgzjlAppBuJCIORA2iQfIksLGheePQZl7uQMCKSiBWTWG4m2OoHWSqNapXPySxLubmgYVPBrkUDeNJUK1VsdSKFSOas5G4gFrOMiLFWEpvwqZ2mmSTY20S43ZsXPn3GDVwhVSOcgE7OM8KBeJxlfIbxicb/Bp4QSSHmK4+dcYmxfAa4PJcMszHIGmlYK3zU6qaHZNRzuu3EfOXYGYd3H/a7QvB8Gg5Tv2HSWdzDE8qnaZplHqE14opczNeOP+v4omAMH2VFkfPBEi+spHmLHgUeJnwufPWxM64whlb5hHG55A7+W6maRNIiJSpcGyskExZAKJ8LLz72rCu4RYNA4dsXGh629WoiRixfbfzLgAcAtPjPcxjA+2EuTtJBKpbxh0veDSvG6wIoQRqtMLaSZkMY+BOH9x1AwsSwBlfQlwuEq+BLgHABtFqC9ySBkE47rAbbeZGJOMPnIYZvDPtikyo1gUjhXpZn4oyj4Cikf/jUaUdJGhNE5DjYYVYhUq1YIsajHv/QvBJhLBfzj498FovTV6+gYD2Q1ajVxeap9HMfHYyyiSEakvnCsTNczFu2krlCLPwbDomIqzmRgRRSESuIEXOjZsXkMPDpZxxf00FImkoKf7GhBFXCKEjgAerPodZCEmf4GsBkKhUWkMAdrIy8QCQYc5znuY8W0IJUa8WceODzDoO0Mc7WeD8LxyRLQCSoyQuvVg02yIcBjS+5YHiggVwgHR98/5aGdYrM5w1TAuhOPHDWFVQBfPSQVbb+9c4CyDb7AVwpxJx88KwPOfeHwhvwgicPm5tdZMSv7/eDEx8766BOvx/4Y44s23SUNypVn2R5FkyS2ELMEx8/67A7heuQSOX0kjCGMnQTJDSSGDGPP3jWIU/YSeNwI+y6yA8ypCnsdyJFiqiQAx8av5niFZ9Q8xA+imczdMqPovEkhsUd3tiZdfDJGyJqhHHEq5B84EoR6KYaQhBICSoMWwkNBkvIYLp64oHPhRzz4kGWVWrYykTSNBVjKySPwJyhGjVxKaTjH/mcU6seRVg1ZCH20FInKuGQ+djFzfGPfp4y3HTRi4HG8GRCxhUFfyOWGguRYGghJJ3NrNaHRpZHmYhNtxAbth1MtFUjBt4wmcJ+INzvkPt0uIw/8IWgMBuZAw4Zy3TeRFDu+z5y3MLK5wGFtpkrXASLHXj2391wY0VqzalN2eL5GPpmJq/IcDiQpaUZyYcDSWr1kaPZ/9S/OBkuitRmZWZmSZauOZ6jL1usiW2ti21UeU5NhWucD64PA4KVt2Rmp+EqzIbVa5zE837Kcxzztf/7sZ00pDI75LUUG95A/9qbfkJYGROxIgay1WZptOi1SxTeejAwXHnLrzS5k9BpPTRMoqHarLRrK7I236chouitegTV/Lysd/1P33JiMILB8HtirlGOUW7SNbfJQbuTcEDs87jvSiDG0HBjfpSD8kZrvUSClQFbCdRI4Dppd8V8+PkfuCu/XfMWw0Q9L32N3HF5X6q3+L2CHMQGyjgHMtVXZZ/JmvfLUJY6QBgxKL65nZjURUVBA1AiYszVG1VJr4dX2aRBl3T1yq5OGWJ1cSQKah3xjY0o7GQiH1EnjPSH73gEzIUg29jf2GflR8MDtHThthM/dG4x3dR3pECdFBuNk6l79YpHMLh0dUSFelGdMAI/03xB6slOdg9yz5c2c/zkn3H729jolp3Npv9a1WpN8NjrrW1ZQO/RQDy53980hFmNhjeGpve0b8eO3UIDS0vehSLvl4Nt4j9Qoi0uXOZxenqWR9xTIyWC3vr8Fpjasby8KIcOPyQXzr9WGsDJzMwuMfd/9JiDNRgYDPpSr4dPo+EcfTOz+wg/Rthqz0npAjhQA83WtGz0lks0sUF06jXcIALlANZh9fKlN6XZbG3rjk5WHrYYYOjac7K0eHHEACaqe7ivDeE2n3j4aaf+YdB7tY2NnuzZe6AMKw1oBG5mIOYGiIAEC48YiMP2XjzAAF04cNchpwJRDhCe3/32P7d4M85FycGNXLhRCHUhGoilrLJV+PGKMRyVOcP49Gf/1i0sXBlJFGhhdscezlH1xbmhxkoD6NCURZrquWYpoOIchjWEmvLm1m98d+Qt0q5cENMtxHWsFFO3jRCZXHpH8r3vK/s4Vg3gAm1wcJ8ku0Xsq0Z0gt6DYTQ1QgO7vvzXRKCrofNmK6vR9DYn1QtGzO4vPu/G4WIQ+nTF/v23c3DsQnHUESUNpJ+5nRfaMFChKiJ1YxwtDegKvHnUSX5FpPHL8yP+xsYVMRYiB4Aas4vB6kbMh8KOETIKGjoYGT+PIYO4+usXyY0uSANqUWHGYdouInEoSwPjLsS6QATQYnQakS1hVN8xAVARocp/XKQ2xnmhQURBV4/jr0zH4VM+FAmMl1IGQQhdLKpYOPHqcX8ZhXGI8aDY91gPQD6SjeMrxsTGOYBkq/7kPENZGsAAlbSuGCs0Nq7u0sBD58667Bb/CO/96g2ZvG0vz9Gn1+P342vzwLf+ylWud2X92rysXV2UuUfuk//PNRFgMn6N9BbXZebOvZJ1UYgRGtz1wQM0jvtoQBiPN0ee+qTDRLTWrP89MN7G78fX5kPPPObaO+dKn1v33SWD198W9K1euLSFE9xnLrx9TQaLy0IOtGPpd5cIGSRhAK7hUrJ/J43CJVzX222Omf/Fr3wU4FPs82B9nTyMcwDoykml0/QItuMAA2M+bsrBdjqI41yfnS4hb6eLUgeADZ+300HM0fj9bTkY1wVIQ9OoxByVHLyXzze6b+7/wmechuX30T6UCI4gdyC6YS7cjJM4V7bkgsZ5PBcQdxXae+bCzeLOtI9yx3zhnz/pli/25fTxc2T6Z6/8SPrL/n2xMd2Q/e+fk0Evl6Xukrir++WuA3fJocOHZGVlRf77rR+LOfWnH3GYPDU1Ja/92r+Nv/o/P90y+cDkMfZPVe6mkcuXL8mePXvFPPfcc+7RRx+V8++cl9vfd7v88pVX5OLyf8kdd+/mqmj4DTInB9mv7eg9T9IIDaBTrc7L63QBA359+edyeM8xDsTk6X0NmenM0DDcRjOnTp1y+/bulbVuV1ay37ATk9948w0ZdN6Wenc/+7DA9eLVEgGMAJl5+eWX3b/+23fk7vv2kaxb7NHSFRpdWZGjf+z7fvHajwRcvLn6c04GOvPSSy85+A+CAPGRQ39BPtAAXV1SZNoPl0C++f73vk8OYGCcICUT/er3vukPkX24CLfM350755RddUMHA5FCVvIAHbzANXBHHUAwu3fNyJWrS6I/EzvdgwSE1dAQEdwD+xiv53QBvnY7r5cxVyWqS4CNpnxoOP/ojtOeA/UfljFZV9h1q5fxW7+5QgUizAgxIoIGsksXVPPp1b0UTcwH/Ec/wgriNBKUMpIJK119d56EaURUyuBCeVBFakgpZbgAhUFAmiA6UEOmK6pa4QbEBELpgkoXAyc6nRHxoA/+q5w1leE/jJiTp+7RL6iBdP9F05cDnBR5Lkkl4XfJInwm5UB+hzXeAAsv+PiKG6gvoFDgUDIK9cZQJsBlnuf6ZdV/bT75NP6Iw39W9Z9tw7fUsAzqC/FPGgxhuU2/rT5x+l7O5vd1VLzCN3aUC7W+UFZQ8BlVrfGjrRPz+Ol7WahiYSOMZAGq/Nbsq5SVii/YwoXNemMh5slnDjr+cZYYVnBYdNBP92V++o/UUbmRiCsVK4YuaL0xGPAkwwUUb1EH9D2sY6I0FNDyb7KeOH3QOXwvDsNAGoNRoOLFYiHPtZDrbTGA/hQGcO5rK5lYfsLGz7vwNxihNMYohY/yaiDH32AQAcog/sdfKSYdzbojv9aHFbW+wMKmiHn81Ac8B4SBD7P4ou8Zz1DRRH2BrvsxUKYvunnFmJOnPoDCHzs9is36AiolrORoHUrp1LCDRJ8LvtFF4zzLoadSrYjJc0lJtB+jlR5yASGVBqyvPbNwm/o/2vIB3aa+AA2Qg6fvcayV4aLIUDlgxTdQF9Jus8pT1hdYc7A+mcoKVoCC6ZAD6jGbpWKfK1p5RbUDOfS/BP4h0aa0Gn4AAAAASUVORK5CYII=",
 			"mode": "bitmap"
 		},
 		{
 			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\lower_eye\\colorful_sclera.png",
-			"name": "colorful_sclera",
+			"name": "colorful_sclera.png",
 			"folder": "",
 			"namespace": "",
 			"id": "9",
@@ -2503,13 +2465,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "4c654000-464a-16cc-1468-37e092fa9283",
-			"relative_path": "../../../../../textures/custom/lower_eye/colorful_sclera.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAACgCAYAAAAFOewUAAAAAXNSR0IArs4c6QAAEXtJREFUaEOFWluMJNdZ/k5VV1dVX6t77jM7e/cFGww8BIkgiEIICFlYgBRFCQpCIsADEU9EfiDSCiSixDyscAgQSITAQcSAnMh58IONogRfFiXx4uDrrmd3vXPrnumevlZVV3dVHfSfqr+mpneS/NKqLuec7//+7/9OdU/1iu2/+JREGqOgh6rZAB0p6Hw+aGwYzDD1Pez2xhAEsDs8UPPoJkXRLqljzTROANK9Tn+gxvr+DK2jwTHARm0Z1+/cxHKz/iMXX1g5r+ZRZAC323cyxEcunz2RmegSk/nMq806bu0fJAwIIE+b66bF+dKoZoqyZcKxDbx6a/ekBpTpRy0eeRNUSxY2GhXFOGNAIuYFOy3z/GJKlAHk2/fjFnMHSOxrb9xMSqCb3F+umSi6kwD5zPnFdJ4BnLaYJhAABdXMkRf7xTe27jUSZebFrPZpi8mlz736vWMAciEv5gXUqnnaebEzBuQDdhjRzmcm0Hl3smMzDfLWJIdRZmaTX0xs3t3vKAs/uLF4bKQX335dqf3jFhMA70Q6f3u3A/Hmn/2OpFrIYQRC4QUBSqapjiuNZHOpVs+N0z1x+8n/lKZuAjEQRTNo0DBxJyg6FuLJDKWVJqb9Mcgs1k+dx+DFt+DUHXiOBvQ8iN2/eVYKU0fszlBaX8Bw4iJq9WEv1RFPZzA1CzN/gkq5Bk96CHoe/JGP6nId9uYSRPffvyMLF9YQXb+Dg519lBZrKDolhD0PxaUq0Kwi3GrDatYgZyHC9QZ6195EddlB/ew6xN0vfkMatgl3rwerVoLUBayVBQy2dlB2qhgEY9gzDZACZr2M2J/BWmvAP+jBDzyIw6dekH63D7tagz8aw7Jt6BUL054La70B33XhbndQPr8MceTDHYyhNy1oRxEmIoDY+dfnpTjyAMdG06rjcG8XlfVlRGsOorfuYnTQx/JD5xH4E+z8702sPHwOomQDvTH8iQfx/ce/JOuVOvSyhvLGEtpv3kHZsBELCd3UEAUxCqaO+oPnYGoGDt/cQvXcKmZjF8PtI4itz35NagWBcrOOWAdkGGOw08XSQ+dgXl6Hv3eI2cjFdO8IgTdFpVmDkED13BpGt/cgDr/6X9Ld6cK5uI5Jd4DC/WvwXr+D6uYK4pU6hi+/idVf/Tnsffu7KNtlTIaeSqIXCojCGcTtL39TmtAQdlzodRsz14eQAsZqHcFBH8VyCdO+q4zmnFtFEE4Qdj0UFkowRAFi9wvPSqNs4vaNW7j00H0Y9nowfB3G2RrCgxEQSBQsA2EUAkWB4koTlVDHwB8i9qcQO1/6prQrFWC9gcH1d1DdXEfk+9AvrsF/dQuRP4W9VEMUTFE2K/DoQ0sTCLYPETs2xM5ffV0KW8NsOoVzYQPDrT0UmmUUpMDQG6JYqcIyTUgZw2sdofrTl6H1PYz2DmCSlW//5dOyfv86OjfuIioCRqTBrNrQChoqlTp6222UyhUUHl7H5K1t+EcuZuEMznITw24fovv0t2UkBCb7HWhlE7P2CPb5BfjbPbUvyCyaH2G2aMOONFiLDrzZFJppQNvvQ2x97muyutZEMHQRRFM09Dr6wz60WgHNn3kQwZ19GLKA4VEXpUcuIry5D/dghPJGHUd3DyCufPyKdKpO8vAc9gEBOOX02usDIeDUctfUThoXQGvYgrj6B1dlq9sCNMApJQN9WhgBTiW9dvuJD+hafTfog54wlmFBXP2jq7J11IJjO+pfNoGYWLlrAqw7amF/1Ec/6MPSrKQEQlKTdSjKKuhcPfSg2KhnWiF7PKI/7qM9bENc+egVaZlWVvfxlHQxf4PScuBURtBHu9eGuPrJq7I1aKn6mbLKzgvjFJIA0ui7faVDosEfphoQQCqaWkwfkUyZSiDQFKw/6YNArAJrUEg1oHopCOC0c2JBIBoUQLtPGrCIRSfJyAsJiASlay6Jy0lb2R6QBuSDXkvR5zZyFqZMGVUQgJ4YjspINPj9FIA0SB2ZtY/LYfXmNdDzGqT2VVnSOjMv5IHyGlAJVz52RVpFK+kA1Uz1Ut0kJP07pY3KrV4qYtZG00msGkLVR8Gg6pqsbSZuJQ+QDmTARMTDdDMRizgF4F3Im4sAaa+kLVSbqWhBPP6Rx9VeIL8PJsk38bpdVxkHXnpt1VXmwXigAOp0DWDgDyD++CszKYpJnyzr2ASTiYScJgLYNR3rVWDDEdjtS+yNABqnUADqJAfCgwxA47/0cOGexacCZDsmZcRMmAVnJ3BKKj71VCT5go9UClGmoAX+MFKTLy4J3Do8Li0DUD7J1fu+zeNaaYwBCJgZ0WK6Fn/6H7HM36QsFHnBCIB1okRUDocC4AlcJw8SfSplazcBoLi0kSymMQWa14Cz5yfMd4SS5EvMAPLZGZ2AGCBfP7HgEhUATWQTEWVSmq/zAKcJmjmRM+SPzICFm3cnXWdOZJXngfJuZLeyXzInnjaQN1cenLuRtZ414IF87ZydTZP1Mj1RBssDnGZhmps3DoOQ2NStE13I+58Vz28iupefo0S874lrMpYSuhCIogjQ0me4jAFBX7IlIIQ6Ck2DjGNoPIecePmJa5I/cKSU0IQAASrhhFDPV3VNYwRAGy8mayd7RgHQQkhC1tVkWkiZUhQ1ptNYuoznKIBLn3spewWiKFMQTV3PPiLjFIypMwsCFZc+/0rySKOsUQRBC4miqj/VYa5/NJdSRcRWAWSCpWVwjSQeRa48pVFMJWmI4ohKeFnmVVXz6V8qJAOQaMcixklHiAG3UZXAAqaqU/vuKS0PpEpIGSTCkM7JtwvKdtyRpG2cNWGVtvqEiKlJFBiZijRQMqRM4pQ6H5lBqpRSXjkyNRT3V4FRkANTQXnsRBu5W9mnO5VEWfTkQcoa8TmBJQA0UaHP25XY577fcWdonp669v4nrkmiTOKJdDIZSWhkKDKSOLE/VCX5/UJdIHV503A7j5XOqlVgNJ54K1J7J3Uib1lSWT9pojQj63NiNxLgbzz3mjTsEsIwRm/PxepFB63bfSysmXCHIc6ebaJ9OEapoqNZtnFjq4eHHtnAna1tCL0I8aFn/k+aFj0DNCwtVbBzax9aoYiipaFULmImi4hnEUJhYTrowbQNCC1Go1HC3o4P8aGvvy4hCijaJkJ3CLtqYBpEyR+fdgHxLMbgaIbNS3V0OhNEkynqDR39bgC9VIf4wL99T9K+tiqG6uYsmGHiSyytmpj4QOz2MIltBG6MtUt19DpTtXmdxQIG7R7E+79yXepGjPJCBaODEZYvNhCGEkYB6LYnqNag/ug26FWhVkTBiOH2xtCKdRi6B/HzX35FOqs1rC+YsJeX8db1LWiGjWA8QaVhIpzOUHKqKBkxep0BwlhgY6UKaDpuvduC+O3nrkuUKvD6Yyws1zEZDAG7jL2bfVx+0EFvFGBwGKCxUYfr61h2IgSxwKjrwzAFxO9euyVlFGM0A4q6RGffw+Kyif4oxsK6g0Grj/VFG+2+h9mUzFOAO45QX61h0BpB/MI/X5dn7qtj0I9gl5Lnvz/20Vx2YCDGna0jNM4uA6MOuh165AFaQYfQBJwlE+IDX31F0tsavWhg4gZYXSnBncYoIEZ714VZLkIvCLjDGYRuolSOAV1Hs2Zg+70JxAef/oE0SjrcvX00LpzFoNWFUW3AMkMMOlMsnW9gcBDArghMRh5W1qooOA4Ob+/DG8wgPvnKlhxGAq27LmbjEarLNcz8KZbOVGFoAnvbY2WooimglWrKjUZRQ0hfNKMA4iMvvyf33u1iddPGNC4i9CfwxgFWNx0cvteG70pc/sk1jP0AlgF0jiJUHBMzz8eoN4P4zRfelr1uiHMbJrZvt7C0uYTduyOcvVjHXkviJy6WsdOdIfAD2DbQ70xxZtOGNxOY+hOIX37mdRl6U5QcA4P9MRY2HfTaLmpNC2EENOsaQs2Ae3gEPzBQX6sh9Fz1bKg3qxAffuY1Oe7FWDlvYdgZYenyWbgHPQRjF0bNQUGbodcFNOmhVLXgjUOlR7lm4OBOD+JPXvqn7MP1sDvC0kLyLTt/nv9opPsevd3yWji8M0oA6CYHDwaj5F1y9WztnjG6QePdG28cA1DmW9d31QICidpj6CsVlExNXdNx2tvDxuUH1DyKEwCju0MMu/vY+NkH1CBNLjbW1Tmz4sw0b+l8Fa2XthIG7+0NVE0UYWn1RFZeTPeJlVlNfmOgyAB2330nW0xAnDkvHjEiEBrnYwZAIvIEqvW0yDMhEBKx94PXjkVkoehIwUD5+ikzBZdygkG+jXzOIPPs6PqEBmyOfNZ8+/LgdJ86RmLuff+9k13IdyBfRr6VVDv5g3TIALgL3MZ8J1gD6gxlpqDsdH3nhVcgPvbskzLvMO5zng27koDZicSi8/xLCQAjs8OIJmch8Pw1O7bx0H0JADsx3x7eSJSFsnPwPuHrg//+n4QB1ZIPbRIitgqgYz7oHgWP07n4+JOPqefB2O+hWU9+X5xOk2sKu3i8nfNz6HNyOpkmAEWreI97aZBC1yMFOB+93gFW1s5A/N7fPyYJDfE0y1yxEyaUUf0VA4DuFYvH7PhaPPb5X5TNxoqiQwtmkxkMy1DlUGYGyDOgeQRAx6yEo15bLaZoNJaz+YNxR00myjzGAJmIeWq8kssgDajE9v6OYsb3eV7CYK62PF0FkHaG75/K4GhwXBeVwmX8MA1YI/HRq48qBgyQrzVp4/HrDmagWriyrERWANyyfH1cFgPQItJgvqXi0c++X+b7Pi8SAbArT/NDBsAZ5x3HDNgjNM70lQ8+8cVHJVtVWTp1JE0k2ouL9N0g2Rd5k2V7gQDa7cQk+Rp5ETGY10ZN5s30ib/7LZk3CZVywgeGPV9Vdq12o2rjHHXuCh3rlcV7AE4YaX/neTmiN5q09ytV+OMRZu4ItZV1df7D7g3be2qOeOPFv5VGOflSQQvpnI4UNOHo9g0UShU0z98HSrRw5kHsXP8W7KU1VJdWIbZvfkNSJv9wX02k4Mnz3OcTUDJx4/pTkmhSEC1mQNmZJo9xWQxE97MSiFp35+1T62cd8mWyZopBHpHZ0AQWlFjRfWaYB1IMuGYWb/WB96H1zndPCBp6YyXcvNj3MMizmRdNubVcVepTR2g80yBfJ9OlrNQZFpRLyZcm2Ej5zEyTM1KLif68VqSJKoEn5F2Xz5Z3KfuFx1UJnGnezjyJfcDGYq8oI7GV2f9sHq6TOlQ0HXj93aytnJAYZ1Zm+nQk/1PN+Xv5jXXCB2xlnlByNlQ2NtI8CGnQvHC/YqOszJspP3F+8bz6eTbiC5/+FelUDSwvJD86mFYJR4M+mvRzSRrBxFP3KejcDyLYpq6OGUC5YqNsFk8AxIgwmwQomCZ0oUMrFOCPh2qh6szQg/jHz/yatIoaCGA8DHBmcxHDgQenXlXZmNXI81Cv1RRA+3CEcrWC0WiQANCLg4XFqgKo1Oh3cB11p5r9DymizwBhGGCH/jtBtQJdxBD/8ue/LoMgPAFA9dMC+tWE/iQuaIa6rpYSHSi6fRc7rYNUg0oRy4s1uMFUUS8UTAyGQwVA9RuGqahb1eS/UdBiigzAMIALG4sKgLKTWARgW0l2Fo8W0Q8hY89HsWDBHY0TBgRADKh2YkBBlEt2oj4FdaQ/GMEwihlAp9dJu2DosEsWCjqJV1G/s7tekKluV2qIw1D5gwBIi/1OFzM/TBhsrNUy5JVFR703CcI4AyDatIhYEDCd391uww8nEH/96Q/KZsWG06wpahXTQtFI3pexK8lgxVIZMg7VX/b0hoe8oAD+4TMflmdWFtRPyyoieQ8A3W406KteT7l1nP5MRj9gK4CFRhXuKEBjoQqzkLw/p+xsZeqOVdAxCSNIaSj16X8AlIxiWkLNUu9inUZd9Z7CsEy1DyhIxE63o7ITdQoCKJuFBKBkFLC06KguUH0cxIJ3InWAAcjGFIdHR8e7cXMj+dDIbyC+zm9lFpfcSAD/D+DKXk3yYAjVAAAAAElFTkSuQmCC",
 			"mode": "bitmap"
 		},
 		{
 			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.2-pre1\\1.20.2-pre1\\assets\\minecraft\\textures\\block\\granite.png",
-			"name": "granite",
+			"name": "granite.png",
 			"folder": "",
 			"namespace": "",
 			"id": "10",
@@ -2531,13 +2492,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "3d89c770-6065-095c-0841-9b339bb90675",
-			"relative_path": "C:/Users/afro/AppData/Roaming/.minecraft/versions/1.20.2-pre1/1.20.2-pre1/assets/minecraft/textures/block/granite.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAcNJREFUOE9dU71LQnEUvW+K0hbjFQT2hQ2ZghQlbg3VEDQU9DE5tfUHNPY3tNRQ0NISQVNFIJVLFEURaAYm+koISmxJiybjXDmvn97l/T7u79xzzz3POtreqJUeruTr51faW1vEKX1Kn+0TBM+wPrxJy/x4SGx/r5SKL3rf5vWKtbu6XEPiXb4oM9GIfFcqEgwNycnFpQsEUASBue/weuoAycecTAwHNImV8e2yOyRTeNWHkwtLsrO5pWvmg00DgEkZlwenZwoMqoj3UlnKlaqgMtpFWOuL0zUegBrWSHI+6rRHB/wyEJuQai6l7aEIgnopAxzgcbC/x63EBACBhfnQjsTkNnGs7SgDikOq7JuamOBmK9oCGJijAzrHmkg9y0h/t7aDCSEITkYKAMHy2awrTHNFPEKY4rGotb+2ohpAYXNsJgir0kR8rEYigCcQlvxVUg0F0ZgEqtGxiGTST8oC52ipr9OnorsAGBEMQjcy+b7wpjqYLsTDvfNrmQoPijU7FqphQYPgy2SCYA8m5h32c/H4/7+A/ptVRjugCvF4D63oQneM+Hkcp9hgV46O7iMA9g1Gooi4QOASYjJI2/SK6dw/1UxBFKrZrfwAAAAASUVORK5CYII=",
 			"mode": "bitmap"
 		},
 		{
 			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\lower_eye\\granite_inner_eye.png",
-			"name": "granite_inner_eye",
+			"name": "granite_inner_eye.png",
 			"folder": "",
 			"namespace": "",
 			"id": "11",
@@ -2559,11 +2519,57 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "430ffeff-a100-d7bc-2362-4a3980e59ff5",
-			"relative_path": "../../../../../textures/custom/lower_eye/granite_inner_eye.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAcNJREFUOE9dU71LQnEUvW+K0hbjFQT2hQ2ZghQlbg3VEDQU9DE5tfUHNPY3tNRQ0NISQVNFIJVLFEURaAYm+koISmxJiybjXDmvn97l/T7u79xzzz3POtreqJUeruTr51faW1vEKX1Kn+0TBM+wPrxJy/x4SGx/r5SKL3rf5vWKtbu6XEPiXb4oM9GIfFcqEgwNycnFpQsEUASBue/weuoAycecTAwHNImV8e2yOyRTeNWHkwtLsrO5pWvmg00DgEkZlwenZwoMqoj3UlnKlaqgMtpFWOuL0zUegBrWSHI+6rRHB/wyEJuQai6l7aEIgnopAxzgcbC/x63EBACBhfnQjsTkNnGs7SgDikOq7JuamOBmK9oCGJijAzrHmkg9y0h/t7aDCSEITkYKAMHy2awrTHNFPEKY4rGotb+2ohpAYXNsJgir0kR8rEYigCcQlvxVUg0F0ZgEqtGxiGTST8oC52ipr9OnorsAGBEMQjcy+b7wpjqYLsTDvfNrmQoPijU7FqphQYPgy2SCYA8m5h32c/H4/7+A/ptVRjugCvF4D63oQneM+Hkcp9hgV46O7iMA9g1Gooi4QOASYjJI2/SK6dw/1UxBFKrZrfwAAAAASUVORK5CYII=",
 			"mode": "bitmap"
 		}
 	],
+	"variants": {
+		"default": {
+			"display_name": "default",
+			"name": "default",
+			"uuid": "6fde0b59-c952-3d58-4087-1bfa481a613d",
+			"texture_map": {},
+			"excluded_bones": []
+		},
+		"list": [
+			{
+				"display_name": "bright",
+				"name": "bright",
+				"uuid": "0463c19a-d0e3-3f38-c2fa-9e3b26443e96",
+				"texture_map": {
+					"43c7499b-810c-e305-aa49-1e7c13c77d34": "6a66d687-6cf4-c706-b428-fa07ee115882",
+					"aff1612c-e069-f3fa-76b8-d53c474570a6": "d24c4edd-98f9-71e3-31f3-bc89d06b79ba",
+					"91f4647e-d482-ceca-1b5c-12a72e28cad1": "d24c4edd-98f9-71e3-31f3-bc89d06b79ba",
+					"430ffeff-a100-d7bc-2362-4a3980e59ff5": "d24c4edd-98f9-71e3-31f3-bc89d06b79ba"
+				},
+				"excluded_bones": []
+			},
+			{
+				"display_name": "colorful",
+				"name": "colorful",
+				"uuid": "6659e3dc-75cd-b379-5cc7-3bc2cc56a15a",
+				"texture_map": {
+					"43c7499b-810c-e305-aa49-1e7c13c77d34": "4c654000-464a-16cc-1468-37e092fa9283",
+					"aff1612c-e069-f3fa-76b8-d53c474570a6": "8ea9aaaa-6fd6-ff19-df07-073e7ac43c4d",
+					"91f4647e-d482-ceca-1b5c-12a72e28cad1": "ae3d3116-819d-9cbe-6043-ff4b64e46b3f",
+					"430ffeff-a100-d7bc-2362-4a3980e59ff5": "4c654000-464a-16cc-1468-37e092fa9283"
+				},
+				"excluded_bones": []
+			},
+			{
+				"display_name": "dark",
+				"name": "dark",
+				"uuid": "b91ac4d2-5302-2bde-859e-84985699299b",
+				"texture_map": {
+					"43c7499b-810c-e305-aa49-1e7c13c77d34": "d47619a9-94ae-577b-9b1c-5212504c43a5",
+					"aff1612c-e069-f3fa-76b8-d53c474570a6": "d47619a9-94ae-577b-9b1c-5212504c43a5",
+					"91f4647e-d482-ceca-1b5c-12a72e28cad1": "7af71311-1188-adbb-0391-ffa2173d1081",
+					"430ffeff-a100-d7bc-2362-4a3980e59ff5": "d47619a9-94ae-577b-9b1c-5212504c43a5"
+				},
+				"excluded_bones": []
+			}
+		]
+	},
 	"animations": [
 		{
 			"uuid": "64924b82-61bb-82ea-08a9-4ca50fb9d0e3",
@@ -2572,13 +2578,14 @@
 			"override": false,
 			"length": 6,
 			"snapping": 20,
-			"selected": false,
+			"selected": true,
+			"saved": true,
+			"path": "",
 			"anim_time_update": "",
 			"blend_weight": "",
 			"start_delay": "",
 			"loop_delay": "",
-			"affected_bones": [],
-			"affected_bones_is_a_whitelist": false,
+			"excluded_bones": [],
 			"animators": {
 				"f13c55d0-8667-840d-3540-9fdda50cfc40": {
 					"name": "root",
@@ -2601,7 +2608,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2620,7 +2629,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2639,7 +2650,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2658,7 +2671,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2677,7 +2692,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2696,7 +2713,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2715,7 +2734,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2734,7 +2755,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2753,7 +2776,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2772,7 +2797,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2791,7 +2818,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2810,7 +2839,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2829,7 +2860,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2848,7 +2881,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2867,7 +2902,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2886,7 +2923,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2905,7 +2944,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2924,7 +2965,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2943,7 +2986,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2962,7 +3007,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -2981,7 +3028,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3000,7 +3049,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3019,7 +3070,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3038,7 +3091,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3057,7 +3112,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -3082,7 +3139,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3101,7 +3160,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3120,7 +3181,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3139,7 +3202,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3158,7 +3223,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3177,7 +3244,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3196,7 +3265,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3215,7 +3286,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3234,7 +3307,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3253,7 +3328,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3272,7 +3349,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3291,7 +3370,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3310,7 +3391,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3329,7 +3412,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3348,7 +3433,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3367,7 +3454,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3386,7 +3475,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3405,7 +3496,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3424,7 +3517,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3443,7 +3538,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3462,7 +3559,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3481,7 +3580,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3500,7 +3601,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3519,7 +3622,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3538,7 +3643,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3557,7 +3664,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3576,7 +3685,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3595,7 +3706,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3614,7 +3727,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3633,7 +3748,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3652,7 +3769,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3671,7 +3790,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3690,7 +3811,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3709,7 +3832,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3728,7 +3853,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3747,7 +3874,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3766,7 +3895,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3785,7 +3916,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3804,7 +3937,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3823,7 +3958,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -3842,7 +3979,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3861,7 +4000,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3880,7 +4021,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3899,7 +4042,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3918,7 +4063,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3937,7 +4084,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3956,7 +4105,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3975,7 +4126,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -3994,7 +4147,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4013,7 +4168,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4032,7 +4189,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4051,7 +4210,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4070,7 +4231,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4089,7 +4252,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4108,7 +4273,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4127,7 +4294,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4146,7 +4315,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4165,7 +4336,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4184,7 +4357,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4203,7 +4378,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4222,7 +4399,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4241,7 +4420,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4260,7 +4441,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4279,7 +4462,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4298,7 +4483,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4317,7 +4504,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4336,7 +4525,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4355,7 +4546,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4374,7 +4567,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4393,7 +4588,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4412,7 +4609,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -4431,7 +4630,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -4457,7 +4658,9 @@
 							"bezier_left_time": [-0.04332, -0.04332, -0.04332],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.04332, 0.04332, 0.04332],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4477,7 +4680,9 @@
 							"bezier_left_time": [-0.14993, -0.15128, -0.1],
 							"bezier_left_value": [-0.00566, -0.00566, 0],
 							"bezier_right_time": [0.14993, 0.15128, 0.1],
-							"bezier_right_value": [0.00566, 0.00566, 0]
+							"bezier_right_value": [0.00566, 0.00566, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4497,7 +4702,9 @@
 							"bezier_left_time": [-0.04332, -0.04332, -0.04332],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.04332, 0.04332, 0.04332],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4517,7 +4724,9 @@
 							"bezier_left_time": [-0.14993, -0.15128, -0.1],
 							"bezier_left_value": [-0.00566, -0.00566, 0],
 							"bezier_right_time": [0.14993, 0.15128, 0.1],
-							"bezier_right_value": [0.00566, 0.00566, 0]
+							"bezier_right_value": [0.00566, 0.00566, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4537,7 +4746,9 @@
 							"bezier_left_time": [-0.04332, -0.04332, -0.04332],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.04332, 0.04332, 0.04332],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4557,7 +4768,9 @@
 							"bezier_left_time": [-0.14993, -0.15128, -0.1],
 							"bezier_left_value": [-0.00566, -0.00566, 0],
 							"bezier_right_time": [0.14993, 0.15128, 0.1],
-							"bezier_right_value": [0.00566, 0.00566, 0]
+							"bezier_right_value": [0.00566, 0.00566, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4577,7 +4790,9 @@
 							"bezier_left_time": [-0.04332, -0.04332, -0.04332],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.04332, 0.04332, 0.04332],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4597,7 +4812,9 @@
 							"bezier_left_time": [-0.14993, -0.15128, -0.1],
 							"bezier_left_value": [-0.00566, -0.00566, 0],
 							"bezier_right_time": [0.14993, 0.15128, 0.1],
-							"bezier_right_value": [0.00566, 0.00566, 0]
+							"bezier_right_value": [0.00566, 0.00566, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4617,7 +4834,9 @@
 							"bezier_left_time": [-0.04332, -0.04332, -0.04332],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.04332, 0.04332, 0.04332],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4637,7 +4856,9 @@
 							"bezier_left_time": [-0.14993, -0.15128, -0.1],
 							"bezier_left_value": [-0.00566, -0.00566, 0],
 							"bezier_right_time": [0.14993, 0.15128, 0.1],
-							"bezier_right_value": [0.00566, 0.00566, 0]
+							"bezier_right_value": [0.00566, 0.00566, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4657,7 +4878,9 @@
 							"bezier_left_time": [-0.04332, -0.04332, -0.04332],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.04332, 0.04332, 0.04332],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4677,7 +4900,9 @@
 							"bezier_left_time": [-0.14993, -0.15128, -0.1],
 							"bezier_left_value": [-0.00566, -0.00566, 0],
 							"bezier_right_time": [0.14993, 0.15128, 0.1],
-							"bezier_right_value": [0.00566, 0.00566, 0]
+							"bezier_right_value": [0.00566, 0.00566, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4697,7 +4922,9 @@
 							"bezier_left_time": [-0.04332, -0.04332, -0.04332],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.04332, 0.04332, 0.04332],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4717,7 +4944,9 @@
 							"bezier_left_time": [-0.14993, -0.15128, -0.1],
 							"bezier_left_value": [-0.00566, -0.00566, 0],
 							"bezier_right_time": [0.14993, 0.15128, 0.1],
-							"bezier_right_value": [0.00566, 0.00566, 0]
+							"bezier_right_value": [0.00566, 0.00566, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4737,7 +4966,9 @@
 							"bezier_left_time": [-0.04332, -0.04332, -0.04332],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.04332, 0.04332, 0.04332],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4757,7 +4988,9 @@
 							"bezier_left_time": [-0.14993, -0.15128, -0.1],
 							"bezier_left_value": [-0.00566, -0.00566, 0],
 							"bezier_right_time": [0.14993, 0.15128, 0.1],
-							"bezier_right_value": [0.00566, 0.00566, 0]
+							"bezier_right_value": [0.00566, 0.00566, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4777,7 +5010,9 @@
 							"bezier_left_time": [-0.04332, -0.04332, -0.04332],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.04332, 0.04332, 0.04332],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4797,7 +5032,9 @@
 							"bezier_left_time": [-0.14993, -0.15128, -0.1],
 							"bezier_left_value": [-0.00566, -0.00566, 0],
 							"bezier_right_time": [0.14993, 0.15128, 0.1],
-							"bezier_right_value": [0.00566, 0.00566, 0]
+							"bezier_right_value": [0.00566, 0.00566, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4817,7 +5054,9 @@
 							"bezier_left_time": [-0.04332, -0.04332, -0.04332],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.04332, 0.04332, 0.04332],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4837,7 +5076,9 @@
 							"bezier_left_time": [-0.14993, -0.15128, -0.1],
 							"bezier_left_value": [-0.00566, -0.00566, 0],
 							"bezier_right_time": [0.14993, 0.15128, 0.1],
-							"bezier_right_value": [0.00566, 0.00566, 0]
+							"bezier_right_value": [0.00566, 0.00566, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4857,7 +5098,9 @@
 							"bezier_left_time": [-0.04332, -0.04332, -0.04332],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.04332, 0.04332, 0.04332],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4877,7 +5120,9 @@
 							"bezier_left_time": [-0.14993, -0.15128, -0.1],
 							"bezier_left_value": [-0.00566, -0.00566, 0],
 							"bezier_right_time": [0.14993, 0.15128, 0.1],
-							"bezier_right_value": [0.00566, 0.00566, 0]
+							"bezier_right_value": [0.00566, 0.00566, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4897,7 +5142,9 @@
 							"bezier_left_time": [-0.04332, -0.04332, -0.04332],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.04332, 0.04332, 0.04332],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4917,7 +5164,9 @@
 							"bezier_left_time": [-0.14993, -0.15128, -0.1],
 							"bezier_left_value": [-0.00566, -0.00566, 0],
 							"bezier_right_time": [0.14993, 0.15128, 0.1],
-							"bezier_right_value": [0.00566, 0.00566, 0]
+							"bezier_right_value": [0.00566, 0.00566, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4937,7 +5186,9 @@
 							"bezier_left_time": [-0.04332, -0.04332, -0.04332],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.04332, 0.04332, 0.04332],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4957,7 +5208,9 @@
 							"bezier_left_time": [-0.14993, -0.15128, -0.1],
 							"bezier_left_value": [-0.00566, -0.00566, 0],
 							"bezier_right_time": [0.14993, 0.15128, 0.1],
-							"bezier_right_value": [0.00566, 0.00566, 0]
+							"bezier_right_value": [0.00566, 0.00566, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4977,7 +5230,9 @@
 							"bezier_left_time": [-0.04332, -0.04332, -0.04332],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.04332, 0.04332, 0.04332],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -4997,7 +5252,9 @@
 							"bezier_left_time": [-0.14993, -0.15128, -0.1],
 							"bezier_left_value": [-0.00566, -0.00566, 0],
 							"bezier_right_time": [0.14993, 0.15128, 0.1],
-							"bezier_right_value": [0.00566, 0.00566, 0]
+							"bezier_right_value": [0.00566, 0.00566, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -5017,7 +5274,9 @@
 							"bezier_left_time": [-0.04332, -0.04332, -0.04332],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.04332, 0.04332, 0.04332],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -5037,7 +5296,9 @@
 							"bezier_left_time": [-0.04332, -0.04332, -0.04332],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.04332, 0.04332, 0.04332],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -5057,7 +5318,9 @@
 							"bezier_left_time": [-0.14993, -0.15128, -0.1],
 							"bezier_left_value": [-0.00566, -0.00566, 0],
 							"bezier_right_time": [0.14993, 0.15128, 0.1],
-							"bezier_right_value": [0.00566, 0.00566, 0]
+							"bezier_right_value": [0.00566, 0.00566, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -5082,7 +5345,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5101,7 +5366,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5120,7 +5387,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5139,7 +5408,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5158,7 +5429,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5177,7 +5450,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5196,7 +5471,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5215,7 +5492,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5234,7 +5513,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5253,7 +5534,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5272,7 +5555,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5291,7 +5576,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5310,7 +5597,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5329,7 +5618,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5348,7 +5639,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5367,7 +5660,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5386,7 +5681,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5405,7 +5702,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5424,7 +5723,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5443,7 +5744,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5462,7 +5765,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5481,7 +5786,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5500,7 +5807,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5519,7 +5828,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5538,7 +5849,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5557,7 +5870,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5576,7 +5891,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5595,7 +5912,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5614,7 +5933,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5633,7 +5954,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5652,7 +5975,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5671,7 +5996,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5690,7 +6017,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5709,7 +6038,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5728,7 +6059,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5747,7 +6080,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5766,7 +6101,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5785,7 +6122,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5804,7 +6143,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5823,7 +6164,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -5842,7 +6185,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5861,7 +6206,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5880,7 +6227,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5899,7 +6248,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5918,7 +6269,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5937,7 +6290,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5956,7 +6311,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5975,7 +6332,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -5994,7 +6353,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6013,7 +6374,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6032,7 +6395,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6051,7 +6416,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6070,7 +6437,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6089,7 +6458,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6108,7 +6479,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6127,7 +6500,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6146,7 +6521,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6165,7 +6542,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6184,7 +6563,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6203,7 +6584,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6222,7 +6605,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6241,7 +6626,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6260,7 +6647,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6279,7 +6668,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6298,7 +6689,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6317,7 +6710,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6336,7 +6731,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6355,7 +6752,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6374,7 +6773,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6393,7 +6794,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6412,7 +6815,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6431,7 +6836,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -6456,7 +6863,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6475,7 +6884,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6494,7 +6905,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6513,7 +6926,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6532,7 +6947,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6551,7 +6968,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6570,7 +6989,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6589,7 +7010,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6608,7 +7031,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6627,7 +7052,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6646,7 +7073,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6665,7 +7094,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6684,7 +7115,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6703,7 +7136,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6722,7 +7157,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6741,7 +7178,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6760,7 +7199,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6779,7 +7220,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6798,7 +7241,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6817,7 +7262,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6836,7 +7283,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6855,7 +7304,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6874,7 +7325,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6893,7 +7346,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6912,7 +7367,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6931,7 +7388,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6950,7 +7409,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6969,7 +7430,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -6988,7 +7451,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7007,7 +7472,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7026,7 +7493,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7045,7 +7514,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7064,7 +7535,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7083,7 +7556,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7102,7 +7577,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7121,7 +7598,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7140,7 +7619,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7159,7 +7640,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7178,7 +7661,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7197,7 +7682,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7216,7 +7703,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7235,7 +7724,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7254,7 +7745,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7273,7 +7766,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7292,7 +7787,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7311,7 +7808,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7330,7 +7829,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7349,7 +7850,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7368,7 +7871,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7387,7 +7892,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7406,7 +7913,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7425,7 +7934,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7444,7 +7955,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7463,7 +7976,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7482,7 +7997,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7501,7 +8018,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7520,7 +8039,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7539,7 +8060,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7558,7 +8081,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7577,7 +8102,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7596,7 +8123,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7615,7 +8144,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7634,7 +8165,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7653,7 +8186,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7672,7 +8207,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7691,7 +8228,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7710,7 +8249,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7729,7 +8270,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7748,7 +8291,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7767,7 +8312,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7786,7 +8333,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7805,7 +8354,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -7830,7 +8381,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7849,7 +8402,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7868,7 +8423,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7887,7 +8444,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7906,7 +8465,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7925,7 +8486,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7944,7 +8507,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7963,7 +8528,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -7982,7 +8549,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -8001,7 +8570,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -8020,7 +8591,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -8039,7 +8612,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -8058,7 +8633,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -8077,7 +8654,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -8096,7 +8675,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -8115,7 +8696,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -8134,7 +8717,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -8153,7 +8738,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -8172,7 +8759,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -8191,7 +8780,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -8210,7 +8801,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -8229,7 +8822,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -8248,7 +8843,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -8267,7 +8864,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "rotation",
@@ -8286,7 +8885,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8305,7 +8906,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8324,7 +8927,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8343,7 +8948,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8362,7 +8969,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8381,7 +8990,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8400,7 +9011,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8419,7 +9032,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8438,7 +9053,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8457,7 +9074,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8476,7 +9095,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8495,7 +9116,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8514,7 +9137,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8533,7 +9158,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8552,7 +9179,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8571,7 +9200,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8590,7 +9221,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8609,7 +9242,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8628,7 +9263,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8647,7 +9284,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8666,7 +9305,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8685,7 +9326,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8704,7 +9347,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8723,7 +9368,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8742,7 +9389,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8761,7 +9410,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8780,7 +9431,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8799,7 +9452,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8818,7 +9473,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8837,7 +9494,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8856,7 +9515,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8875,11 +9536,14 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				}
 			}
 		}
-	]
+	],
+	"animation_controllers": []
 }


### PR DESCRIPTION
# Summary

This PR migrates the `lower-eye` AJ model file so we can summon it in-game again for Minecraft 1.21.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Reproducing in-game

```mcfunction
function _:summon
```

---

## Supplemental changes

N/A

<!--
describe what other changes this PR makes which aren't specific to its main purpose.
- does it contain a world backup? (recommended)
- does it contain other miscellaneous code cleanup?

format these extra changes with bullet points, preferrably.
-->
