### PR TITLE
⬆️ 🍱 migrate `nose` model to AJ v1.0

### DIFF
--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon.mcfunction
@@ -32,7 +32,7 @@ execute positioned 14 48 -6.5 rotated -160 -40 run function animated_java:petal_
 tag @e[tag=aj.petal_pipe_middle.root,tag=!petal_pipe.right] add petal_pipe.left
 
 ## Nose
-execute positioned 0 37 -13 rotated 0 10 run function animated_java:nose/summon
+execute positioned 0 37 -13 rotated 0 10 run function animated_java:nose/summon { args: {} }
 
 ## TV-screen
 execute positioned 0 49 -6 rotated 0 45 run function animated_java:tv_screen/summon { args: {} }

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/nose.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/nose.ajblueprint
@@ -1,55 +1,32 @@
 {
 	"meta": {
-		"format": "animated_java/ajmodel",
-		"format_version": "0.4.8",
-		"uuid": "be34281d-956c-1cd2-17a4-83f1c471a265"
+		"format": "animated_java_blueprint",
+		"format_version": "0.5.3",
+		"uuid": "be34281d-956c-1cd2-17a4-83f1c471a265",
+		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\nose.ajblueprint",
+		"last_used_export_namespace": "nose"
 	},
-	"animated_java": {
-		"settings": {
-			"project_namespace": "nose",
-			"project_resolution": [16, 16],
-			"target_minecraft_version": "1.20+",
-			"rig_item": "minecraft:white_dye",
-			"rig_item_model": "",
-			"rig_export_folder": "",
-			"texture_export_folder": "",
-			"enable_advanced_resource_pack_settings": false,
-			"resource_pack_mcmeta": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\pack.mcmeta",
-			"verbose": true,
-			"exporter": "animated_java:datapack_exporter"
-		},
-		"exporter_settings": {
-			"animated_java:datapack_exporter": {
-				"datapack_mcmeta": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java\\pack.mcmeta",
-				"outdated_rig_warning": true,
-				"root_entity_nbt": "{Tags:[\"omega-flowey-remastered\", \"omega-flowey\", \"omega-flowey-nose\"]}",
-				"use_component_system": true,
-				"include_variant_summon_functions": true,
-				"include_apply_variant_functions": true,
-				"include_uninstall_function": true,
-				"include_pause_all_animations_function": true,
-				"include_remove_rigs_function": true,
-				"include_remove_all_function": true,
-				"include_on_load_function_tags": true,
-				"include_on_tick_function_tags": true,
-				"include_on_summon_function_tags": true,
-				"include_on_remove_function_tags": true
-			},
-			"animated_java:json_exporter": {
-				"output_file": ""
-			}
-		},
-		"variants": [
-			{
-				"name": "default",
-				"textureMap": {},
-				"uuid": "05d4ccab-be17-d1b2-6e1d-e8844e64c952",
-				"boneConfig": {},
-				"default": true,
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			}
-		]
+	"project_settings": {
+		"export_namespace": "nose",
+		"show_bounding_box": false,
+		"auto_bounding_box": true,
+		"bounding_box": [48, 48],
+		"enable_plugin_mode": false,
+		"enable_resource_pack": true,
+		"enable_data_pack": true,
+		"display_item": "minecraft:white_dye",
+		"customModelDataOffset": 0,
+		"enable_advanced_resource_pack_settings": false,
+		"resource_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\",
+		"display_item_path": "",
+		"model_folder": "",
+		"texture_folder": "",
+		"enable_advanced_data_pack_settings": false,
+		"data_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java\\",
+		"summon_commands": "tag @s add omega-flowey-remastered\ntag @s add omega-flowey\ntag @s add omega-flowey-nose",
+		"interpolation_duration": 1,
+		"teleportation_duration": 1,
+		"use_storage_for_animation": false
 	},
 	"resolution": {
 		"width": 16,
@@ -718,7 +695,10 @@
 			"name": "root",
 			"origin": [0, 0, 0],
 			"color": 0,
-			"nbt": "{}",
+			"configs": {
+				"default": {},
+				"variants": {}
+			},
 			"uuid": "3e980009-746b-23da-6f81-346ab60a3a0c",
 			"export": true,
 			"mirror_uv": false,
@@ -731,7 +711,10 @@
 					"name": "nostril",
 					"origin": [0, 0, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "4dd51fae-e544-e85d-8e08-322e9915fe99",
 					"export": true,
 					"mirror_uv": false,
@@ -744,7 +727,10 @@
 							"name": "left",
 							"origin": [0, -19, 0],
 							"color": 0,
-							"nbt": "{}",
+							"configs": {
+								"default": {},
+								"variants": {}
+							},
 							"uuid": "e58dce37-cd7d-711f-d42d-35ed00ea415a",
 							"export": true,
 							"mirror_uv": false,
@@ -765,7 +751,10 @@
 							"name": "right",
 							"origin": [0, -19, 0],
 							"color": 0,
-							"nbt": "{}",
+							"configs": {
+								"default": {},
+								"variants": {}
+							},
 							"uuid": "44b82a9d-0789-5d04-3c70-3f4b21a8ccd3",
 							"export": true,
 							"mirror_uv": false,
@@ -788,7 +777,10 @@
 					"name": "base",
 					"origin": [0, 0, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "4861a2de-002c-efa9-dc2e-3abaa4952e2c",
 					"export": true,
 					"mirror_uv": false,
@@ -809,7 +801,7 @@
 	"textures": [
 		{
 			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.1\\1.20.1\\assets\\minecraft\\textures\\block\\polished_granite.png",
-			"name": "polished_granite",
+			"name": "polished_granite.png",
 			"folder": "",
 			"namespace": "",
 			"id": "0",
@@ -831,13 +823,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "da3f0805-a312-9c45-8a17-34a6689c6ced",
-			"relative_path": "C:/Users/afro/AppData/Roaming/.minecraft/versions/1.20.1/1.20.1/assets/minecraft/textures/block/polished_granite.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAWJJREFUOE99U7tKA1EQnQVBza6oCVuKYpFaBYt0Vn6Cv2IpdrZWFv5GPiBdCEFNoRGCrNFUuiQq7kYFYeVMmOvJZsk0c/fuPM6cOddrXZxmQhYvrEn4+y7xx1jC1ZJ6GJ/Tt6H46xWB91Cge3svn18/GriyvKge3ziXgkDGSeJacBzOXv3yPIs7TQl3agIPQxKME/vxSLbC8gTNxqbEgydp3D38I7AWFmidDJUVfYmHDili3QjMg52RxAkcgwbDJBWvfnacta9vpBL4OnOeC0vC/XbtQKJmw/HkELTaHUeYza4J1arOWmT4fxUN5o+ADoasiFxFgBGiXk8R4AI2L8lGBDrkaYE8zCJNsEZ4Y6oDJqZwYNo9F59ZI8SEYtyNBcSdMeYUiUXqYz3wdqyBKtFIzL8DiGR/b9et0d4Gb6P7+DxLIgfao8oTaO9GEZwcHWb918n6YKP0W33ZX5q642+O+wNIixCo6WvjfQAAAABJRU5ErkJggg==",
 			"mode": "bitmap"
 		},
 		{
 			"path": "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.1\\1.20.1\\assets\\minecraft\\textures\\block\\coal_block.png",
-			"name": "coal_block",
+			"name": "coal_block.png",
 			"folder": "",
 			"namespace": "",
 			"id": "1",
@@ -859,11 +850,20 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "32d4af31-9048-91f1-6cfc-23cd06b2bb9a",
-			"relative_path": "C:/Users/afro/AppData/Roaming/.minecraft/versions/1.20.1/1.20.1/assets/minecraft/textures/block/coal_block.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAQlJREFUOE+FU0EKgzAQTA6CBgSt9WAP9v9/q+ApemuZhQmTxaIg0c3uZGd2Et/r+g0hhHwcWMJ5nqFtW/ve993WYRjKHvbxIAdvnOfZALQYSUwkAGMsTF1nNQbgC5ikXfAQdsP/2Pe9AWhbz2kKOedCi8mg5OnEpmmMgm+NmpAaDwGAdmwUFJmn+UKNK0XrAIHHOFaTIAC701XBDECF8WojGYqnlCpdmFcAyJE+QFcc1T89bIxeRAKgWM1FSq9lsThNVnyAE9WFVyLqCKlJhJWBSE4ck4qmY9MJoMtCQS2Lb0xFhVNq2Ce9CkDNhOLPtlUXyusC0EsnKiV1KedfORF3gddXExi7E/YHpAf5qSjgElwAAAAASUVORK5CYII=",
 			"mode": "bitmap"
 		}
 	],
+	"variants": {
+		"default": {
+			"display_name": "default",
+			"name": "default",
+			"uuid": "05d4ccab-be17-d1b2-6e1d-e8844e64c952",
+			"texture_map": {},
+			"excluded_bones": []
+		},
+		"list": []
+	},
 	"animations": [
 		{
 			"uuid": "37169b00-b60c-d095-d411-6b9ad91c61a3",
@@ -872,13 +872,14 @@
 			"override": false,
 			"length": 1.2,
 			"snapping": 20,
-			"selected": false,
+			"selected": true,
+			"saved": true,
+			"path": "",
 			"anim_time_update": "",
 			"blend_weight": "",
 			"start_delay": "",
 			"loop_delay": "",
-			"affected_bones": [],
-			"affected_bones_is_a_whitelist": false,
+			"excluded_bones": [],
 			"animators": {
 				"4dd51fae-e544-e85d-8e08-322e9915fe99": {
 					"name": "nostril",
@@ -901,7 +902,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -920,7 +923,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -939,7 +944,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -958,7 +965,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -977,7 +986,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -996,7 +1007,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -1015,7 +1028,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -1034,7 +1049,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -1053,7 +1070,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -1068,7 +1087,9 @@
 							"time": 0.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "step"
+							"interpolation": "step",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -1083,7 +1104,9 @@
 							"time": 0,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "step"
+							"interpolation": "step",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -1098,7 +1121,9 @@
 							"time": 0.4,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "step"
+							"interpolation": "step",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -1113,7 +1138,9 @@
 							"time": 0.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "step"
+							"interpolation": "step",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -1128,7 +1155,9 @@
 							"time": 0.8,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "step"
+							"interpolation": "step",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -1143,7 +1172,9 @@
 							"time": 1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "step"
+							"interpolation": "step",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -1158,7 +1189,9 @@
 							"time": 1.2,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "step"
+							"interpolation": "step",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -1184,7 +1217,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -1204,7 +1239,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -1224,7 +1261,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -1244,7 +1283,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -1264,7 +1305,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -1284,7 +1327,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -1304,7 +1349,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, -0.00699, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0.00699, 0]
+							"bezier_right_value": [0, 0.00699, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -1324,7 +1371,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -1344,11 +1393,14 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, 0, 0]
+							"bezier_right_value": [0, 0, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				}
 			}
 		}
-	]
+	],
+	"animation_controllers": []
 }


### PR DESCRIPTION
# Summary

This PR migrates the `nose` AJ model file so we can summon it in-game again for Minecraft 1.21.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Reproducing in-game

```mcfunction
function _:summon
```

---

## Supplemental changes

N/A

<!--
describe what other changes this PR makes which aren't specific to its main purpose.
- does it contain a world backup? (recommended)
- does it contain other miscellaneous code cleanup?

format these extra changes with bullet points, preferrably.
-->
