### PR TITLE
⬆️ 🍱 migrate `petal-pipe-circle` model to AJ v1.0

### DIFF
--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate/petal_pipe_circle/default.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate/petal_pipe_circle/default.mcfunction
@@ -1,2 +1,2 @@
 function animated_java:petal_pipe_circle/animations/float_and_pulsate/play
-function animated_java:petal_pipe_circle/apply_variant/default
+function animated_java:petal_pipe_circle/variants/default/apply

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate/petal_pipe_circle/disabled.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate/petal_pipe_circle/disabled.mcfunction
@@ -1,2 +1,2 @@
 function animated_java:petal_pipe_circle/animations/float_disabled/play
-function animated_java:petal_pipe_circle/apply_variant/disabled
+function animated_java:petal_pipe_circle/variants/disabled/apply

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate/pipe/soul_0.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate/pipe/soul_0.mcfunction
@@ -1,1 +1,1 @@
-execute as @e[tag=aj.petal_pipe_circle.root,tag=petal_pipe_lower,tag=petal_pipe.right] run function animated_java:petal_pipe_circle/apply_variant/soul_0
+execute as @e[tag=aj.petal_pipe_circle.root,tag=petal_pipe_lower,tag=petal_pipe.right] run function animated_java:petal_pipe_circle/variants/soul_0/apply

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate/pipe/soul_1.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate/pipe/soul_1.mcfunction
@@ -1,1 +1,1 @@
-execute as @e[tag=aj.petal_pipe_circle.root,tag=petal_pipe_lower,tag=petal_pipe.left] run function animated_java:petal_pipe_circle/apply_variant/soul_1
+execute as @e[tag=aj.petal_pipe_circle.root,tag=petal_pipe_lower,tag=petal_pipe.left] run function animated_java:petal_pipe_circle/variants/soul_1/apply

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate/pipe/soul_4.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate/pipe/soul_4.mcfunction
@@ -1,1 +1,1 @@
-execute as @e[tag=aj.petal_pipe_circle.root,tag=petal_pipe_upper,tag=petal_pipe.right] run function animated_java:petal_pipe_circle/apply_variant/soul_4
+execute as @e[tag=aj.petal_pipe_circle.root,tag=petal_pipe_upper,tag=petal_pipe.right] run function animated_java:petal_pipe_circle/variants/soul_4/apply

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate/pipe/soul_5.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate/pipe/soul_5.mcfunction
@@ -1,1 +1,1 @@
-execute as @e[tag=aj.petal_pipe_circle.root,tag=petal_pipe_upper,tag=petal_pipe.left] run function animated_java:petal_pipe_circle/apply_variant/soul_5
+execute as @e[tag=aj.petal_pipe_circle.root,tag=petal_pipe_upper,tag=petal_pipe.left] run function animated_java:petal_pipe_circle/variants/soul_5/apply

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon.mcfunction
@@ -16,10 +16,10 @@ execute positioned 5 42 -7 rotated 10 20 run function animated_java:lower_eye/su
 
 ## Lower petal pipes
 # Right-lower petal pipe
-execute positioned -11 44 -12.5 rotated -10 20 run function animated_java:petal_pipe_circle/summon
+execute positioned -11 44 -12.5 rotated -10 20 run function animated_java:petal_pipe_circle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_circle.root] add petal_pipe.right
 # Left-lower petal pipe
-execute positioned 11 44 -12.5 rotated -170 -20 run function animated_java:petal_pipe_circle/summon
+execute positioned 11 44 -12.5 rotated -170 -20 run function animated_java:petal_pipe_circle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe.right] add petal_pipe.left
 tag @e[tag=aj.petal_pipe_circle.root] add petal_pipe_lower
 
@@ -46,9 +46,9 @@ execute positioned 16.5 48 -4 rotated 20 40 run function animated_java:upper_eye
 
 ## Upper petal pipes
 # Right-upper petal pipe
-execute positioned -11 63 4 rotated -10 45 run function animated_java:petal_pipe_circle/summon
+execute positioned -11 63 4 rotated -10 45 run function animated_java:petal_pipe_circle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe_lower] add petal_pipe.right
 # Left-upper petal pipe
-execute positioned 11 63 4 rotated -170 -45 run function animated_java:petal_pipe_circle/summon
+execute positioned 11 63 4 rotated -170 -45 run function animated_java:petal_pipe_circle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe_lower,tag=!petal_pipe.right] add petal_pipe.left
 tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe_lower] add petal_pipe_upper

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/petal_pipes/petal-pipe-circle.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/petal_pipes/petal-pipe-circle.ajblueprint
@@ -1,105 +1,32 @@
 {
 	"meta": {
-		"format": "animated_java/ajmodel",
-		"format_version": "0.4.8",
-		"uuid": "0a67fc8d-a3ef-3cc4-dff1-42715f75494e"
+		"format": "animated_java_blueprint",
+		"format_version": "0.5.3",
+		"uuid": "0a67fc8d-a3ef-3cc4-dff1-42715f75494e",
+		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\petal_pipes\\petal-pipe-circle.ajblueprint",
+		"last_used_export_namespace": "petal_pipe_circle"
 	},
-	"animated_java": {
-		"settings": {
-			"project_namespace": "petal_pipe_circle",
-			"project_resolution": [64, 64],
-			"target_minecraft_version": "1.20+",
-			"rig_item": "minecraft:white_dye",
-			"rig_item_model": "",
-			"rig_export_folder": "",
-			"texture_export_folder": "",
-			"enable_advanced_resource_pack_settings": false,
-			"resource_pack_mcmeta": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\pack.mcmeta",
-			"verbose": true,
-			"exporter": "animated_java:datapack_exporter"
-		},
-		"exporter_settings": {
-			"animated_java:datapack_exporter": {
-				"datapack_mcmeta": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java\\pack.mcmeta",
-				"outdated_rig_warning": true,
-				"root_entity_nbt": "{Tags:[\"omega-flowey-remastered\", \"omega-flowey\", \"omega-flowey-petal-pipe\",\"omega-flowey-petal-pipe-circle\"]}",
-				"use_component_system": true,
-				"include_variant_summon_functions": true,
-				"include_apply_variant_functions": true,
-				"include_uninstall_function": true,
-				"include_pause_all_animations_function": true,
-				"include_remove_rigs_function": true,
-				"include_remove_all_function": true,
-				"include_on_load_function_tags": true,
-				"include_on_tick_function_tags": true,
-				"include_on_summon_function_tags": true,
-				"include_on_remove_function_tags": true
-			},
-			"animated_java:json_exporter": {
-				"output_file": ""
-			}
-		},
-		"variants": [
-			{
-				"name": "default",
-				"textureMap": {},
-				"uuid": "6fde0b59-c952-3d58-4087-1bfa481a613d",
-				"boneConfig": {},
-				"default": true,
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			},
-			{
-				"name": "disabled",
-				"textureMap": {
-					"1868b0c5-f4b5-0140-e8a7-84b899578a24": "eaba8d80-2850-abbb-be36-60ce443febf8"
-				},
-				"uuid": "cbe46cbf-071c-0aee-a431-4bf59526c51d",
-				"boneConfig": {},
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			},
-			{
-				"name": "soul_0",
-				"textureMap": {
-					"1868b0c5-f4b5-0140-e8a7-84b899578a24": "88578fa9-bd59-c1bd-f1de-deb7325cbfd2"
-				},
-				"uuid": "2b4ca496-7f78-2b89-5caf-28e5ce9d5245",
-				"boneConfig": {},
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			},
-			{
-				"name": "soul_1",
-				"textureMap": {
-					"1868b0c5-f4b5-0140-e8a7-84b899578a24": "02dcfadf-8ddc-4b7c-579c-ecebabe8c4df"
-				},
-				"uuid": "6fc85607-8130-8ad5-7c6f-fdf16211c9c4",
-				"boneConfig": {},
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			},
-			{
-				"name": "soul_4",
-				"textureMap": {
-					"1868b0c5-f4b5-0140-e8a7-84b899578a24": "c8217f38-b5aa-2b8f-a0ea-27aff03b5a04"
-				},
-				"uuid": "71d9a0d0-c44c-32e8-f804-071ba03e4ac9",
-				"boneConfig": {},
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			},
-			{
-				"name": "soul_5",
-				"textureMap": {
-					"1868b0c5-f4b5-0140-e8a7-84b899578a24": "2a8d1554-d346-03ec-67c7-095e633be282"
-				},
-				"uuid": "578b351e-2659-1479-96f7-e76436b4a031",
-				"boneConfig": {},
-				"affectedBonesIsAWhitelist": false,
-				"affectedBones": []
-			}
-		]
+	"project_settings": {
+		"export_namespace": "petal_pipe_circle",
+		"show_bounding_box": false,
+		"auto_bounding_box": true,
+		"bounding_box": [48, 48],
+		"enable_plugin_mode": false,
+		"enable_resource_pack": true,
+		"enable_data_pack": true,
+		"display_item": "minecraft:white_dye",
+		"customModelDataOffset": 0,
+		"enable_advanced_resource_pack_settings": false,
+		"resource_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\",
+		"display_item_path": "",
+		"model_folder": "",
+		"texture_folder": "",
+		"enable_advanced_data_pack_settings": false,
+		"data_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java\\",
+		"summon_commands": "tag @s add omega-flowey-remastered\ntag @s add omega-flowey\ntag @s add omega-flowey-petal-pipe\ntag @s add omega-flowey-petal-pipe-circle",
+		"interpolation_duration": 1,
+		"teleportation_duration": 1,
+		"use_storage_for_animation": false
 	},
 	"resolution": {
 		"width": 64,
@@ -3976,8 +3903,11 @@
 			"ignore_inherited_scale": false,
 			"visibility": true,
 			"locked": false,
-			"entity_type": "minecraft:marker",
-			"nbt": "{}",
+			"config": {
+				"use_entity": true,
+				"entity_type": "minecraft:marker",
+				"summon_commands": "data merge entity @s {}"
+			},
 			"export": false,
 			"uuid": "49f3d396-14a1-9064-26d7-32b47055e719",
 			"type": "locator"
@@ -5177,7 +5107,10 @@
 			"name": "root",
 			"origin": [0, 0, 0],
 			"color": 0,
-			"nbt": "{}",
+			"configs": {
+				"default": {},
+				"variants": {}
+			},
 			"uuid": "830f44d9-bad3-8d7b-6a20-4957bb43995f",
 			"export": true,
 			"mirror_uv": false,
@@ -5190,7 +5123,10 @@
 					"name": "bone",
 					"origin": [-56, -160, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "70a0798f-71f8-5a17-fb75-59eba18ea91c",
 					"export": true,
 					"mirror_uv": false,
@@ -5204,7 +5140,10 @@
 					"name": "bone2",
 					"origin": [-40, -160, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "9e79942a-7410-ae45-4bd0-8b281ddfe758",
 					"export": true,
 					"mirror_uv": false,
@@ -5218,7 +5157,10 @@
 					"name": "bone3",
 					"origin": [-24, -160, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "5011a39a-680e-7228-9bf3-195cce91f16d",
 					"export": true,
 					"mirror_uv": false,
@@ -5232,7 +5174,10 @@
 					"name": "bone4",
 					"origin": [-8, -144, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "0fa511d5-f80b-9f96-836c-f02fc462526e",
 					"export": true,
 					"mirror_uv": false,
@@ -5246,7 +5191,10 @@
 					"name": "bone5",
 					"origin": [8, -144, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "b57e3858-f262-0c49-2b1d-a83d95bbd7bc",
 					"export": true,
 					"mirror_uv": false,
@@ -5260,7 +5208,10 @@
 					"name": "bone6",
 					"origin": [24.35, -128.33333, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "ffa60ad2-d062-79a4-9df1-411f46b86341",
 					"export": true,
 					"mirror_uv": false,
@@ -5280,7 +5231,10 @@
 					"origin": [40, -111.99375, 0],
 					"rotation": [0, 0, 90],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "3a3a7e11-a5b8-ffba-44e0-025c19f4f634",
 					"export": true,
 					"mirror_uv": false,
@@ -5295,7 +5249,10 @@
 					"origin": [40, -95.99375, 0],
 					"rotation": [0, 0, 90],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "3377d2c5-e125-7d73-4861-65a171f699a5",
 					"export": true,
 					"mirror_uv": false,
@@ -5310,7 +5267,10 @@
 					"origin": [56, -79.99375, 0],
 					"rotation": [0, 0, 90],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "cd473f6b-e426-e57e-f045-6f04192c59c7",
 					"export": true,
 					"mirror_uv": false,
@@ -5325,7 +5285,10 @@
 					"origin": [56, -64, 0],
 					"rotation": [0, 0, 90],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "f4113f0a-b884-4fde-ac46-5f2269ee2a01",
 					"export": true,
 					"mirror_uv": false,
@@ -5340,7 +5303,10 @@
 					"origin": [56, -48.00625, 0],
 					"rotation": [0, 0, 90],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "77d50a1f-5293-484a-55cd-95b8f69ee24e",
 					"export": true,
 					"mirror_uv": false,
@@ -5355,7 +5321,10 @@
 					"origin": [56, -48, 0],
 					"rotation": [0, 0, 90],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "0f94aca4-96be-ad65-d491-8a3fdeee3ab0",
 					"export": true,
 					"mirror_uv": false,
@@ -5370,7 +5339,10 @@
 					"origin": [56, -32, 0],
 					"rotation": [0, 0, 90],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "28b63c19-ad21-e74e-1a3f-81b758266a17",
 					"export": true,
 					"mirror_uv": false,
@@ -5385,7 +5357,10 @@
 					"origin": [26.85, 5.33333, 0],
 					"rotation": [0, 0, 90],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "12b75fad-552b-1f76-e578-96b81fbec11e",
 					"export": true,
 					"mirror_uv": false,
@@ -5404,7 +5379,10 @@
 					"name": "bone15",
 					"origin": [8, 16, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "d86d4e1b-1515-215e-02a3-d76d75018529",
 					"export": true,
 					"mirror_uv": false,
@@ -5418,7 +5396,10 @@
 					"name": "bone16",
 					"origin": [-8, 16, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "5ff8c315-d674-0e13-6aa1-f1a70d6ec0df",
 					"export": true,
 					"mirror_uv": false,
@@ -5432,7 +5413,10 @@
 					"name": "bone17",
 					"origin": [-24, 32, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "2aa50109-7d2f-e9dc-3bc7-8b191de952fe",
 					"export": true,
 					"mirror_uv": false,
@@ -5446,7 +5430,10 @@
 					"name": "bone18",
 					"origin": [-40, 32, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "c6f25e06-dda5-971e-828d-e522120df05e",
 					"export": true,
 					"mirror_uv": false,
@@ -5460,7 +5447,10 @@
 					"name": "bone19",
 					"origin": [-56, 32, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "c3ac1ed1-eee7-1004-1298-530486cebbb2",
 					"export": true,
 					"mirror_uv": false,
@@ -5474,7 +5464,10 @@
 					"name": "bone20",
 					"origin": [-72, 16, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "3319de8f-4bf8-82ee-89b6-291350a9e27a",
 					"export": true,
 					"mirror_uv": false,
@@ -5488,7 +5481,10 @@
 					"name": "bone21",
 					"origin": [-88, 16, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "a39a8433-7ed7-5480-4314-4b6d94eaf5d0",
 					"export": true,
 					"mirror_uv": false,
@@ -5503,7 +5499,10 @@
 					"origin": [-104, 0, 0],
 					"rotation": [0, 0, -180],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "522b5114-ab42-3262-762a-abf15bf12b97",
 					"export": true,
 					"mirror_uv": false,
@@ -5518,7 +5517,10 @@
 					"origin": [-120, -16.00625, 0],
 					"rotation": [0, 0, 90],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "0e525818-f47c-1f37-fcdb-4c44be7dabb3",
 					"export": true,
 					"mirror_uv": false,
@@ -5533,7 +5535,10 @@
 					"origin": [-120, -31.99375, 0],
 					"rotation": [0, 0, 90],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "40a9fab0-0ab4-5d6b-581b-0f4e85baa38f",
 					"export": true,
 					"mirror_uv": false,
@@ -5548,7 +5553,10 @@
 					"origin": [-136, -48.00625, 0],
 					"rotation": [0, 0, 90],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "e85a583d-b394-120c-e80e-ac96ae40dcc5",
 					"export": true,
 					"mirror_uv": false,
@@ -5563,7 +5571,10 @@
 					"origin": [-152, -80, 0],
 					"rotation": [0, 0, 90],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "a1ffc3c0-ca0c-39a0-a8a2-e46d0796c4cd",
 					"export": true,
 					"mirror_uv": false,
@@ -5578,7 +5589,10 @@
 					"origin": [-152, -96, 0],
 					"rotation": [0, 0, 90],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "2e3c9942-2d16-d1e8-e111-4a9515894a2b",
 					"export": true,
 					"mirror_uv": false,
@@ -5593,7 +5607,10 @@
 					"origin": [-120, -96.00625, 0],
 					"rotation": [0, 0, 90],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "eae49d12-cc5f-d9db-5ed1-6dc655d07079",
 					"export": true,
 					"mirror_uv": false,
@@ -5608,7 +5625,10 @@
 					"origin": [-120, -111.99375, 0],
 					"rotation": [0, 0, 90],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "54b909c2-71a7-8135-974c-a4f9af3caccf",
 					"export": true,
 					"mirror_uv": false,
@@ -5623,7 +5643,10 @@
 					"origin": [-104, -128, 0],
 					"rotation": [0, 0, -90],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "f5a19c12-0669-73e0-779b-e15ca83151a4",
 					"export": true,
 					"mirror_uv": false,
@@ -5642,7 +5665,10 @@
 					"name": "bone31",
 					"origin": [-88, -144, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "36af199b-cf51-e810-fb63-25e66faf696e",
 					"export": true,
 					"mirror_uv": false,
@@ -5656,7 +5682,10 @@
 					"name": "bone32",
 					"origin": [-72, -144, 0],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "85e99b9c-245f-a6d2-81d5-bbacef4a418b",
 					"export": true,
 					"mirror_uv": false,
@@ -5673,7 +5702,10 @@
 			"origin": [-104, 0, -70],
 			"rotation": [0, -180, 0],
 			"color": 0,
-			"nbt": "{}",
+			"configs": {
+				"default": {},
+				"variants": {}
+			},
 			"uuid": "f13c55d0-8667-840d-3540-9fdda50cfc40",
 			"export": false,
 			"mirror_uv": false,
@@ -5686,7 +5718,10 @@
 					"name": "sclera",
 					"origin": [-125, 0, -102.05],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "d6cd4de3-8375-b558-e3c1-76e23149ff10",
 					"export": false,
 					"mirror_uv": false,
@@ -5700,7 +5735,10 @@
 					"name": "lid",
 					"origin": [-125, 0, -102.05],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "b68d2836-80d9-27aa-0d3a-124ba44fce75",
 					"export": false,
 					"mirror_uv": false,
@@ -5713,7 +5751,10 @@
 							"name": "dark",
 							"origin": [-125, 0, -102.05],
 							"color": 0,
-							"nbt": "{}",
+							"configs": {
+								"default": {},
+								"variants": {}
+							},
 							"uuid": "7b7340bc-78c6-1299-de1b-edf96e09fec6",
 							"export": false,
 							"mirror_uv": false,
@@ -5736,7 +5777,10 @@
 							"name": "light",
 							"origin": [-112.04, 35.64, -104.75],
 							"color": 0,
-							"nbt": "{}",
+							"configs": {
+								"default": {},
+								"variants": {}
+							},
 							"uuid": "32a2beec-a2be-93ec-fd62-73107f2ee6d7",
 							"export": false,
 							"mirror_uv": false,
@@ -5758,7 +5802,10 @@
 					"name": "iris",
 					"origin": [-125, 0, -102.05],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "880e6759-b6fb-7278-fe5e-7aef4153a88a",
 					"export": false,
 					"mirror_uv": false,
@@ -5774,7 +5821,10 @@
 							"name": "diag",
 							"origin": [-125, 0, -102.05],
 							"color": 0,
-							"nbt": "{}",
+							"configs": {
+								"default": {},
+								"variants": {}
+							},
 							"uuid": "4ae5ba92-0303-4b85-bd02-215b0b417f07",
 							"export": false,
 							"mirror_uv": false,
@@ -5793,7 +5843,10 @@
 							"name": "pupil",
 							"origin": [-146.6, 16.2, -104.75],
 							"color": 0,
-							"nbt": "{}",
+							"configs": {
+								"default": {},
+								"variants": {}
+							},
 							"uuid": "66b0c5dd-24ab-7cf3-a0b2-e6bd91aaea37",
 							"export": false,
 							"mirror_uv": false,
@@ -5809,7 +5862,10 @@
 					"name": "outer_lid",
 					"origin": [-125, -10.8, -102.05],
 					"color": 0,
-					"nbt": "{}",
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
 					"uuid": "8762d93c-9910-956b-1cb8-18d4d7378ff6",
 					"export": false,
 					"mirror_uv": false,
@@ -5835,7 +5891,10 @@
 							"name": "black",
 							"origin": [-194.3, -10.8, -102.05],
 							"color": 0,
-							"nbt": "{}",
+							"configs": {
+								"default": {},
+								"variants": {}
+							},
 							"uuid": "5d40d45a-2378-802c-df67-a649b180003c",
 							"export": false,
 							"mirror_uv": false,
@@ -5858,7 +5917,7 @@
 	"textures": [
 		{
 			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\pipe\\polished_andesite.png",
-			"name": "polished_andesite",
+			"name": "polished_andesite.png",
 			"folder": "",
 			"namespace": "",
 			"id": "0",
@@ -5880,13 +5939,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "1868b0c5-f4b5-0140-e8a7-84b899578a24",
-			"relative_path": "../../../../../../textures/custom/pipe/polished_andesite.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAAt5JREFUeF7tW1FLVEEUPheTXFFZrYU0lSCIHgMh6DUIwsegl35ST/4AH+utp4he+gFKIESZQYsSrbnEmt5ccQ2LjTO73zQ79/qw9z7Ioe++ONe9H8w5882ZM9+cSZ49X+1WJ6uStlPRv+c94e9of6qnMntNHM4qPnn18kX3/VZdTjq/vO3jlcu+/eNwX65MX3Xv+s3BQVtmZiZFv9n8+EGePH4klvHeAXkjD6fcvjUve61j98nv0453xs7OZ+8Aq/hEp8DXRkt2v+3LjZsLMlebcMYeHabOJh1pdQRYcWms4p2gDFh+eF8s43MZANqPjtakO3LsDA6nCBwTToGQAZbwzgHrG5t+tDHXYZCOfBwH8JvGg+UH98QyPsMApbjSXw3XNp7kz4Rrnp21HBs6p21p7jUzMcAaPsOAmOpqaOdEpDIuUhnrRX88GjdiBljDewZgvn9vNvyyB0PBBA2Q+mBFeLfx1jPAKn4gD8DoYhTPe1djdSrEeYBF/EAMCEc6XAp11Keme1ki8gBtx6uARbxzwOs3azJ/vZftxQ+MguF416mCIGgZ7xkQR3xE+3DJQwq8uFBzcSCMAVbxmWUwL+FRJ6iBuhT+PNr1OUNeImQNP7AMYrTz5nuYICHYwQFIhCzik6crK90v2w1J02ZuDMA/q9VZ14y/u7N0Vyzj3WbI8n6+rB5BPQCCSB7/qQdQD6Ae4HZ/1ANEXBJEPYB6APUANw2oB/STBuoBfVGUesBWPaMgW9ETqAeEByMW9/N6OFtGj6AeQD2A9QG9AgnqAawP+McBS+f7KNEJGTxM/1kfEGuC1s73YwYM23/WB4ABVs/3wYCi/Wd9QBgDLJ7vhzGgSP9ZHwAGWD3fBwOK9p96APUA1gewPoD3BagH8L7AoCI0zH667H78ovHUA6gHRDdGrNX7l72vwPsC4b1Bi/X+4b3FIv3nfQHeF+gfjRXdT5fdj180nnoA9YD/XA/4C06f6XYS8//pAAAAAElFTkSuQmCC",
 			"mode": "bitmap"
 		},
 		{
 			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\pipe\\polished_andesite_soul_0.png",
-			"name": "polished_andesite_soul_0",
+			"name": "polished_andesite_soul_0.png",
 			"folder": "",
 			"namespace": "",
 			"id": "1",
@@ -5908,13 +5966,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "88578fa9-bd59-c1bd-f1de-deb7325cbfd2",
-			"relative_path": "../../../../../../textures/custom/pipe/polished_andesite_soul_0.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAACACAYAAAC7gW9qAAAAAXNSR0IArs4c6QAABXlJREFUeF7tXEFvE1cQniUx2FGMTMBSoAmqKCDEpVUrIXFFrVpxROXSn9QDyg/gBr1xQKjiAvcgJBAqNJWwGiFM41Z2w4JN7OCERfN25+Xt242Qdw/WiG8v2Y13pDfzvjdv5nszG9z87XrUqDco7IfEf/e73N/l/q9WSMcXychplQ9+v3Mr+mOtRVvDbav7XO2Qvf//dY+OHjlmnvmdzc0+LSzUid959udT+uXqFdIsbw2QN/NilHNnl2ijOzCv7IyG1hjr68+tAbTKB7wEXra79OqfHn351TKdaM4bZd++Do1OPNNsCEHFbLVmjcAIuPzTJdIsn4sAgX2l0qRoZmAUdpeIGMZdAi4CNMkbAzx49MzOtqx1UYhn3vcD8hv7g8s/XCTN8hkEMMQZ/qw438sV7M6b2/G4a9AwHPWps9HJ+ABt8hkE+FBnRYdbRLU5olo19v5ysd/wEaBN3iJA1vt/nbbd9kRRQQI7SL5kR3jy6KFFgFb5VBwgsyuzuN8zK8tLwY8DNMqnfIA70+5WyLN++EgcJUocwPf+LqBR3hjg7r1VWvoijvb8S5QSxeWZl4o4Qc3yFgG+xxdv7255EgKfXG4aP+D6AK3ymW0wL+BhI7CCvBW+efvKxgx5gZA2+dQ2KLOdt97dAEmcnRhAAiGN8sGvKyvRi7/bFIadXB8g/2w0jptb/71vvrtAmuVNMqQ5ny/LR4APEEIkD//gA8AHgA8w2R/4ACITBIEPAB8APsAsA/ABSdAAPiAhRcEHrLUyDLIWPgF8gHswojGf58PZMnwE+ADwAagPiAskwAegPmAPA5rO96VEx0XwJONHfYDPCWo73/cRMOn4UR8gCNB6vi8IKDp+1Ae4PkDj+b7rA4qMH/UBggCt5/uCgKLjBx8APgD1AagPQL8A+AD0C6QZoUny6bL5+LTlwQeAD/A6RrTV+5ftV0C/gNs3qLHe3+1bLDJ+9AugXyA5GiuaT5fNx6ctDz4AfMDnzgecv3E9qtQbNO6HxH/3u9zf5f5dK6SDi2TktMoHX9++FQ3WWrQ72vt+wEx1rzt0HPao0og7yvid8WafKgt14ncGa09p8ecrpFneGiBv5sUoc2eW6H3y/YAo+X4A/zZcf24NoFU+4CWw3e7SaKNHtVPLdLA5b5TdCePvB/BMs7KCiqBaIzECI+Doj5dIs3wuAgT2QaVJNDMwCrtLRAzjLgEXAZrkjQHePI6/HyCz7PsD3w+IsuwPjn1/kTTLZxDAEGf4szH43l5Jv0A07ho0fBj1aXujk/EB2uQzCPChzorubhHNzBEdqMbeXy72Gz4CtMlbBMh6f/9v2257oqgggR0kX7Ij9B8/tAjQKp+KA3wfsN8zK8tLwY8DNMqnfIA70+5WyLM+24ijRNkC+d7fBTTKGwP07q9S9UT+9wNEKVFcnnmpiBPULL/nAzyPL97e3fIkBD603DR+IOUDlMpntsG8gIeNYGZ+d552+vH3A/xcQAylTT61DYoSeetdkiE3YBIfIIGQRvng9LWVaLjepp1PfD9gNvl+gP9e/dsLpFneJEOa8/myfAT4ACFEtObzQsgUHT/4gDwEaMrn8xAwyfjBB/gI0JbP+wiYdPzgAwQBWvN5QUDR8YMPcH2Axnze9QFFxg8+wPoApfm89QEFxw8+wD0Y0ZjPMwLK8BHgA8AHoD4gLpAomk+XzcenLQ8+AHwA6gPSPmDSfLpsPj5tefAB4AOcOEDj+b5bp1hk/KgPQH1AsgT8ijDUBySxsVshivqApKBajIL6ACJCfQD6BdAvYBomtPIJ4APAB4APAB+Q6hjRVu9ftl8B/QJu32CRfLpsPj5tefAB4APAB6S3QW31/j6tPun40S/wufcLfARehqEGYIUY2gAAAABJRU5ErkJggg==",
 			"mode": "bitmap"
 		},
 		{
 			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\pipe\\polished_andesite_soul_1.png",
-			"name": "polished_andesite_soul_1",
+			"name": "polished_andesite_soul_1.png",
 			"folder": "",
 			"namespace": "",
 			"id": "2",
@@ -5936,13 +5993,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "02dcfadf-8ddc-4b7c-579c-ecebabe8c4df",
-			"relative_path": "../../../../../../textures/custom/pipe/polished_andesite_soul_1.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAACACAYAAAC7gW9qAAAAAXNSR0IArs4c6QAABVFJREFUeF7tXMtuFEcUvR1wwjgYhglWMM9ESCGbPKRIQdlGihRYImWRLPID2fIRiBUfwArBLisUwSIfkAQJKeEpxYp5+DEBw7jjcTwkBgbdqjnd1dXtxXQvrCtOS5a7Z/pIdW+dunXr1K1JLl46P2xPtSXtp6L/N7vC73F/dzaVmX3icFbxyU+XfxzeuDMr64P/MtsnW29l909Xnsg7e/a6Z32n1+tLpzMl+s6t2zflu29OiWV85oCqnodTPvzgoCwtr7lXnj8bZM6Ym/szc4BVfKJD4OH8siwsPpH3jh6S/dM7nbGrK6mzSXtaHQFWbN/RypygDDj59ZdiGV/JANB+YmJahtvWnMHhEIFjwiEQMsAS3jng1+u3st7GWIdB2vNxHMB3Gg9OfvWFWMaXGKAUV/qr4XqPK3mx091ubCw7Ngye9aW71C3FAGv4EgNiqquhg3WR1qRIa4eP/rg0bsQMsIbPGIDx/qg7n017MBRM0ACpF2aE369fyxhgFV/IA9C76MXNntVYHQpxHmARX4gBYU+HU6H2+q49PktEHqD38SxgEe8ccOXnX+TgAZ/txReMguF41qGCIGgZnzEgjviI9uGUhxT48KFpFwfCGGAVX5oGqxIedYIaqFPhP6sLWc5QlQhZwxemQfR21XgPEyQEOzgAiZBFfHL23Lnh/b/mJU27lTEAH7bbM+42fu/Tzz4Xy3i3GLK8nm+qR1APgCBSxX/qAdQDqAe41R/1ABGXBFEPoB5APcANA+oBo6SBesBIFKUecGe2pCBb0ROoB4QbIxbX87o520SPoB5APYD1Ab5AgnoA6wNyDlja30eJTsjgcdrP+oBYE7S2vx8zYNz2sz4ADLC6vw8G1G0/6wPCGGBxfz+MAXXaz/oAMMDq/j4YULf91AOoB7A+gPUBPC9APYDnBYqK0Djr6abr8a3GUw+gHhCdGLFW79/0vALPC4TnBi3W+4fnFuu0n+cFeF5gtDVWdz3ddD2+1XjqAdQDXnc94MIPMmy3RNKBiP7f7Aq/x/3dv0VmdnucVXxy+bQMbyyKDP7PTW+9md/31kQ6vj7SvYNnfef2gsi3x0Us4zMHVPU8nHJsn8hS37/xfCN3xtzj3AFW8YkOgYc9kcWeyJF3RfZPeWP7/3qTtKfVEWDF9oncCcqAEx+LWMZXMgA0n9gmMnzDGxwOETgmHAIhAyzhnQN+u5f3NsY6DNKej+MAvtPPT3wkYhlfYoBSXOmvhus9ruSlv9t44dmgf920HAOs4UsMiKkOY9Uh+INTNG7EDLCGzxiA8f54JZ/2YCiYoAFSL8wIf9zLGWAVX8gDEOnRi5s9q7E6FOI8wCK+EAPCng6nQu31qbeLeYA+xbOARbxzwNWbIgc6ValMHgiRAMFIHSoIgpbxGQPiiI9oH055mhIrzQ93fBwIY4BVfGkarEp41AlqoE6Fq/6XtJwjqhIha/jCNIjerhrvYYKEYAcHIBGyiE/OfC/DB49E0vXqGIBP25P+Ln7vk/dFLOPdYsjyer6pHkE9AIJI1QCgHkA9gHqAm++pB+jvB1APoB7gBFPqAfr7AdQDPBOoB4xEUeoBi2UF2YqeQD0g3BixuJ7XzdkmegT1AOoBrA/wBRLUA1gfkHPA0v4+SnRCBo/TftYHxJqgtf39mAHjtp/1AWCA1f19MKBu+1kfEMYAi/v7YQyo037WB4ABVvf3wYC67aceQD2A9QGsD+B5AeoBPC9Q1IPGWU83XY9vNZ56APWA6MSItXr/pucVeF4gPDdosd4/PLdYp/08L8DzAqOtsbrr6abr8a3GUw+gHvCa6wGvAPhgoacMhVBHAAAAAElFTkSuQmCC",
 			"mode": "bitmap"
 		},
 		{
 			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\pipe\\polished_andesite_soul_4.png",
-			"name": "polished_andesite_soul_4",
+			"name": "polished_andesite_soul_4.png",
 			"folder": "",
 			"namespace": "",
 			"id": "3",
@@ -5964,13 +6020,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "c8217f38-b5aa-2b8f-a0ea-27aff03b5a04",
-			"relative_path": "../../../../../../textures/custom/pipe/polished_andesite_soul_4.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAACACAYAAAC7gW9qAAAAAXNSR0IArs4c6QAABQNJREFUeF7tXM9LFVEU/qasVDLUMso0gkBaBoXQLoIgXAZt+hv6E1q3aNUf0LJ2rSLa9AcUkRBlBkoRaUpp+lJJ+/ni3Jkz78ydedF7b2EHv9l4x5kDc8757rnnfvecl9y5e7ve39eP2noN8rfZZZ/r+PVsDUePIMh5lU8e3L9XfzE9i6+b33Lde3v25ePPq8s4OHAo3Ms7KyvrGBzsg7wz9eolrl65DM/yuQGqPK9GOTU2goWljfDKz63N3Bhv387kBvAqn8gUeD+3hPkPyzhxchTDQ/uDsmurtaCTeFoMoajo6u7JjSAImLh0AZ7lKxGgsN+zZwj13RtBYTtF1DB2ClgEeJIPBngyOZV7W+e6KiSej+OAPpN4MHHxHDzLlxAgEBf4i+Iy1iv5tT8Mf/xYCmjY3FrH4sJiKQZ4ky8hIIa6KLr5FejpBXq60+ivl8SNGAHe5HME6Hz/uDiXL3uqqCJBAqRcuiI8n3yaI8CrfCEPUO+qF5vdi7IyFeI8wKN8IQZYT9ulULx+YCDNEjUPkHG8CniUDwZ4+OgxRo6l2V58qVKquN7LVNEg6Fk+R0Ac8TXa2yVPU+Djo0MhDtgY4FW+tAxWJTxiBFFQlsIva/N5zlCVCHmTLyyD6u2q+W4TJA12agBNhDzKJzdv3aq/ezOHWm2xMgboP/v7j4Zh/N7pM+PwLB82Q573853yEeQDlBCpwj/5APIB5APC7o98ABCSIPIB5APIB4RpQD4gSxrIB2SkKPmA6dkSg+yFTyAfYA9GPO7n5XC2Ez6CfAD5ANYHpAUS5ANYH9DAgKfzfS3RsQhu5ftZHxBzgt7O92MEtPr9rA9QBHg931cEtPv9rA+wMcDj+b6NAe18P+sDFAFez/cVAe1+P/kA8gGsD2B9APsFyAewX6DICLWyn+50P77d8uQDyAdEHSPe6v077Vdgv4DtG/RY72/7Ftv5fvYLsF8gOxprdz/d6X58u+XJB5AP2Ol8AK6jjl7pjZfK6L/0TNjnOpbumcFMzql8ghuo4x2A70b5vWYsXfNpfWT6zpr00AGQd0TufPbXqXzDAFXOV6VGpFfGGEGNsWAM4FQ+CVPgE4BlAMMApD9SlE1/LyH1tBhCUaH38kwQMA54lq9GgMK+C8CuzAAW4moYOwUsAhzJpwaYMd5WeKtC4vE4DugziQdnAc/yZQSowvLXBsPfmdY/DSJk2mgQjA3mRL6MgBjqcr8FoDsziDWKGCBGgDP5BgJ0vq+YZc96Vcb6M0O6IsjUUQQ4lS/mAepd9WKze1FWpkKcBziUL8YAVSBeCsX7NhlSZMSrgEP51ADPAFT/fEAjEMaokKmiQdCxfAMBccTXaG+XPE2BD2fJko0BTuXLy2BVwqOJjyyFsun5WyLkTL64DKq3q+a7TZDU2xoDNJFyKJ/gGuqQTY3m/lWbGhsE4/fG5Hd1/MqnmyHyAeQDqoFPPoB8APmAsCUmHwCAfAD5APIBOUVGPiBLG8gHZJQY+YAKBtkJn0A+oHAw4nA/H1jpDvgI8gHkA1gfkBVIOD3fL51NWj3+gc9gfUBeIuP0fL8SAS3UJ7A+oIQA1gdE0ZD1ASbPZ31Ahg7yAeQDANYHZLswrRFifUA2LVgf0KSe6D+tLyAfQD6AfAD5APYLhJJX8gFm0xP3/7A+gPUB7BcIIYJ8APmAYoMl6wNYH9DoGSIfQD6gkUs66jfY8XzAHwkdbECi4SAXAAAAAElFTkSuQmCC",
 			"mode": "bitmap"
 		},
 		{
 			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\pipe\\polished_andesite_soul_5.png",
-			"name": "polished_andesite_soul_5",
+			"name": "polished_andesite_soul_5.png",
 			"folder": "",
 			"namespace": "",
 			"id": "4",
@@ -5992,13 +6047,12 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "2a8d1554-d346-03ec-67c7-095e633be282",
-			"relative_path": "../../../../../../textures/custom/pipe/polished_andesite_soul_5.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAACACAYAAAC7gW9qAAAAAXNSR0IArs4c6QAABSVJREFUeF7tXUtLHEEQrkGXuKKyaoT4RBDEoxAI5BoQxGPAiz/Jkz8gR73lJOLFHxAJLIgxChFFfC2i7q4P3A2rTKieqZmenvHg7kGLfHOxd3cKpqq+rq7+umr0lle++YXuAlXvqsR/n7vs32W8t1+lwQ9k5LTKe2ur3/3t3X16qP2NdO/Mv4vG15Ur6u99bz7zPeXyHfX1dRPfs/P7Fy3MfyXN8pEBsjwvRpmaHKHzy3tzy2O9Fhnj8PBPZACt8h5PgeOTSzo9u6LxiVEaGugyyt5WqkYn9jQbQlDR3pGPjMAImJv9QprlMxEgsM/lBshvuzcK21NEDGNPARsBmuSNATaLO5G3Za6LQux5Nw7IbxwP5mY+k2b5FAIY4gx/VpzHcnlPXWbYaFwaNNTqd1Q6L6VigDb5FAJcqLOitQeifCdRviOI/nJx3HARoE0+QoDM94vSSbTsiaKCBA6QfMmKsFX8GSFAq3wiDxDvihef+8zK8lRw8wCN8okYYHvaXgrZ6z29QZYoeQCP3VVAo7wxwPrGDxoZDrI99xKlRHH5zFNFgqBm+QgBbsSXaG8veZICj40OmDhgxwCt8qllMCvhYSOwgrwU3tyeRjlDViKkTT6xDIq3s+a7nSBJsBMDSCKkUd5bXFryjw5OqFotZcYA+bJQGDRD977pj59Is7zZDGnez7fKR4APEEIkC//gA8AHgA8wuz/wAUQmCQIfAD4AfICZBuADwqQBfEBIioIP2N1PMcha+ATwAfbBiMb9PB/OtsJHgA8AH4D6gKBAAnwA6gNiDGg635cSHRvBL3l+1Ae4nKC2830XAS99ftQHCAK0nu8LApp9ftQH2DFA4/m+HQOaeX7UBwgCtJ7vCwKafX7wAeADUB+A+gD0C4APQL9AkhF6yX661f34a8uDDwAf4HSMaKv3b7VfAf0Cdt+gxnp/u2+xmedHvwD6BcKjsWb3063ux19bHnwA+ADwAeQXuomqd/wegOd7JuzfZby3T+H7A/TKe2ur5G/v8rsBYuU7445Zuq4Q9fcGv/E95TJRXx93lXPbHNHCPJFm+cgA2fUBwbdTk9wtGowf67ExDg9jA2iV95ZXyD8+ITo9IxqfIBoaCJS9rQQqsafZ84KK9o7YCIyAuVkizfKZCBDY53JEflugsD1FxDD2FEiezwfTRoO8McBmMfa2zHVRiD3vxgH5jePB3AyRZvkUAhjiDH9WnMdyeU/BqNEI0FCrE5XO0zFAm3wKAS7UWdH4/QFxLGBjcNxwEaBNPkKAzNeLUrzsifcFCRwg+ZIVYasYI0CrfCIPkEgvXnzuMyvLU8HNAzTKJ2KA7Wl7KWSv94TJkOQB/J27CmiUNwZY3yAaGc5KZeJAKIqLkjxVJAhqlo8Q4EZ8ifb2kicp8NhoEAfsGKBVPrUMZiU8bARWkJfCm9s4Z8hKhLTJJ5ZB8XbWfLcTJAl2YgBJhDTKe4tL5B8d8HsBsmOAfFsI37Tn3jf9kUizvNkMgQ8AH5ANfwlo4APAB4APSPCC4APABwQYAB8APiB5LgA+IOQQXWr9LfMJ4APkaEzrfl6O5pp9fvAB9sGIxv08I6AVPgJ8APgA1AcEBRJZF/gA1AegPsAck6M+wLxPEPUBlO9AfQDqA9gCqA8IkwbUB4RFUqgP2E1XlGmpLwAfAD4A9QGoD0C/APgA9Ask+SD0Czj9Q+ADwAfI/xsEHwA+AHxA2DeIfgH0C6BfINUyY5fUS2pld5y+xX4D9Av87/0C/wA1QapfTa7KhQAAAABJRU5ErkJggg==",
 			"mode": "bitmap"
 		},
 		{
 			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\pipe\\polished_andesite_disabled.png",
-			"name": "polished_andesite_disabled",
+			"name": "polished_andesite_disabled.png",
 			"folder": "",
 			"namespace": "",
 			"id": "5",
@@ -6020,11 +6074,66 @@
 			"internal": false,
 			"saved": true,
 			"uuid": "eaba8d80-2850-abbb-be36-60ce443febf8",
-			"relative_path": "../../../../../../textures/custom/pipe/polished_andesite_disabled.png",
 			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAArpJREFUeF7tW01v2zAMpRMnMdJsK1C0BTq0QIf9hwE97FCgWP//TyjQQ7+SJXVcO3bigXKoKbJ7iH0oiD5dIscmIFJPFPVEBtfXv8vhYESrPCP+fa+576X/d57ReExGTqt8cPvnppzO5lSs11b3sN+3/XSVUjSMzDN/k2Y5RaMB8TfT2ZR+/rgkzfLWAE0zL0Y5/HZAy7Qwn5RF9cvvFou5NYBW+YCXQBynFCcpffk6oYMoNMrmWWZ04plmZQUVQRhaIzACLs7PSLN8IwIE9r1eRGWvMAq7S0QM4y4BFwGa5I0BHp+ndrYF3qIQz7zvB+Qd+4OL76ekWb6GAIY4w58V5760YFP1N5vUoKFY55Qsk5oP0CZfQ4APdVaU/R7bIuxX3l8a+w0fAdrkLQJkvb8lsd327OxvkcAOkpvsCC9PjxYBWuV34gCZXZnF955ZWV4KfhygUX7HB8ia97dCnvXBqIoSJQ7gvr8LaJQ3Bri7f6DJuIr2/CZKieLyzEtFnKBmeYsA3+OLt3e3PAmBJ5PI+AHXB2iVr22DTQEPG4EV5K1wlS9tzNAUCGmT39kGZbab1rsbIImzEwNIIKRRPvh1dVW+LmJaZUmjD5A/h6Ox6frfHR2fkGZ5cxjSfJ7vykeADxBCpAn/4APAB4APMKc/8AEcCIEPAB9gCFPwAUQEPmAbNIAP2JKi4ANm8xqDrIVPAB/gXoxoPM/z5WwXPgJ8APgA5AdUCRLgA5Af8B8Dmu73JUXHRfA+40d+gM8Jarvf9xGw7/iRHyAI0Hq/LwhoO37kB7g+QOP9vusD2owf+QGCAK33+4KAtuMHHwA+APkByA9AvQD4ANQL7DJC+5ynu57HP1oefAD4AK9iRFu+f9d6BdQLuHWDGvP93brFNuNHvQDqBbZXY23P013P4x8tDz4AfMAn5wP+AVWvvd78gHaPAAAAAElFTkSuQmCC",
 			"mode": "bitmap"
 		}
 	],
+	"variants": {
+		"default": {
+			"display_name": "default",
+			"name": "default",
+			"uuid": "6fde0b59-c952-3d58-4087-1bfa481a613d",
+			"texture_map": {},
+			"excluded_bones": []
+		},
+		"list": [
+			{
+				"display_name": "disabled",
+				"name": "disabled",
+				"uuid": "cbe46cbf-071c-0aee-a431-4bf59526c51d",
+				"texture_map": {
+					"1868b0c5-f4b5-0140-e8a7-84b899578a24": "eaba8d80-2850-abbb-be36-60ce443febf8"
+				},
+				"excluded_bones": []
+			},
+			{
+				"display_name": "soul_0",
+				"name": "soul_0",
+				"uuid": "2b4ca496-7f78-2b89-5caf-28e5ce9d5245",
+				"texture_map": {
+					"1868b0c5-f4b5-0140-e8a7-84b899578a24": "88578fa9-bd59-c1bd-f1de-deb7325cbfd2"
+				},
+				"excluded_bones": []
+			},
+			{
+				"display_name": "soul_1",
+				"name": "soul_1",
+				"uuid": "6fc85607-8130-8ad5-7c6f-fdf16211c9c4",
+				"texture_map": {
+					"1868b0c5-f4b5-0140-e8a7-84b899578a24": "02dcfadf-8ddc-4b7c-579c-ecebabe8c4df"
+				},
+				"excluded_bones": []
+			},
+			{
+				"display_name": "soul_4",
+				"name": "soul_4",
+				"uuid": "71d9a0d0-c44c-32e8-f804-071ba03e4ac9",
+				"texture_map": {
+					"1868b0c5-f4b5-0140-e8a7-84b899578a24": "c8217f38-b5aa-2b8f-a0ea-27aff03b5a04"
+				},
+				"excluded_bones": []
+			},
+			{
+				"display_name": "soul_5",
+				"name": "soul_5",
+				"uuid": "578b351e-2659-1479-96f7-e76436b4a031",
+				"texture_map": {
+					"1868b0c5-f4b5-0140-e8a7-84b899578a24": "2a8d1554-d346-03ec-67c7-095e633be282"
+				},
+				"excluded_bones": []
+			}
+		]
+	},
 	"animations": [
 		{
 			"uuid": "569a0c15-30ff-0b4f-9568-6014b76ea9c9",
@@ -6034,12 +6143,13 @@
 			"length": 10.4,
 			"snapping": 20,
 			"selected": false,
+			"saved": true,
+			"path": "",
 			"anim_time_update": "",
 			"blend_weight": "",
 			"start_delay": "",
 			"loop_delay": "",
-			"affected_bones": [],
-			"affected_bones_is_a_whitelist": false,
+			"excluded_bones": [],
 			"animators": {
 				"70a0798f-71f8-5a17-fb75-59eba18ea91c": {
 					"name": "bone",
@@ -6062,7 +6172,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6081,7 +6193,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6100,7 +6214,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6119,7 +6235,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6138,7 +6256,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6157,7 +6277,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6176,7 +6298,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6195,7 +6319,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6214,7 +6340,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6233,7 +6361,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6252,7 +6382,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6271,7 +6403,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6290,7 +6424,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6309,7 +6445,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6328,7 +6466,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6347,7 +6487,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6366,7 +6508,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6381,7 +6525,9 @@
 							"time": 0,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6396,7 +6542,9 @@
 							"time": 0.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6411,7 +6559,9 @@
 							"time": 0.3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6426,7 +6576,9 @@
 							"time": 0.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6441,7 +6593,9 @@
 							"time": 0.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6456,7 +6610,9 @@
 							"time": 1.1,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6471,7 +6627,9 @@
 							"time": 2.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6486,7 +6644,9 @@
 							"time": 2.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6501,7 +6661,9 @@
 							"time": 2.7,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6516,7 +6678,9 @@
 							"time": 1.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6531,7 +6695,9 @@
 							"time": 1.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6546,7 +6712,9 @@
 							"time": 1.9,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6561,7 +6729,9 @@
 							"time": 4.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6576,7 +6746,9 @@
 							"time": 4.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6591,7 +6763,9 @@
 							"time": 5.1,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6606,7 +6780,9 @@
 							"time": 3.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6621,7 +6797,9 @@
 							"time": 3.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6636,7 +6814,9 @@
 							"time": 3.5,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6651,7 +6831,9 @@
 							"time": 4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6666,7 +6848,9 @@
 							"time": 4.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6681,7 +6865,9 @@
 							"time": 4.3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6696,7 +6882,9 @@
 							"time": 5.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6711,7 +6899,9 @@
 							"time": 5.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6726,7 +6916,9 @@
 							"time": 5.9,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6741,7 +6933,9 @@
 							"time": 8.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6756,7 +6950,9 @@
 							"time": 8.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6771,7 +6967,9 @@
 							"time": 9.1,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6786,7 +6984,9 @@
 							"time": 9.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6801,7 +7001,9 @@
 							"time": 9.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6816,7 +7018,9 @@
 							"time": 9.9,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6831,7 +7035,9 @@
 							"time": 8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6846,7 +7052,9 @@
 							"time": 8.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6861,7 +7069,9 @@
 							"time": 8.3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6876,7 +7086,9 @@
 							"time": 6.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6891,7 +7103,9 @@
 							"time": 6.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6906,7 +7120,9 @@
 							"time": 6.7,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6921,7 +7137,9 @@
 							"time": 7.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6936,7 +7154,9 @@
 							"time": 7.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -6951,7 +7171,9 @@
 							"time": 7.5,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -6976,7 +7198,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -6995,7 +7219,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7014,7 +7240,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7033,7 +7261,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7052,7 +7282,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7071,7 +7303,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7090,7 +7324,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7109,7 +7345,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7128,7 +7366,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7147,7 +7387,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7166,7 +7408,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7185,7 +7429,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7204,7 +7450,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7223,7 +7471,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7242,7 +7492,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7261,7 +7513,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7280,7 +7534,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7295,7 +7551,9 @@
 							"time": 8.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7310,7 +7568,9 @@
 							"time": 9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7325,7 +7585,9 @@
 							"time": 9.15,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7340,7 +7602,9 @@
 							"time": 9.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7355,7 +7619,9 @@
 							"time": 9.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7370,7 +7636,9 @@
 							"time": 9.95,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7385,7 +7653,9 @@
 							"time": 8.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7400,7 +7670,9 @@
 							"time": 8.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7415,7 +7687,9 @@
 							"time": 8.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7430,7 +7704,9 @@
 							"time": 6.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7445,7 +7721,9 @@
 							"time": 6.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7460,7 +7738,9 @@
 							"time": 6.75,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7475,7 +7755,9 @@
 							"time": 7.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7490,7 +7772,9 @@
 							"time": 7.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7505,7 +7789,9 @@
 							"time": 7.55,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7520,7 +7806,9 @@
 							"time": 0.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7535,7 +7823,9 @@
 							"time": 0.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7550,7 +7840,9 @@
 							"time": 0.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7565,7 +7857,9 @@
 							"time": 0.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7580,7 +7874,9 @@
 							"time": 1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7595,7 +7891,9 @@
 							"time": 1.15,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7610,7 +7908,9 @@
 							"time": 2.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7625,7 +7925,9 @@
 							"time": 2.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7640,7 +7942,9 @@
 							"time": 2.75,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7655,7 +7959,9 @@
 							"time": 1.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7670,7 +7976,9 @@
 							"time": 1.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7685,7 +7993,9 @@
 							"time": 1.95,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7700,7 +8010,9 @@
 							"time": 4.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7715,7 +8027,9 @@
 							"time": 5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7730,7 +8044,9 @@
 							"time": 5.15,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7745,7 +8061,9 @@
 							"time": 3.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7760,7 +8078,9 @@
 							"time": 3.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7775,7 +8095,9 @@
 							"time": 3.55,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7790,7 +8112,9 @@
 							"time": 4.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7805,7 +8129,9 @@
 							"time": 4.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7820,7 +8146,9 @@
 							"time": 4.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7835,7 +8163,9 @@
 							"time": 5.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7850,7 +8180,9 @@
 							"time": 5.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -7865,7 +8197,9 @@
 							"time": 5.95,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -7890,7 +8224,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7909,7 +8245,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7928,7 +8266,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7947,7 +8287,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7966,7 +8308,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -7985,7 +8329,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8004,7 +8350,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8023,7 +8371,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8042,7 +8392,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8061,7 +8413,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8080,7 +8434,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8099,7 +8455,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8118,7 +8476,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8137,7 +8497,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8156,7 +8518,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8175,7 +8539,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8194,7 +8560,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8209,7 +8577,9 @@
 							"time": 8.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8224,7 +8594,9 @@
 							"time": 9.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8239,7 +8611,9 @@
 							"time": 9.2,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8254,7 +8628,9 @@
 							"time": 9.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8269,7 +8645,9 @@
 							"time": 9.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8284,7 +8662,9 @@
 							"time": 10,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8299,7 +8679,9 @@
 							"time": 8.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8314,7 +8696,9 @@
 							"time": 8.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8329,7 +8713,9 @@
 							"time": 8.4,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8344,7 +8730,9 @@
 							"time": 6.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8359,7 +8747,9 @@
 							"time": 6.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8374,7 +8764,9 @@
 							"time": 6.8,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8389,7 +8781,9 @@
 							"time": 7.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8404,7 +8798,9 @@
 							"time": 7.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8419,7 +8815,9 @@
 							"time": 7.6,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8434,7 +8832,9 @@
 							"time": 0.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8449,7 +8849,9 @@
 							"time": 0.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8464,7 +8866,9 @@
 							"time": 0.4,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8479,7 +8883,9 @@
 							"time": 0.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8494,7 +8900,9 @@
 							"time": 1.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8509,7 +8917,9 @@
 							"time": 1.2,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8524,7 +8934,9 @@
 							"time": 2.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8539,7 +8951,9 @@
 							"time": 2.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8554,7 +8968,9 @@
 							"time": 2.8,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8569,7 +8985,9 @@
 							"time": 1.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8584,7 +9002,9 @@
 							"time": 1.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8599,7 +9019,9 @@
 							"time": 2,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8614,7 +9036,9 @@
 							"time": 4.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8629,7 +9053,9 @@
 							"time": 5.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8644,7 +9070,9 @@
 							"time": 5.2,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8659,7 +9087,9 @@
 							"time": 3.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8674,7 +9104,9 @@
 							"time": 3.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8689,7 +9121,9 @@
 							"time": 3.6,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8704,7 +9138,9 @@
 							"time": 4.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8719,7 +9155,9 @@
 							"time": 4.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8734,7 +9172,9 @@
 							"time": 4.4,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8749,7 +9189,9 @@
 							"time": 5.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8764,7 +9206,9 @@
 							"time": 5.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -8779,7 +9223,9 @@
 							"time": 6,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -8804,7 +9250,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8823,7 +9271,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8842,7 +9292,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8861,7 +9313,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8880,7 +9334,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8899,7 +9355,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8918,7 +9376,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8937,7 +9397,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8956,7 +9418,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8975,7 +9439,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -8994,7 +9460,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9013,7 +9481,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9032,7 +9502,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9051,7 +9523,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9070,7 +9544,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9089,7 +9565,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9108,7 +9586,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9123,7 +9603,9 @@
 							"time": 8.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9138,7 +9620,9 @@
 							"time": 9.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9153,7 +9637,9 @@
 							"time": 9.25,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9168,7 +9654,9 @@
 							"time": 9.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9183,7 +9671,9 @@
 							"time": 9.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9198,7 +9688,9 @@
 							"time": 10.05,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9213,7 +9705,9 @@
 							"time": 8.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9228,7 +9722,9 @@
 							"time": 8.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9243,7 +9739,9 @@
 							"time": 8.45,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9258,7 +9756,9 @@
 							"time": 6.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9273,7 +9773,9 @@
 							"time": 6.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9288,7 +9790,9 @@
 							"time": 6.85,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9303,7 +9807,9 @@
 							"time": 7.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9318,7 +9824,9 @@
 							"time": 7.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9333,7 +9841,9 @@
 							"time": 7.65,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9348,7 +9858,9 @@
 							"time": 0.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9363,7 +9875,9 @@
 							"time": 0.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9378,7 +9892,9 @@
 							"time": 0.45,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9393,7 +9909,9 @@
 							"time": 0.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9408,7 +9926,9 @@
 							"time": 1.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9423,7 +9943,9 @@
 							"time": 1.25,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9438,7 +9960,9 @@
 							"time": 2.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9453,7 +9977,9 @@
 							"time": 2.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9468,7 +9994,9 @@
 							"time": 2.85,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9483,7 +10011,9 @@
 							"time": 1.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9498,7 +10028,9 @@
 							"time": 1.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9513,7 +10045,9 @@
 							"time": 2.05,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9528,7 +10062,9 @@
 							"time": 4.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9543,7 +10079,9 @@
 							"time": 5.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9558,7 +10096,9 @@
 							"time": 5.25,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9573,7 +10113,9 @@
 							"time": 3.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9588,7 +10130,9 @@
 							"time": 3.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9603,7 +10147,9 @@
 							"time": 3.65,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9618,7 +10164,9 @@
 							"time": 4.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9633,7 +10181,9 @@
 							"time": 4.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9648,7 +10198,9 @@
 							"time": 4.45,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9663,7 +10215,9 @@
 							"time": 5.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9678,7 +10232,9 @@
 							"time": 5.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -9693,7 +10249,9 @@
 							"time": 6.05,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -9718,7 +10276,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9737,7 +10297,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9756,7 +10318,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9775,7 +10339,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9794,7 +10360,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9813,7 +10381,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9832,7 +10402,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9851,7 +10423,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9870,7 +10444,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9889,7 +10465,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9908,7 +10486,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9927,7 +10507,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9946,7 +10528,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9965,7 +10549,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -9984,7 +10570,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -10003,7 +10591,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -10022,7 +10612,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10037,7 +10629,9 @@
 							"time": 9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10052,7 +10646,9 @@
 							"time": 9.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10067,7 +10663,9 @@
 							"time": 9.3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10082,7 +10680,9 @@
 							"time": 9.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10097,7 +10697,9 @@
 							"time": 9.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10112,7 +10714,9 @@
 							"time": 10.1,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10127,7 +10731,9 @@
 							"time": 8.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10142,7 +10748,9 @@
 							"time": 8.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10157,7 +10765,9 @@
 							"time": 8.5,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10172,7 +10782,9 @@
 							"time": 6.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10187,7 +10799,9 @@
 							"time": 6.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10202,7 +10816,9 @@
 							"time": 6.9,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10217,7 +10833,9 @@
 							"time": 7.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10232,7 +10850,9 @@
 							"time": 7.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10247,7 +10867,9 @@
 							"time": 7.7,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10262,7 +10884,9 @@
 							"time": 0.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10277,7 +10901,9 @@
 							"time": 0.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10292,7 +10918,9 @@
 							"time": 0.5,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10307,7 +10935,9 @@
 							"time": 1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10322,7 +10952,9 @@
 							"time": 1.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10337,7 +10969,9 @@
 							"time": 1.3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10352,7 +10986,9 @@
 							"time": 2.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10367,7 +11003,9 @@
 							"time": 2.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10382,7 +11020,9 @@
 							"time": 2.9,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10397,7 +11037,9 @@
 							"time": 1.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10412,7 +11054,9 @@
 							"time": 1.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10427,7 +11071,9 @@
 							"time": 2.1,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10442,7 +11088,9 @@
 							"time": 5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10457,7 +11105,9 @@
 							"time": 5.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10472,7 +11122,9 @@
 							"time": 5.3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10487,7 +11139,9 @@
 							"time": 3.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10502,7 +11156,9 @@
 							"time": 3.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10517,7 +11173,9 @@
 							"time": 3.7,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10532,7 +11190,9 @@
 							"time": 4.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10547,7 +11207,9 @@
 							"time": 4.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10562,7 +11224,9 @@
 							"time": 4.5,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10577,7 +11241,9 @@
 							"time": 5.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10592,7 +11258,9 @@
 							"time": 5.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10607,7 +11275,9 @@
 							"time": 6.1,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -10632,7 +11302,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -10651,7 +11323,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -10670,7 +11344,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -10689,7 +11365,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -10708,7 +11386,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -10727,7 +11407,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -10746,7 +11428,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -10765,7 +11449,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -10784,7 +11470,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -10803,7 +11491,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -10822,7 +11512,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -10841,7 +11533,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -10860,7 +11554,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -10879,7 +11575,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -10898,7 +11596,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -10917,7 +11617,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -10936,7 +11638,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10951,7 +11655,9 @@
 							"time": 9.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10966,7 +11672,9 @@
 							"time": 9.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10981,7 +11689,9 @@
 							"time": 9.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -10996,7 +11706,9 @@
 							"time": 9.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11011,7 +11723,9 @@
 							"time": 10,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11026,7 +11740,9 @@
 							"time": 10.15,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11041,7 +11757,9 @@
 							"time": 8.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11056,7 +11774,9 @@
 							"time": 8.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11071,7 +11791,9 @@
 							"time": 8.55,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11086,7 +11808,9 @@
 							"time": 6.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11101,7 +11825,9 @@
 							"time": 6.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11116,7 +11842,9 @@
 							"time": 6.95,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11131,7 +11859,9 @@
 							"time": 7.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11146,7 +11876,9 @@
 							"time": 7.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11161,7 +11893,9 @@
 							"time": 7.75,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11176,7 +11910,9 @@
 							"time": 0.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11191,7 +11927,9 @@
 							"time": 0.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11206,7 +11944,9 @@
 							"time": 0.55,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11221,7 +11961,9 @@
 							"time": 1.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11236,7 +11978,9 @@
 							"time": 1.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11251,7 +11995,9 @@
 							"time": 1.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11266,7 +12012,9 @@
 							"time": 2.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11281,7 +12029,9 @@
 							"time": 2.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11296,7 +12046,9 @@
 							"time": 2.95,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11311,7 +12063,9 @@
 							"time": 1.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11326,7 +12080,9 @@
 							"time": 2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11341,7 +12097,9 @@
 							"time": 2.15,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11356,7 +12114,9 @@
 							"time": 5.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11371,7 +12131,9 @@
 							"time": 5.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11386,7 +12148,9 @@
 							"time": 5.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11401,7 +12165,9 @@
 							"time": 3.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11416,7 +12182,9 @@
 							"time": 3.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11431,7 +12199,9 @@
 							"time": 3.75,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11446,7 +12216,9 @@
 							"time": 4.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11461,7 +12233,9 @@
 							"time": 4.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11476,7 +12250,9 @@
 							"time": 4.55,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11491,7 +12267,9 @@
 							"time": 5.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11506,7 +12284,9 @@
 							"time": 6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11521,7 +12301,9 @@
 							"time": 6.15,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -11546,7 +12328,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -11565,7 +12349,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -11584,7 +12370,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -11603,7 +12391,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -11622,7 +12412,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -11641,7 +12433,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -11660,7 +12454,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -11679,7 +12475,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -11698,7 +12496,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -11717,7 +12517,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -11736,7 +12538,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -11755,7 +12559,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -11774,7 +12580,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -11793,7 +12601,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -11812,7 +12622,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -11831,7 +12643,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -11850,7 +12664,9 @@
 							"bezier_left_time": [-0.1, -0.07476, -0.1],
 							"bezier_left_value": [0, 1.63617, 0],
 							"bezier_right_time": [0.1, 0.07476, 0.1],
-							"bezier_right_value": [0, -1.63617, 0]
+							"bezier_right_value": [0, -1.63617, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -11869,7 +12685,9 @@
 							"bezier_left_time": [-0.1, -0.07476, -0.1],
 							"bezier_left_value": [0, 2.87339, 0],
 							"bezier_right_time": [0.1, 0.07476, 0.1],
-							"bezier_right_value": [0, -2.87339, 0]
+							"bezier_right_value": [0, -2.87339, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11884,7 +12702,9 @@
 							"time": 9.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11899,7 +12719,9 @@
 							"time": 9.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11914,7 +12736,9 @@
 							"time": 9.4,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11929,7 +12753,9 @@
 							"time": 9.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11944,7 +12770,9 @@
 							"time": 10.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11959,7 +12787,9 @@
 							"time": 10.2,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11974,7 +12804,9 @@
 							"time": 8.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -11989,7 +12821,9 @@
 							"time": 8.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12004,7 +12838,9 @@
 							"time": 8.6,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12019,7 +12855,9 @@
 							"time": 6.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12034,7 +12872,9 @@
 							"time": 6.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12049,7 +12889,9 @@
 							"time": 7,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12064,7 +12906,9 @@
 							"time": 7.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12079,7 +12923,9 @@
 							"time": 7.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12094,7 +12940,9 @@
 							"time": 7.8,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12109,7 +12957,9 @@
 							"time": 0.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12124,7 +12974,9 @@
 							"time": 0.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12139,7 +12991,9 @@
 							"time": 0.6,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12154,7 +13008,9 @@
 							"time": 1.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12169,7 +13025,9 @@
 							"time": 1.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12184,7 +13042,9 @@
 							"time": 1.4,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12199,7 +13059,9 @@
 							"time": 2.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12214,7 +13076,9 @@
 							"time": 2.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12229,7 +13093,9 @@
 							"time": 3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12244,7 +13110,9 @@
 							"time": 1.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12259,7 +13127,9 @@
 							"time": 2.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12274,7 +13144,9 @@
 							"time": 2.2,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12289,7 +13161,9 @@
 							"time": 5.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12304,7 +13178,9 @@
 							"time": 5.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12319,7 +13195,9 @@
 							"time": 5.4,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12334,7 +13212,9 @@
 							"time": 3.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12349,7 +13229,9 @@
 							"time": 3.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12364,7 +13246,9 @@
 							"time": 3.8,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12379,7 +13263,9 @@
 							"time": 4.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12394,7 +13280,9 @@
 							"time": 4.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12409,7 +13297,9 @@
 							"time": 4.6,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12424,7 +13314,9 @@
 							"time": 5.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12439,7 +13331,9 @@
 							"time": 6.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12454,7 +13348,9 @@
 							"time": 6.2,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -12479,7 +13375,9 @@
 							"bezier_left_time": [-0.1, -0.07476, -0.1],
 							"bezier_left_value": [0, 1.63617, 0],
 							"bezier_right_time": [0.1, 0.07476, 0.1],
-							"bezier_right_value": [0, -1.63617, 0]
+							"bezier_right_value": [0, -1.63617, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -12498,7 +13396,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -12517,7 +13417,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -12536,7 +13438,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -12555,7 +13459,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -12574,7 +13480,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -12593,7 +13501,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -12612,7 +13522,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -12631,7 +13543,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -12650,7 +13564,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -12669,7 +13585,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -12688,7 +13606,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -12707,7 +13627,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -12726,7 +13648,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -12745,7 +13669,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -12764,7 +13690,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -12783,7 +13711,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -12802,7 +13732,9 @@
 							"bezier_left_time": [-0.1, -0.07476, -0.1],
 							"bezier_left_value": [0, 2.87339, 0],
 							"bezier_right_time": [0.1, 0.07476, 0.1],
-							"bezier_right_value": [0, -2.87339, 0]
+							"bezier_right_value": [0, -2.87339, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12817,7 +13749,9 @@
 							"time": 9.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12832,7 +13766,9 @@
 							"time": 9.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12847,7 +13783,9 @@
 							"time": 9.45,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12862,7 +13800,9 @@
 							"time": 9.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12877,7 +13817,9 @@
 							"time": 10.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12892,7 +13834,9 @@
 							"time": 10.25,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12907,7 +13851,9 @@
 							"time": 8.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12922,7 +13868,9 @@
 							"time": 8.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12937,7 +13885,9 @@
 							"time": 8.65,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12952,7 +13902,9 @@
 							"time": 6.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12967,7 +13919,9 @@
 							"time": 6.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12982,7 +13936,9 @@
 							"time": 7.05,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -12997,7 +13953,9 @@
 							"time": 7.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13012,7 +13970,9 @@
 							"time": 7.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13027,7 +13987,9 @@
 							"time": 7.85,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13042,7 +14004,9 @@
 							"time": 0.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13057,7 +14021,9 @@
 							"time": 0.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13072,7 +14038,9 @@
 							"time": 0.65,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13087,7 +14055,9 @@
 							"time": 1.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13102,7 +14072,9 @@
 							"time": 1.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13117,7 +14089,9 @@
 							"time": 1.45,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13132,7 +14106,9 @@
 							"time": 2.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13147,7 +14123,9 @@
 							"time": 2.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13162,7 +14140,9 @@
 							"time": 3.05,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13177,7 +14157,9 @@
 							"time": 1.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13192,7 +14174,9 @@
 							"time": 2.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13207,7 +14191,9 @@
 							"time": 2.25,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13222,7 +14208,9 @@
 							"time": 5.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13237,7 +14225,9 @@
 							"time": 5.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13252,7 +14242,9 @@
 							"time": 5.45,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13267,7 +14259,9 @@
 							"time": 3.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13282,7 +14276,9 @@
 							"time": 3.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13297,7 +14293,9 @@
 							"time": 3.85,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13312,7 +14310,9 @@
 							"time": 4.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13327,7 +14327,9 @@
 							"time": 4.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13342,7 +14344,9 @@
 							"time": 4.65,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13357,7 +14361,9 @@
 							"time": 5.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13372,7 +14378,9 @@
 							"time": 6.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13387,7 +14395,9 @@
 							"time": 6.25,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -13412,7 +14422,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 2.95145, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -2.95145, 0]
+							"bezier_right_value": [0, -2.95145, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -13431,7 +14443,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -13450,7 +14464,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -13469,7 +14485,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -13488,7 +14506,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -13507,7 +14527,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -13526,7 +14548,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -13545,7 +14569,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -13564,7 +14590,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -13583,7 +14611,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -13602,7 +14632,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -13621,7 +14653,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -13640,7 +14674,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -13659,7 +14695,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -13678,7 +14716,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -13697,7 +14737,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -13716,7 +14758,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -13735,7 +14779,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 2.95145, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -2.95145, 0]
+							"bezier_right_value": [0, -2.95145, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13750,7 +14796,9 @@
 							"time": 9.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13765,7 +14813,9 @@
 							"time": 9.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13780,7 +14830,9 @@
 							"time": 9.5,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13795,7 +14847,9 @@
 							"time": 10,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13810,7 +14864,9 @@
 							"time": 10.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13825,7 +14881,9 @@
 							"time": 10.3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13840,7 +14898,9 @@
 							"time": 8.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13855,7 +14915,9 @@
 							"time": 8.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13870,7 +14932,9 @@
 							"time": 8.7,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13885,7 +14949,9 @@
 							"time": 6.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13900,7 +14966,9 @@
 							"time": 6.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13915,7 +14983,9 @@
 							"time": 7.1,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13930,7 +15000,9 @@
 							"time": 7.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13945,7 +15017,9 @@
 							"time": 7.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13960,7 +15034,9 @@
 							"time": 7.9,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13975,7 +15051,9 @@
 							"time": 0.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -13990,7 +15068,9 @@
 							"time": 0.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14005,7 +15085,9 @@
 							"time": 0.7,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14020,7 +15102,9 @@
 							"time": 1.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14035,7 +15119,9 @@
 							"time": 1.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14050,7 +15136,9 @@
 							"time": 1.5,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14065,7 +15153,9 @@
 							"time": 2.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14080,7 +15170,9 @@
 							"time": 2.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14095,7 +15187,9 @@
 							"time": 3.1,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14110,7 +15204,9 @@
 							"time": 2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14125,7 +15221,9 @@
 							"time": 2.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14140,7 +15238,9 @@
 							"time": 2.3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14155,7 +15255,9 @@
 							"time": 5.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14170,7 +15272,9 @@
 							"time": 5.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14185,7 +15289,9 @@
 							"time": 5.5,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14200,7 +15306,9 @@
 							"time": 3.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14215,7 +15323,9 @@
 							"time": 3.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14230,7 +15340,9 @@
 							"time": 3.9,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14245,7 +15357,9 @@
 							"time": 4.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14260,7 +15374,9 @@
 							"time": 4.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14275,7 +15391,9 @@
 							"time": 4.7,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14290,7 +15408,9 @@
 							"time": 6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14305,7 +15425,9 @@
 							"time": 6.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14320,7 +15442,9 @@
 							"time": 6.3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -14345,7 +15469,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 2.95145, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -2.95145, 0]
+							"bezier_right_value": [0, -2.95145, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -14364,7 +15490,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -14383,7 +15511,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -14402,7 +15532,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -14421,7 +15553,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -14440,7 +15574,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -14459,7 +15595,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -14478,7 +15616,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -14497,7 +15637,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -14516,7 +15658,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -14535,7 +15679,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -14554,7 +15700,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -14573,7 +15721,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -14592,7 +15742,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -14611,7 +15763,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -14630,7 +15784,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -14649,7 +15805,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -14668,7 +15826,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 2.95145, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -2.95145, 0]
+							"bezier_right_value": [0, -2.95145, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14683,7 +15843,9 @@
 							"time": 9.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14698,7 +15860,9 @@
 							"time": 9.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14713,7 +15877,9 @@
 							"time": 9.55,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14728,7 +15894,9 @@
 							"time": 10.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14743,7 +15911,9 @@
 							"time": 10.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14758,7 +15928,9 @@
 							"time": 10.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14773,7 +15945,9 @@
 							"time": 8.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14788,7 +15962,9 @@
 							"time": 8.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14803,7 +15979,9 @@
 							"time": 8.75,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14818,7 +15996,9 @@
 							"time": 6.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14833,7 +16013,9 @@
 							"time": 7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14848,7 +16030,9 @@
 							"time": 7.15,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14863,7 +16047,9 @@
 							"time": 7.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14878,7 +16064,9 @@
 							"time": 7.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14893,7 +16081,9 @@
 							"time": 7.95,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14908,7 +16098,9 @@
 							"time": 0.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14923,7 +16115,9 @@
 							"time": 0.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14938,7 +16132,9 @@
 							"time": 0.75,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14953,7 +16149,9 @@
 							"time": 1.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14968,7 +16166,9 @@
 							"time": 1.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14983,7 +16183,9 @@
 							"time": 1.55,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -14998,7 +16200,9 @@
 							"time": 2.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15013,7 +16217,9 @@
 							"time": 3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15028,7 +16234,9 @@
 							"time": 3.15,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15043,7 +16251,9 @@
 							"time": 2.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15058,7 +16268,9 @@
 							"time": 2.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15073,7 +16285,9 @@
 							"time": 2.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15088,7 +16302,9 @@
 							"time": 5.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15103,7 +16319,9 @@
 							"time": 5.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15118,7 +16336,9 @@
 							"time": 5.55,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15133,7 +16353,9 @@
 							"time": 3.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15148,7 +16370,9 @@
 							"time": 3.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15163,7 +16387,9 @@
 							"time": 3.95,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15178,7 +16404,9 @@
 							"time": 4.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15193,7 +16421,9 @@
 							"time": 4.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15208,7 +16438,9 @@
 							"time": 4.75,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15223,7 +16455,9 @@
 							"time": 6.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15238,7 +16472,9 @@
 							"time": 6.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15253,7 +16489,9 @@
 							"time": 6.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -15278,7 +16516,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 2.95145, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -2.95145, 0]
+							"bezier_right_value": [0, -2.95145, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -15297,7 +16537,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -15316,7 +16558,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -15335,7 +16579,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -15354,7 +16600,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -15373,7 +16621,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -15392,7 +16642,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -15411,7 +16663,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -15430,7 +16684,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -15449,7 +16705,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -15468,7 +16726,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -15487,7 +16747,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -15506,7 +16768,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -15525,7 +16789,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -15544,7 +16810,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -15563,7 +16831,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -15582,7 +16852,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -15601,7 +16873,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 2.95145, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -2.95145, 0]
+							"bezier_right_value": [0, -2.95145, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15616,7 +16890,9 @@
 							"time": 0.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15631,7 +16907,9 @@
 							"time": 0.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15646,7 +16924,9 @@
 							"time": 0.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15661,7 +16941,9 @@
 							"time": 1.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15676,7 +16958,9 @@
 							"time": 1.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15691,7 +16975,9 @@
 							"time": 1.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15706,7 +16992,9 @@
 							"time": 3.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15721,7 +17009,9 @@
 							"time": 2.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15736,7 +17026,9 @@
 							"time": 3.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15751,7 +17043,9 @@
 							"time": 2.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15766,7 +17060,9 @@
 							"time": 2.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15781,7 +17077,9 @@
 							"time": 2.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15796,7 +17094,9 @@
 							"time": 4.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15811,7 +17111,9 @@
 							"time": 4.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15826,7 +17128,9 @@
 							"time": 4.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15841,7 +17145,9 @@
 							"time": 3.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15856,7 +17162,9 @@
 							"time": 3.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15871,7 +17179,9 @@
 							"time": 4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15886,7 +17196,9 @@
 							"time": 6.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15901,7 +17213,9 @@
 							"time": 6.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15916,7 +17230,9 @@
 							"time": 6.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15931,7 +17247,9 @@
 							"time": 5.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15946,7 +17264,9 @@
 							"time": 5.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15961,7 +17281,9 @@
 							"time": 5.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15976,7 +17298,9 @@
 							"time": 7.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -15991,7 +17315,9 @@
 							"time": 7.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16006,7 +17332,9 @@
 							"time": 8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16021,7 +17349,9 @@
 							"time": 7.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16036,7 +17366,9 @@
 							"time": 6.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16051,7 +17383,9 @@
 							"time": 7.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16066,7 +17400,9 @@
 							"time": 9.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16081,7 +17417,9 @@
 							"time": 9.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16096,7 +17434,9 @@
 							"time": 9.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16111,7 +17451,9 @@
 							"time": 10.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16126,7 +17468,9 @@
 							"time": 10.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16141,7 +17485,9 @@
 							"time": 10.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16156,7 +17502,9 @@
 							"time": 8.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16171,7 +17519,9 @@
 							"time": 8.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16186,7 +17536,9 @@
 							"time": 8.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -16211,7 +17563,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -16230,7 +17584,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -16249,7 +17605,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -16268,7 +17626,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -16287,7 +17647,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -16306,7 +17668,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -16325,7 +17689,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -16344,7 +17710,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -16363,7 +17731,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -16382,7 +17752,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -16401,7 +17773,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -16420,7 +17794,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -16439,7 +17815,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -16458,7 +17836,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -16477,7 +17857,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -16496,7 +17878,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -16515,7 +17899,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.08361, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.08361, 0]
+							"bezier_right_value": [0, -3.08361, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -16534,7 +17920,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.08361, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.08361, 0]
+							"bezier_right_value": [0, -3.08361, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16549,7 +17937,9 @@
 							"time": 0.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16564,7 +17954,9 @@
 							"time": 0.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16579,7 +17971,9 @@
 							"time": 0.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16594,7 +17988,9 @@
 							"time": 0.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16609,7 +18005,9 @@
 							"time": 1.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16624,7 +18022,9 @@
 							"time": 1.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16639,7 +18039,9 @@
 							"time": 1.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16654,7 +18056,9 @@
 							"time": 2.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16669,7 +18073,9 @@
 							"time": 2.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16684,7 +18090,9 @@
 							"time": 2.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16699,7 +18107,9 @@
 							"time": 3.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16714,7 +18124,9 @@
 							"time": 2.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16729,7 +18141,9 @@
 							"time": 3.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16744,7 +18158,9 @@
 							"time": 3.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16759,7 +18175,9 @@
 							"time": 3.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16774,7 +18192,9 @@
 							"time": 4.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16789,7 +18209,9 @@
 							"time": 4.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16804,7 +18226,9 @@
 							"time": 4.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16819,7 +18243,9 @@
 							"time": 4.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16834,7 +18260,9 @@
 							"time": 5.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16849,7 +18277,9 @@
 							"time": 5.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16864,7 +18294,9 @@
 							"time": 5.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16879,7 +18311,9 @@
 							"time": 6.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16894,7 +18328,9 @@
 							"time": 6.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16909,7 +18345,9 @@
 							"time": 6.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16924,7 +18362,9 @@
 							"time": 7.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16939,7 +18379,9 @@
 							"time": 6.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16954,7 +18396,9 @@
 							"time": 7.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16969,7 +18413,9 @@
 							"time": 7.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16984,7 +18430,9 @@
 							"time": 7.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -16999,7 +18447,9 @@
 							"time": 8.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17014,7 +18464,9 @@
 							"time": 8.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17029,7 +18481,9 @@
 							"time": 8.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17044,7 +18498,9 @@
 							"time": 8.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17059,7 +18515,9 @@
 							"time": 9.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17074,7 +18532,9 @@
 							"time": 9.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17089,7 +18549,9 @@
 							"time": 9.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17104,7 +18566,9 @@
 							"time": 10.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17119,7 +18583,9 @@
 							"time": 10.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17134,7 +18600,9 @@
 							"time": 10.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -17159,7 +18627,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.08361, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.08361, 0]
+							"bezier_right_value": [0, -3.08361, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -17178,7 +18648,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -17197,7 +18669,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -17216,7 +18690,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -17235,7 +18711,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -17254,7 +18732,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -17273,7 +18753,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -17292,7 +18774,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -17311,7 +18795,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -17330,7 +18816,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -17349,7 +18837,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -17368,7 +18858,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -17387,7 +18879,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -17406,7 +18900,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -17425,7 +18921,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -17444,7 +18942,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -17463,7 +18963,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -17482,7 +18984,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.08361, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.08361, 0]
+							"bezier_right_value": [0, -3.08361, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17497,7 +19001,9 @@
 							"time": 0.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17512,7 +19018,9 @@
 							"time": 0,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17527,7 +19035,9 @@
 							"time": 0.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17542,7 +19052,9 @@
 							"time": 0.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17557,7 +19069,9 @@
 							"time": 0.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17572,7 +19086,9 @@
 							"time": 1.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17587,7 +19103,9 @@
 							"time": 1.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17602,7 +19120,9 @@
 							"time": 1.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17617,7 +19137,9 @@
 							"time": 2.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17632,7 +19154,9 @@
 							"time": 2.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17647,7 +19171,9 @@
 							"time": 2.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17662,7 +19188,9 @@
 							"time": 3.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17677,7 +19205,9 @@
 							"time": 3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17692,7 +19222,9 @@
 							"time": 3.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17707,7 +19239,9 @@
 							"time": 3.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17722,7 +19256,9 @@
 							"time": 3.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17737,7 +19273,9 @@
 							"time": 4.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17752,7 +19290,9 @@
 							"time": 4.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17767,7 +19307,9 @@
 							"time": 4.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17782,7 +19324,9 @@
 							"time": 4.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17797,7 +19341,9 @@
 							"time": 5.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17812,7 +19358,9 @@
 							"time": 5.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17827,7 +19375,9 @@
 							"time": 5.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17842,7 +19392,9 @@
 							"time": 6.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17857,7 +19409,9 @@
 							"time": 6.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17872,7 +19426,9 @@
 							"time": 6.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17887,7 +19443,9 @@
 							"time": 7.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17902,7 +19460,9 @@
 							"time": 7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17917,7 +19477,9 @@
 							"time": 7.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17932,7 +19494,9 @@
 							"time": 7.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17947,7 +19511,9 @@
 							"time": 7.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17962,7 +19528,9 @@
 							"time": 8.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17977,7 +19545,9 @@
 							"time": 8.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -17992,7 +19562,9 @@
 							"time": 8.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18007,7 +19579,9 @@
 							"time": 8.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18022,7 +19596,9 @@
 							"time": 9.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18037,7 +19613,9 @@
 							"time": 9.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18052,7 +19630,9 @@
 							"time": 9.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18067,7 +19647,9 @@
 							"time": 10.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18082,7 +19664,9 @@
 							"time": 10.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18097,7 +19681,9 @@
 							"time": 10.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -18122,7 +19708,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -18141,7 +19729,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -18160,7 +19750,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -18179,7 +19771,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -18198,7 +19792,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -18217,7 +19813,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -18236,7 +19834,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -18255,7 +19855,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -18274,7 +19876,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -18293,7 +19897,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -18312,7 +19918,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -18331,7 +19939,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -18350,7 +19960,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -18369,7 +19981,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -18388,7 +20002,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -18407,7 +20023,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -18426,7 +20044,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.25468, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.25468, 0]
+							"bezier_right_value": [0, -3.25468, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -18445,7 +20065,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.25468, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.25468, 0]
+							"bezier_right_value": [0, -3.25468, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18460,7 +20082,9 @@
 							"time": 0.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18475,7 +20099,9 @@
 							"time": 0.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18490,7 +20116,9 @@
 							"time": 0.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18505,7 +20133,9 @@
 							"time": 0.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18520,7 +20150,9 @@
 							"time": 0,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18535,7 +20167,9 @@
 							"time": 1.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18550,7 +20184,9 @@
 							"time": 1.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18565,7 +20201,9 @@
 							"time": 1.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18580,7 +20218,9 @@
 							"time": 2.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18595,7 +20235,9 @@
 							"time": 2.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18610,7 +20252,9 @@
 							"time": 2.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18625,7 +20269,9 @@
 							"time": 3.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18640,7 +20286,9 @@
 							"time": 3.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18655,7 +20303,9 @@
 							"time": 3.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18670,7 +20320,9 @@
 							"time": 4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18685,7 +20337,9 @@
 							"time": 3.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18700,7 +20354,9 @@
 							"time": 4.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18715,7 +20371,9 @@
 							"time": 4.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18730,7 +20388,9 @@
 							"time": 4.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18745,7 +20405,9 @@
 							"time": 4.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18760,7 +20422,9 @@
 							"time": 5.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18775,7 +20439,9 @@
 							"time": 5.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18790,7 +20456,9 @@
 							"time": 5.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18805,7 +20473,9 @@
 							"time": 6.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18820,7 +20490,9 @@
 							"time": 6.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18835,7 +20507,9 @@
 							"time": 6.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18850,7 +20524,9 @@
 							"time": 7.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18865,7 +20541,9 @@
 							"time": 7.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18880,7 +20558,9 @@
 							"time": 7.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18895,7 +20575,9 @@
 							"time": 8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18910,7 +20592,9 @@
 							"time": 7.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18925,7 +20609,9 @@
 							"time": 8.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18940,7 +20626,9 @@
 							"time": 8.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18955,7 +20643,9 @@
 							"time": 8.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18970,7 +20660,9 @@
 							"time": 8.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -18985,7 +20677,9 @@
 							"time": 9.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19000,7 +20694,9 @@
 							"time": 9.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19015,7 +20711,9 @@
 							"time": 9.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19030,7 +20728,9 @@
 							"time": 10.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19045,7 +20745,9 @@
 							"time": 10.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -19070,7 +20772,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.1693, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.1693, 0]
+							"bezier_right_value": [0, -3.1693, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -19089,7 +20793,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -19108,7 +20814,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -19127,7 +20835,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -19146,7 +20856,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -19165,7 +20877,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -19184,7 +20898,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -19203,7 +20919,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -19222,7 +20940,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -19241,7 +20961,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -19260,7 +20982,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -19279,7 +21003,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -19298,7 +21024,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -19317,7 +21045,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -19336,7 +21066,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -19355,7 +21087,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -19374,7 +21108,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -19393,7 +21129,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.1693, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.1693, 0]
+							"bezier_right_value": [0, -3.1693, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19408,7 +21146,9 @@
 							"time": 0.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19423,7 +21163,9 @@
 							"time": 0.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19438,7 +21180,9 @@
 							"time": 0.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19453,7 +21197,9 @@
 							"time": 0.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19468,7 +21214,9 @@
 							"time": 1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19483,7 +21231,9 @@
 							"time": 1.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19498,7 +21248,9 @@
 							"time": 1.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19513,7 +21265,9 @@
 							"time": 1.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19528,7 +21282,9 @@
 							"time": 2.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19543,7 +21299,9 @@
 							"time": 2.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19558,7 +21316,9 @@
 							"time": 2.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19573,7 +21333,9 @@
 							"time": 3.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19588,7 +21350,9 @@
 							"time": 3.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19603,7 +21367,9 @@
 							"time": 3.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19618,7 +21384,9 @@
 							"time": 3.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19633,7 +21401,9 @@
 							"time": 4.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19648,7 +21418,9 @@
 							"time": 4.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19663,7 +21435,9 @@
 							"time": 4.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19678,7 +21452,9 @@
 							"time": 4.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19693,7 +21469,9 @@
 							"time": 5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19708,7 +21486,9 @@
 							"time": 5.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19723,7 +21503,9 @@
 							"time": 5.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19738,7 +21520,9 @@
 							"time": 5.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19753,7 +21537,9 @@
 							"time": 6.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19768,7 +21554,9 @@
 							"time": 6.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19783,7 +21571,9 @@
 							"time": 6.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19798,7 +21588,9 @@
 							"time": 7.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19813,7 +21605,9 @@
 							"time": 7.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19828,7 +21622,9 @@
 							"time": 7.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19843,7 +21639,9 @@
 							"time": 7.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19858,7 +21656,9 @@
 							"time": 8.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19873,7 +21673,9 @@
 							"time": 8.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19888,7 +21690,9 @@
 							"time": 8.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19903,7 +21707,9 @@
 							"time": 8.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19918,7 +21724,9 @@
 							"time": 9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19933,7 +21741,9 @@
 							"time": 9.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19948,7 +21758,9 @@
 							"time": 9.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19963,7 +21775,9 @@
 							"time": 9.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19978,7 +21792,9 @@
 							"time": 10.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -19993,7 +21809,9 @@
 							"time": 10.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -20018,7 +21836,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.1693, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.1693, 0]
+							"bezier_right_value": [0, -3.1693, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20037,7 +21857,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20056,7 +21878,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20075,7 +21899,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20094,7 +21920,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20113,7 +21941,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20132,7 +21962,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20151,7 +21983,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20170,7 +22004,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20189,7 +22025,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20208,7 +22046,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20227,7 +22067,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20246,7 +22088,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20265,7 +22109,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20284,7 +22130,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20303,7 +22151,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20322,7 +22172,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20341,7 +22193,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.1693, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.1693, 0]
+							"bezier_right_value": [0, -3.1693, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20356,7 +22210,9 @@
 							"time": 0.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20371,7 +22227,9 @@
 							"time": 0.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20386,7 +22244,9 @@
 							"time": 0.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20401,7 +22261,9 @@
 							"time": 0.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20416,7 +22278,9 @@
 							"time": 1.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20431,7 +22295,9 @@
 							"time": 1.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20446,7 +22312,9 @@
 							"time": 1.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20461,7 +22329,9 @@
 							"time": 1.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20476,7 +22346,9 @@
 							"time": 2.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20491,7 +22363,9 @@
 							"time": 2.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20506,7 +22380,9 @@
 							"time": 2.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20521,7 +22397,9 @@
 							"time": 3.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20536,7 +22414,9 @@
 							"time": 3.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20551,7 +22431,9 @@
 							"time": 3.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20566,7 +22448,9 @@
 							"time": 3.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20581,7 +22465,9 @@
 							"time": 4.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20596,7 +22482,9 @@
 							"time": 4.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20611,7 +22499,9 @@
 							"time": 4.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20626,7 +22516,9 @@
 							"time": 4.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20641,7 +22533,9 @@
 							"time": 5.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20656,7 +22550,9 @@
 							"time": 5.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20671,7 +22567,9 @@
 							"time": 5.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20686,7 +22584,9 @@
 							"time": 5.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20701,7 +22601,9 @@
 							"time": 6.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20716,7 +22618,9 @@
 							"time": 6.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20731,7 +22635,9 @@
 							"time": 6.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20746,7 +22652,9 @@
 							"time": 7.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20761,7 +22669,9 @@
 							"time": 7.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20776,7 +22686,9 @@
 							"time": 7.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20791,7 +22703,9 @@
 							"time": 7.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20806,7 +22720,9 @@
 							"time": 8.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20821,7 +22737,9 @@
 							"time": 8.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20836,7 +22754,9 @@
 							"time": 8.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20851,7 +22771,9 @@
 							"time": 8.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20866,7 +22788,9 @@
 							"time": 9.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20881,7 +22805,9 @@
 							"time": 9.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20896,7 +22822,9 @@
 							"time": 9.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20911,7 +22839,9 @@
 							"time": 9.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -20926,7 +22856,9 @@
 							"time": 0,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -20951,7 +22883,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20970,7 +22904,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -20989,7 +22925,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21008,7 +22946,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21027,7 +22967,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21046,7 +22988,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21065,7 +23009,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21084,7 +23030,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21103,7 +23051,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21122,7 +23072,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21141,7 +23093,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21160,7 +23114,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21179,7 +23135,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21198,7 +23156,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21217,7 +23177,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21236,7 +23198,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21255,7 +23219,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.19307, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.19307, 0]
+							"bezier_right_value": [0, -3.19307, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21274,7 +23240,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.19307, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.19307, 0]
+							"bezier_right_value": [0, -3.19307, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21289,7 +23257,9 @@
 							"time": 0,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21304,7 +23274,9 @@
 							"time": 0.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21319,7 +23291,9 @@
 							"time": 0.3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21334,7 +23308,9 @@
 							"time": 0.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21349,7 +23325,9 @@
 							"time": 0.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21364,7 +23342,9 @@
 							"time": 1.1,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21379,7 +23359,9 @@
 							"time": 2.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21394,7 +23376,9 @@
 							"time": 2.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21409,7 +23393,9 @@
 							"time": 2.7,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21424,7 +23410,9 @@
 							"time": 1.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21439,7 +23427,9 @@
 							"time": 1.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21454,7 +23444,9 @@
 							"time": 1.9,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21469,7 +23461,9 @@
 							"time": 4.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21484,7 +23478,9 @@
 							"time": 4.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21499,7 +23495,9 @@
 							"time": 5.1,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21514,7 +23512,9 @@
 							"time": 3.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21529,7 +23529,9 @@
 							"time": 3.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21544,7 +23546,9 @@
 							"time": 3.5,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21559,7 +23563,9 @@
 							"time": 4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21574,7 +23580,9 @@
 							"time": 4.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21589,7 +23597,9 @@
 							"time": 4.3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21604,7 +23614,9 @@
 							"time": 5.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21619,7 +23631,9 @@
 							"time": 5.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21634,7 +23648,9 @@
 							"time": 5.9,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21649,7 +23665,9 @@
 							"time": 8.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21664,7 +23682,9 @@
 							"time": 8.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21679,7 +23699,9 @@
 							"time": 9.1,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21694,7 +23716,9 @@
 							"time": 9.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21709,7 +23733,9 @@
 							"time": 9.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21724,7 +23750,9 @@
 							"time": 9.9,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21739,7 +23767,9 @@
 							"time": 8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21754,7 +23784,9 @@
 							"time": 8.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21769,7 +23801,9 @@
 							"time": 8.3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21784,7 +23818,9 @@
 							"time": 6.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21799,7 +23835,9 @@
 							"time": 6.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21814,7 +23852,9 @@
 							"time": 6.7,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21829,7 +23869,9 @@
 							"time": 7.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21844,7 +23886,9 @@
 							"time": 7.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -21859,7 +23903,9 @@
 							"time": 7.5,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -21884,7 +23930,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.19307, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.19307, 0]
+							"bezier_right_value": [0, -3.19307, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21903,7 +23951,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21922,7 +23972,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21941,7 +23993,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21960,7 +24014,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21979,7 +24035,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -21998,7 +24056,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22017,7 +24077,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22036,7 +24098,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22055,7 +24119,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22074,7 +24140,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22093,7 +24161,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22112,7 +24182,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22131,7 +24203,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22150,7 +24224,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22169,7 +24245,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22188,7 +24266,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22207,7 +24287,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.19307, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.19307, 0]
+							"bezier_right_value": [0, -3.19307, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22222,7 +24304,9 @@
 							"time": 8.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22237,7 +24321,9 @@
 							"time": 9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22252,7 +24338,9 @@
 							"time": 9.15,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22267,7 +24355,9 @@
 							"time": 9.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22282,7 +24372,9 @@
 							"time": 9.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22297,7 +24389,9 @@
 							"time": 9.95,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22312,7 +24406,9 @@
 							"time": 8.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22327,7 +24423,9 @@
 							"time": 8.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22342,7 +24440,9 @@
 							"time": 8.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22357,7 +24457,9 @@
 							"time": 6.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22372,7 +24474,9 @@
 							"time": 6.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22387,7 +24491,9 @@
 							"time": 6.75,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22402,7 +24508,9 @@
 							"time": 7.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22417,7 +24525,9 @@
 							"time": 7.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22432,7 +24542,9 @@
 							"time": 7.55,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22447,7 +24559,9 @@
 							"time": 0.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22462,7 +24576,9 @@
 							"time": 0.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22477,7 +24593,9 @@
 							"time": 0.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22492,7 +24610,9 @@
 							"time": 0.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22507,7 +24627,9 @@
 							"time": 1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22522,7 +24644,9 @@
 							"time": 1.15,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22537,7 +24661,9 @@
 							"time": 2.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22552,7 +24678,9 @@
 							"time": 2.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22567,7 +24695,9 @@
 							"time": 2.75,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22582,7 +24712,9 @@
 							"time": 1.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22597,7 +24729,9 @@
 							"time": 1.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22612,7 +24746,9 @@
 							"time": 1.95,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22627,7 +24763,9 @@
 							"time": 4.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22642,7 +24780,9 @@
 							"time": 5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22657,7 +24797,9 @@
 							"time": 5.15,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22672,7 +24814,9 @@
 							"time": 3.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22687,7 +24831,9 @@
 							"time": 3.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22702,7 +24848,9 @@
 							"time": 3.55,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22717,7 +24865,9 @@
 							"time": 4.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22732,7 +24882,9 @@
 							"time": 4.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22747,7 +24899,9 @@
 							"time": 4.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22762,7 +24916,9 @@
 							"time": 5.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22777,7 +24933,9 @@
 							"time": 5.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -22792,7 +24950,9 @@
 							"time": 5.95,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -22817,7 +24977,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.19307, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.19307, 0]
+							"bezier_right_value": [0, -3.19307, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22836,7 +24998,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22855,7 +25019,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22874,7 +25040,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22893,7 +25061,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22912,7 +25082,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22931,7 +25103,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22950,7 +25124,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22969,7 +25145,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -22988,7 +25166,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23007,7 +25187,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23026,7 +25208,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23045,7 +25229,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23064,7 +25250,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23083,7 +25271,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23102,7 +25292,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23121,7 +25313,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23140,7 +25334,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.19307, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.19307, 0]
+							"bezier_right_value": [0, -3.19307, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23155,7 +25351,9 @@
 							"time": 8.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23170,7 +25368,9 @@
 							"time": 9.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23185,7 +25385,9 @@
 							"time": 9.2,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23200,7 +25402,9 @@
 							"time": 9.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23215,7 +25419,9 @@
 							"time": 9.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23230,7 +25436,9 @@
 							"time": 10,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23245,7 +25453,9 @@
 							"time": 8.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23260,7 +25470,9 @@
 							"time": 8.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23275,7 +25487,9 @@
 							"time": 8.4,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23290,7 +25504,9 @@
 							"time": 6.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23305,7 +25521,9 @@
 							"time": 6.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23320,7 +25538,9 @@
 							"time": 6.8,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23335,7 +25555,9 @@
 							"time": 7.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23350,7 +25572,9 @@
 							"time": 7.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23365,7 +25589,9 @@
 							"time": 7.6,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23380,7 +25606,9 @@
 							"time": 0.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23395,7 +25623,9 @@
 							"time": 0.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23410,7 +25640,9 @@
 							"time": 0.4,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23425,7 +25657,9 @@
 							"time": 0.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23440,7 +25674,9 @@
 							"time": 1.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23455,7 +25691,9 @@
 							"time": 1.2,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23470,7 +25708,9 @@
 							"time": 2.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23485,7 +25725,9 @@
 							"time": 2.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23500,7 +25742,9 @@
 							"time": 2.8,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23515,7 +25759,9 @@
 							"time": 1.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23530,7 +25776,9 @@
 							"time": 1.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23545,7 +25793,9 @@
 							"time": 2,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23560,7 +25810,9 @@
 							"time": 4.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23575,7 +25827,9 @@
 							"time": 5.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23590,7 +25844,9 @@
 							"time": 5.2,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23605,7 +25861,9 @@
 							"time": 3.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23620,7 +25878,9 @@
 							"time": 3.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23635,7 +25895,9 @@
 							"time": 3.6,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23650,7 +25912,9 @@
 							"time": 4.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23665,7 +25929,9 @@
 							"time": 4.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23680,7 +25946,9 @@
 							"time": 4.4,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23695,7 +25963,9 @@
 							"time": 5.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23710,7 +25980,9 @@
 							"time": 5.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -23725,7 +25997,9 @@
 							"time": 6,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -23750,7 +26024,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.1693, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.1693, 0]
+							"bezier_right_value": [0, -3.1693, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23769,7 +26045,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23788,7 +26066,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23807,7 +26087,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23826,7 +26108,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23845,7 +26129,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23864,7 +26150,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23883,7 +26171,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23902,7 +26192,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23921,7 +26213,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23940,7 +26234,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23959,7 +26255,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23978,7 +26276,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -23997,7 +26297,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24016,7 +26318,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24035,7 +26339,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24054,7 +26360,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24073,7 +26381,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.1693, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.1693, 0]
+							"bezier_right_value": [0, -3.1693, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24088,7 +26398,9 @@
 							"time": 8.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24103,7 +26415,9 @@
 							"time": 9.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24118,7 +26432,9 @@
 							"time": 9.25,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24133,7 +26449,9 @@
 							"time": 9.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24148,7 +26466,9 @@
 							"time": 9.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24163,7 +26483,9 @@
 							"time": 10.05,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24178,7 +26500,9 @@
 							"time": 8.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24193,7 +26517,9 @@
 							"time": 8.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24208,7 +26534,9 @@
 							"time": 8.45,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24223,7 +26551,9 @@
 							"time": 6.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24238,7 +26568,9 @@
 							"time": 6.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24253,7 +26585,9 @@
 							"time": 6.85,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24268,7 +26602,9 @@
 							"time": 7.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24283,7 +26619,9 @@
 							"time": 7.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24298,7 +26636,9 @@
 							"time": 7.65,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24313,7 +26653,9 @@
 							"time": 0.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24328,7 +26670,9 @@
 							"time": 0.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24343,7 +26687,9 @@
 							"time": 0.45,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24358,7 +26704,9 @@
 							"time": 0.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24373,7 +26721,9 @@
 							"time": 1.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24388,7 +26738,9 @@
 							"time": 1.25,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24403,7 +26755,9 @@
 							"time": 2.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24418,7 +26772,9 @@
 							"time": 2.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24433,7 +26789,9 @@
 							"time": 2.85,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24448,7 +26806,9 @@
 							"time": 1.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24463,7 +26823,9 @@
 							"time": 1.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24478,7 +26840,9 @@
 							"time": 2.05,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24493,7 +26857,9 @@
 							"time": 4.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24508,7 +26874,9 @@
 							"time": 5.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24523,7 +26891,9 @@
 							"time": 5.25,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24538,7 +26908,9 @@
 							"time": 3.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24553,7 +26925,9 @@
 							"time": 3.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24568,7 +26942,9 @@
 							"time": 3.65,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24583,7 +26959,9 @@
 							"time": 4.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24598,7 +26976,9 @@
 							"time": 4.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24613,7 +26993,9 @@
 							"time": 4.45,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24628,7 +27010,9 @@
 							"time": 5.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24643,7 +27027,9 @@
 							"time": 5.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -24658,7 +27044,9 @@
 							"time": 6.05,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -24683,7 +27071,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24702,7 +27092,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24721,7 +27113,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24740,7 +27134,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24759,7 +27155,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24778,7 +27176,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24797,7 +27197,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24816,7 +27218,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24835,7 +27239,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24854,7 +27260,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24873,7 +27281,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24892,7 +27302,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24911,7 +27323,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24930,7 +27344,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24949,7 +27365,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24968,7 +27386,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -24987,7 +27407,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.1693, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.1693, 0]
+							"bezier_right_value": [0, -3.1693, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -25006,7 +27428,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.1693, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.1693, 0]
+							"bezier_right_value": [0, -3.1693, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25021,7 +27445,9 @@
 							"time": 9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25036,7 +27462,9 @@
 							"time": 9.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25051,7 +27479,9 @@
 							"time": 9.3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25066,7 +27496,9 @@
 							"time": 9.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25081,7 +27513,9 @@
 							"time": 9.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25096,7 +27530,9 @@
 							"time": 10.1,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25111,7 +27547,9 @@
 							"time": 8.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25126,7 +27564,9 @@
 							"time": 8.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25141,7 +27581,9 @@
 							"time": 8.5,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25156,7 +27598,9 @@
 							"time": 6.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25171,7 +27615,9 @@
 							"time": 6.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25186,7 +27632,9 @@
 							"time": 6.9,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25201,7 +27649,9 @@
 							"time": 7.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25216,7 +27666,9 @@
 							"time": 7.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25231,7 +27683,9 @@
 							"time": 7.7,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25246,7 +27700,9 @@
 							"time": 0.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25261,7 +27717,9 @@
 							"time": 0.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25276,7 +27734,9 @@
 							"time": 0.5,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25291,7 +27751,9 @@
 							"time": 1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25306,7 +27768,9 @@
 							"time": 1.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25321,7 +27785,9 @@
 							"time": 1.3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25336,7 +27802,9 @@
 							"time": 2.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25351,7 +27819,9 @@
 							"time": 2.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25366,7 +27836,9 @@
 							"time": 2.9,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25381,7 +27853,9 @@
 							"time": 1.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25396,7 +27870,9 @@
 							"time": 1.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25411,7 +27887,9 @@
 							"time": 2.1,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25426,7 +27904,9 @@
 							"time": 5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25441,7 +27921,9 @@
 							"time": 5.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25456,7 +27938,9 @@
 							"time": 5.3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25471,7 +27955,9 @@
 							"time": 3.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25486,7 +27972,9 @@
 							"time": 3.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25501,7 +27989,9 @@
 							"time": 3.7,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25516,7 +28006,9 @@
 							"time": 4.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25531,7 +28023,9 @@
 							"time": 4.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25546,7 +28040,9 @@
 							"time": 4.5,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25561,7 +28057,9 @@
 							"time": 5.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25576,7 +28074,9 @@
 							"time": 5.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25591,7 +28091,9 @@
 							"time": 6.1,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -25616,7 +28118,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.25468, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.25468, 0]
+							"bezier_right_value": [0, -3.25468, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -25635,7 +28139,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -25654,7 +28160,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -25673,7 +28181,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -25692,7 +28202,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -25711,7 +28223,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -25730,7 +28244,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -25749,7 +28265,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -25768,7 +28286,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -25787,7 +28307,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -25806,7 +28328,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -25825,7 +28349,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -25844,7 +28370,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -25863,7 +28391,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -25882,7 +28412,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -25901,7 +28433,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -25920,7 +28454,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -25939,7 +28475,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.25468, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.25468, 0]
+							"bezier_right_value": [0, -3.25468, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25954,7 +28492,9 @@
 							"time": 9.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25969,7 +28509,9 @@
 							"time": 9.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25984,7 +28526,9 @@
 							"time": 9.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -25999,7 +28543,9 @@
 							"time": 9.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26014,7 +28560,9 @@
 							"time": 10,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26029,7 +28577,9 @@
 							"time": 10.15,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26044,7 +28594,9 @@
 							"time": 8.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26059,7 +28611,9 @@
 							"time": 8.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26074,7 +28628,9 @@
 							"time": 8.55,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26089,7 +28645,9 @@
 							"time": 6.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26104,7 +28662,9 @@
 							"time": 6.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26119,7 +28679,9 @@
 							"time": 6.95,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26134,7 +28696,9 @@
 							"time": 7.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26149,7 +28713,9 @@
 							"time": 7.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26164,7 +28730,9 @@
 							"time": 7.75,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26179,7 +28747,9 @@
 							"time": 0.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26194,7 +28764,9 @@
 							"time": 0.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26209,7 +28781,9 @@
 							"time": 0.55,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26224,7 +28798,9 @@
 							"time": 1.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26239,7 +28815,9 @@
 							"time": 1.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26254,7 +28832,9 @@
 							"time": 1.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26269,7 +28849,9 @@
 							"time": 2.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26284,7 +28866,9 @@
 							"time": 2.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26299,7 +28883,9 @@
 							"time": 2.95,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26314,7 +28900,9 @@
 							"time": 1.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26329,7 +28917,9 @@
 							"time": 2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26344,7 +28934,9 @@
 							"time": 2.15,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26359,7 +28951,9 @@
 							"time": 5.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26374,7 +28968,9 @@
 							"time": 5.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26389,7 +28985,9 @@
 							"time": 5.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26404,7 +29002,9 @@
 							"time": 3.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26419,7 +29019,9 @@
 							"time": 3.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26434,7 +29036,9 @@
 							"time": 3.75,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26449,7 +29053,9 @@
 							"time": 4.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26464,7 +29070,9 @@
 							"time": 4.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26479,7 +29087,9 @@
 							"time": 4.55,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26494,7 +29104,9 @@
 							"time": 5.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26509,7 +29121,9 @@
 							"time": 6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26524,7 +29138,9 @@
 							"time": 6.15,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -26549,7 +29165,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.08361, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.08361, 0]
+							"bezier_right_value": [0, -3.08361, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -26568,7 +29186,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -26587,7 +29207,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -26606,7 +29228,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -26625,7 +29249,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -26644,7 +29270,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -26663,7 +29291,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -26682,7 +29312,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -26701,7 +29333,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -26720,7 +29354,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -26739,7 +29375,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -26758,7 +29396,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -26777,7 +29417,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -26796,7 +29438,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -26815,7 +29459,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -26834,7 +29480,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -26853,7 +29501,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -26872,7 +29522,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.08361, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.08361, 0]
+							"bezier_right_value": [0, -3.08361, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26887,7 +29539,9 @@
 							"time": 9.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26902,7 +29556,9 @@
 							"time": 9.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26917,7 +29573,9 @@
 							"time": 9.4,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26932,7 +29590,9 @@
 							"time": 9.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26947,7 +29607,9 @@
 							"time": 10.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26962,7 +29624,9 @@
 							"time": 10.2,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26977,7 +29641,9 @@
 							"time": 8.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -26992,7 +29658,9 @@
 							"time": 8.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27007,7 +29675,9 @@
 							"time": 8.6,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27022,7 +29692,9 @@
 							"time": 6.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27037,7 +29709,9 @@
 							"time": 6.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27052,7 +29726,9 @@
 							"time": 7,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27067,7 +29743,9 @@
 							"time": 7.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27082,7 +29760,9 @@
 							"time": 7.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27097,7 +29777,9 @@
 							"time": 7.8,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27112,7 +29794,9 @@
 							"time": 0.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27127,7 +29811,9 @@
 							"time": 0.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27142,7 +29828,9 @@
 							"time": 0.6,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27157,7 +29845,9 @@
 							"time": 1.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27172,7 +29862,9 @@
 							"time": 1.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27187,7 +29879,9 @@
 							"time": 1.4,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27202,7 +29896,9 @@
 							"time": 2.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27217,7 +29913,9 @@
 							"time": 2.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27232,7 +29930,9 @@
 							"time": 3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27247,7 +29947,9 @@
 							"time": 1.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27262,7 +29964,9 @@
 							"time": 2.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27277,7 +29981,9 @@
 							"time": 2.2,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27292,7 +29998,9 @@
 							"time": 5.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27307,7 +30015,9 @@
 							"time": 5.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27322,7 +30032,9 @@
 							"time": 5.4,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27337,7 +30049,9 @@
 							"time": 3.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27352,7 +30066,9 @@
 							"time": 3.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27367,7 +30083,9 @@
 							"time": 3.8,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27382,7 +30100,9 @@
 							"time": 4.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27397,7 +30117,9 @@
 							"time": 4.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27412,7 +30134,9 @@
 							"time": 4.6,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27427,7 +30151,9 @@
 							"time": 5.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27442,7 +30168,9 @@
 							"time": 6.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27457,7 +30185,9 @@
 							"time": 6.2,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -27482,7 +30212,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.08361, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.08361, 0]
+							"bezier_right_value": [0, -3.08361, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -27501,7 +30233,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -27520,7 +30254,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -27539,7 +30275,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -27558,7 +30296,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -27577,7 +30317,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -27596,7 +30338,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -27615,7 +30359,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -27634,7 +30380,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -27653,7 +30401,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -27672,7 +30422,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -27691,7 +30443,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -27710,7 +30464,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -27729,7 +30485,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -27748,7 +30506,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -27767,7 +30527,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -27786,7 +30548,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -27805,7 +30569,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.08361, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.08361, 0]
+							"bezier_right_value": [0, -3.08361, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27820,7 +30586,9 @@
 							"time": 9.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27835,7 +30603,9 @@
 							"time": 9.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27850,7 +30620,9 @@
 							"time": 9.45,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27865,7 +30637,9 @@
 							"time": 9.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27880,7 +30654,9 @@
 							"time": 10.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27895,7 +30671,9 @@
 							"time": 10.25,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27910,7 +30688,9 @@
 							"time": 8.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27925,7 +30705,9 @@
 							"time": 8.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27940,7 +30722,9 @@
 							"time": 8.65,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27955,7 +30739,9 @@
 							"time": 6.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27970,7 +30756,9 @@
 							"time": 6.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -27985,7 +30773,9 @@
 							"time": 7.05,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28000,7 +30790,9 @@
 							"time": 7.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28015,7 +30807,9 @@
 							"time": 7.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28030,7 +30824,9 @@
 							"time": 7.85,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28045,7 +30841,9 @@
 							"time": 0.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28060,7 +30858,9 @@
 							"time": 0.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28075,7 +30875,9 @@
 							"time": 0.65,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28090,7 +30892,9 @@
 							"time": 1.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28105,7 +30909,9 @@
 							"time": 1.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28120,7 +30926,9 @@
 							"time": 1.45,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28135,7 +30943,9 @@
 							"time": 2.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28150,7 +30960,9 @@
 							"time": 2.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28165,7 +30977,9 @@
 							"time": 3.05,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28180,7 +30994,9 @@
 							"time": 1.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28195,7 +31011,9 @@
 							"time": 2.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28210,7 +31028,9 @@
 							"time": 2.25,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28225,7 +31045,9 @@
 							"time": 5.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28240,7 +31062,9 @@
 							"time": 5.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28255,7 +31079,9 @@
 							"time": 5.45,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28270,7 +31096,9 @@
 							"time": 3.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28285,7 +31113,9 @@
 							"time": 3.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28300,7 +31130,9 @@
 							"time": 3.85,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28315,7 +31147,9 @@
 							"time": 4.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28330,7 +31164,9 @@
 							"time": 4.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28345,7 +31181,9 @@
 							"time": 4.65,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28360,7 +31198,9 @@
 							"time": 5.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28375,7 +31215,9 @@
 							"time": 6.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28390,7 +31232,9 @@
 							"time": 6.25,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -28415,7 +31259,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 2.95145, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -2.95145, 0]
+							"bezier_right_value": [0, -2.95145, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -28434,7 +31280,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -28453,7 +31301,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -28472,7 +31322,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -28491,7 +31343,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -28510,7 +31364,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -28529,7 +31385,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -28548,7 +31406,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -28567,7 +31427,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -28586,7 +31448,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -28605,7 +31469,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -28624,7 +31490,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -28643,7 +31511,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -28662,7 +31532,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -28681,7 +31553,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -28700,7 +31574,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -28719,7 +31595,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -28738,7 +31616,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 2.95145, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -2.95145, 0]
+							"bezier_right_value": [0, -2.95145, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28753,7 +31633,9 @@
 							"time": 9.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28768,7 +31650,9 @@
 							"time": 9.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28783,7 +31667,9 @@
 							"time": 9.5,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28798,7 +31684,9 @@
 							"time": 10,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28813,7 +31701,9 @@
 							"time": 10.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28828,7 +31718,9 @@
 							"time": 10.3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28843,7 +31735,9 @@
 							"time": 8.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28858,7 +31752,9 @@
 							"time": 8.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28873,7 +31769,9 @@
 							"time": 8.7,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28888,7 +31786,9 @@
 							"time": 6.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28903,7 +31803,9 @@
 							"time": 6.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28918,7 +31820,9 @@
 							"time": 7.1,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28933,7 +31837,9 @@
 							"time": 7.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28948,7 +31854,9 @@
 							"time": 7.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28963,7 +31871,9 @@
 							"time": 7.9,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28978,7 +31888,9 @@
 							"time": 0.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -28993,7 +31905,9 @@
 							"time": 0.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29008,7 +31922,9 @@
 							"time": 0.7,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29023,7 +31939,9 @@
 							"time": 1.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29038,7 +31956,9 @@
 							"time": 1.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29053,7 +31973,9 @@
 							"time": 1.5,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29068,7 +31990,9 @@
 							"time": 2.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29083,7 +32007,9 @@
 							"time": 2.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29098,7 +32024,9 @@
 							"time": 3.1,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29113,7 +32041,9 @@
 							"time": 2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29128,7 +32058,9 @@
 							"time": 2.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29143,7 +32075,9 @@
 							"time": 2.3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29158,7 +32092,9 @@
 							"time": 5.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29173,7 +32109,9 @@
 							"time": 5.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29188,7 +32126,9 @@
 							"time": 5.5,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29203,7 +32143,9 @@
 							"time": 3.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29218,7 +32160,9 @@
 							"time": 3.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29233,7 +32177,9 @@
 							"time": 3.9,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29248,7 +32194,9 @@
 							"time": 4.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29263,7 +32211,9 @@
 							"time": 4.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29278,7 +32228,9 @@
 							"time": 4.7,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29293,7 +32245,9 @@
 							"time": 6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29308,7 +32262,9 @@
 							"time": 6.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29323,7 +32279,9 @@
 							"time": 6.3,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -29348,7 +32306,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 2.95145, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -2.95145, 0]
+							"bezier_right_value": [0, -2.95145, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -29367,7 +32327,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -29386,7 +32348,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -29405,7 +32369,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -29424,7 +32390,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -29443,7 +32411,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -29462,7 +32432,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -29481,7 +32453,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -29500,7 +32474,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -29519,7 +32495,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -29538,7 +32516,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -29557,7 +32537,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -29576,7 +32558,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -29595,7 +32579,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -29614,7 +32600,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -29633,7 +32621,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -29652,7 +32642,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -29671,7 +32663,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 2.95145, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -2.95145, 0]
+							"bezier_right_value": [0, -2.95145, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29686,7 +32680,9 @@
 							"time": 9.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29701,7 +32697,9 @@
 							"time": 9.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29716,7 +32714,9 @@
 							"time": 9.55,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29731,7 +32731,9 @@
 							"time": 10.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29746,7 +32748,9 @@
 							"time": 10.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29761,7 +32765,9 @@
 							"time": 10.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29776,7 +32782,9 @@
 							"time": 8.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29791,7 +32799,9 @@
 							"time": 8.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29806,7 +32816,9 @@
 							"time": 8.75,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29821,7 +32833,9 @@
 							"time": 6.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29836,7 +32850,9 @@
 							"time": 7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29851,7 +32867,9 @@
 							"time": 7.15,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29866,7 +32884,9 @@
 							"time": 7.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29881,7 +32901,9 @@
 							"time": 7.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29896,7 +32918,9 @@
 							"time": 7.95,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29911,7 +32935,9 @@
 							"time": 0.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29926,7 +32952,9 @@
 							"time": 0.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29941,7 +32969,9 @@
 							"time": 0.75,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29956,7 +32986,9 @@
 							"time": 1.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29971,7 +33003,9 @@
 							"time": 1.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -29986,7 +33020,9 @@
 							"time": 1.55,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30001,7 +33037,9 @@
 							"time": 2.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30016,7 +33054,9 @@
 							"time": 3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30031,7 +33071,9 @@
 							"time": 3.15,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30046,7 +33088,9 @@
 							"time": 2.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30061,7 +33105,9 @@
 							"time": 2.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30076,7 +33122,9 @@
 							"time": 2.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30091,7 +33139,9 @@
 							"time": 5.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30106,7 +33156,9 @@
 							"time": 5.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30121,7 +33173,9 @@
 							"time": 5.55,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30136,7 +33190,9 @@
 							"time": 3.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30151,7 +33207,9 @@
 							"time": 3.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30166,7 +33224,9 @@
 							"time": 3.95,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30181,7 +33241,9 @@
 							"time": 4.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30196,7 +33258,9 @@
 							"time": 4.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30211,7 +33275,9 @@
 							"time": 4.75,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30226,7 +33292,9 @@
 							"time": 6.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30241,7 +33309,9 @@
 							"time": 6.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30256,7 +33326,9 @@
 							"time": 6.35,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -30281,7 +33353,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -30300,7 +33374,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -30319,7 +33395,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -30338,7 +33416,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -30357,7 +33437,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -30376,7 +33458,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -30395,7 +33479,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -30414,7 +33500,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -30433,7 +33521,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -30452,7 +33542,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -30471,7 +33563,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -30490,7 +33584,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -30509,7 +33605,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -30528,7 +33626,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -30547,7 +33647,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -30566,7 +33668,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -30585,7 +33689,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 2.95145, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -2.95145, 0]
+							"bezier_right_value": [0, -2.95145, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -30604,7 +33710,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 2.95145, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -2.95145, 0]
+							"bezier_right_value": [0, -2.95145, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30619,7 +33727,9 @@
 							"time": 0.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30634,7 +33744,9 @@
 							"time": 0.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30649,7 +33761,9 @@
 							"time": 0.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30664,7 +33778,9 @@
 							"time": 1.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30679,7 +33795,9 @@
 							"time": 1.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30694,7 +33812,9 @@
 							"time": 1.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30709,7 +33829,9 @@
 							"time": 3.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30724,7 +33846,9 @@
 							"time": 2.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30739,7 +33863,9 @@
 							"time": 3.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30754,7 +33880,9 @@
 							"time": 2.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30769,7 +33897,9 @@
 							"time": 2.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30784,7 +33914,9 @@
 							"time": 2.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30799,7 +33931,9 @@
 							"time": 4.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30814,7 +33948,9 @@
 							"time": 4.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30829,7 +33965,9 @@
 							"time": 4.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30844,7 +33982,9 @@
 							"time": 3.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30859,7 +33999,9 @@
 							"time": 3.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30874,7 +34016,9 @@
 							"time": 4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30889,7 +34033,9 @@
 							"time": 6.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30904,7 +34050,9 @@
 							"time": 6.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30919,7 +34067,9 @@
 							"time": 6.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30934,7 +34084,9 @@
 							"time": 5.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30949,7 +34101,9 @@
 							"time": 5.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30964,7 +34118,9 @@
 							"time": 5.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30979,7 +34135,9 @@
 							"time": 7.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -30994,7 +34152,9 @@
 							"time": 7.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31009,7 +34169,9 @@
 							"time": 8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31024,7 +34186,9 @@
 							"time": 7.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31039,7 +34203,9 @@
 							"time": 6.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31054,7 +34220,9 @@
 							"time": 7.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31069,7 +34237,9 @@
 							"time": 9.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31084,7 +34254,9 @@
 							"time": 9.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31099,7 +34271,9 @@
 							"time": 9.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31114,7 +34288,9 @@
 							"time": 10.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31129,7 +34305,9 @@
 							"time": 10.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31144,7 +34322,9 @@
 							"time": 10.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31159,7 +34339,9 @@
 							"time": 8.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31174,7 +34356,9 @@
 							"time": 8.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31189,7 +34373,9 @@
 							"time": 8.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -31214,7 +34400,9 @@
 							"bezier_left_time": [-0.1, -0.07476, -0.1],
 							"bezier_left_value": [0, 1.63617, 0],
 							"bezier_right_time": [0.1, 0.07476, 0.1],
-							"bezier_right_value": [0, -1.63617, 0]
+							"bezier_right_value": [0, -1.63617, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -31233,7 +34421,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -31252,7 +34442,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -31271,7 +34463,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -31290,7 +34484,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -31309,7 +34505,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -31328,7 +34526,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -31347,7 +34547,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -31366,7 +34568,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -31385,7 +34589,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -31404,7 +34610,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -31423,7 +34631,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -31442,7 +34652,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -31461,7 +34673,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -31480,7 +34694,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -31499,7 +34715,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -31518,7 +34736,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -31537,7 +34757,9 @@
 							"bezier_left_time": [-0.1, -0.07476, -0.1],
 							"bezier_left_value": [0, 2.87339, 0],
 							"bezier_right_time": [0.1, 0.07476, 0.1],
-							"bezier_right_value": [0, -2.87339, 0]
+							"bezier_right_value": [0, -2.87339, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31552,7 +34774,9 @@
 							"time": 0.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31567,7 +34791,9 @@
 							"time": 0.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31582,7 +34808,9 @@
 							"time": 0.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31597,7 +34825,9 @@
 							"time": 0.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31612,7 +34842,9 @@
 							"time": 1.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31627,7 +34859,9 @@
 							"time": 1.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31642,7 +34876,9 @@
 							"time": 1.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31657,7 +34893,9 @@
 							"time": 2.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31672,7 +34910,9 @@
 							"time": 2.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31687,7 +34927,9 @@
 							"time": 2.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31702,7 +34944,9 @@
 							"time": 3.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31717,7 +34961,9 @@
 							"time": 2.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31732,7 +34978,9 @@
 							"time": 3.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31747,7 +34995,9 @@
 							"time": 3.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31762,7 +35012,9 @@
 							"time": 3.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31777,7 +35029,9 @@
 							"time": 4.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31792,7 +35046,9 @@
 							"time": 4.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31807,7 +35063,9 @@
 							"time": 4.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31822,7 +35080,9 @@
 							"time": 4.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31837,7 +35097,9 @@
 							"time": 5.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31852,7 +35114,9 @@
 							"time": 5.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31867,7 +35131,9 @@
 							"time": 5.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31882,7 +35148,9 @@
 							"time": 6.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31897,7 +35165,9 @@
 							"time": 6.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31912,7 +35182,9 @@
 							"time": 6.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31927,7 +35199,9 @@
 							"time": 7.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31942,7 +35216,9 @@
 							"time": 6.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31957,7 +35233,9 @@
 							"time": 7.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31972,7 +35250,9 @@
 							"time": 7.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -31987,7 +35267,9 @@
 							"time": 7.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32002,7 +35284,9 @@
 							"time": 8.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32017,7 +35301,9 @@
 							"time": 8.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32032,7 +35318,9 @@
 							"time": 8.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32047,7 +35335,9 @@
 							"time": 8.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32062,7 +35352,9 @@
 							"time": 9.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32077,7 +35369,9 @@
 							"time": 9.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32092,7 +35386,9 @@
 							"time": 9.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32107,7 +35403,9 @@
 							"time": 10.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32122,7 +35420,9 @@
 							"time": 10.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32137,7 +35437,9 @@
 							"time": 10.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -32162,7 +35464,9 @@
 							"bezier_left_time": [-0.1, -0.07476, -0.1],
 							"bezier_left_value": [0, 1.63617, 0],
 							"bezier_right_time": [0.1, 0.07476, 0.1],
-							"bezier_right_value": [0, -1.63617, 0]
+							"bezier_right_value": [0, -1.63617, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -32181,7 +35485,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -32200,7 +35506,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -32219,7 +35527,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -32238,7 +35548,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -32257,7 +35569,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -32276,7 +35590,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -32295,7 +35611,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -32314,7 +35632,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -32333,7 +35653,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -32352,7 +35674,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -32371,7 +35695,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -32390,7 +35716,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -32409,7 +35737,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -32428,7 +35758,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -32447,7 +35779,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -32466,7 +35800,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -32485,7 +35821,9 @@
 							"bezier_left_time": [-0.1, -0.07476, -0.1],
 							"bezier_left_value": [0, 2.87339, 0],
 							"bezier_right_time": [0.1, 0.07476, 0.1],
-							"bezier_right_value": [0, -2.87339, 0]
+							"bezier_right_value": [0, -2.87339, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32500,7 +35838,9 @@
 							"time": 0.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32515,7 +35855,9 @@
 							"time": 0,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32530,7 +35872,9 @@
 							"time": 0.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32545,7 +35889,9 @@
 							"time": 0.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32560,7 +35906,9 @@
 							"time": 0.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32575,7 +35923,9 @@
 							"time": 1.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32590,7 +35940,9 @@
 							"time": 1.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32605,7 +35957,9 @@
 							"time": 1.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32620,7 +35974,9 @@
 							"time": 2.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32635,7 +35991,9 @@
 							"time": 2.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32650,7 +36008,9 @@
 							"time": 2.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32665,7 +36025,9 @@
 							"time": 3.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32680,7 +36042,9 @@
 							"time": 3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32695,7 +36059,9 @@
 							"time": 3.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32710,7 +36076,9 @@
 							"time": 3.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32725,7 +36093,9 @@
 							"time": 3.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32740,7 +36110,9 @@
 							"time": 4.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32755,7 +36127,9 @@
 							"time": 4.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32770,7 +36144,9 @@
 							"time": 4.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32785,7 +36161,9 @@
 							"time": 4.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32800,7 +36178,9 @@
 							"time": 5.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32815,7 +36195,9 @@
 							"time": 5.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32830,7 +36212,9 @@
 							"time": 5.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32845,7 +36229,9 @@
 							"time": 6.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32860,7 +36246,9 @@
 							"time": 6.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32875,7 +36263,9 @@
 							"time": 6.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32890,7 +36280,9 @@
 							"time": 7.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32905,7 +36297,9 @@
 							"time": 7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32920,7 +36314,9 @@
 							"time": 7.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32935,7 +36331,9 @@
 							"time": 7.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32950,7 +36348,9 @@
 							"time": 7.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32965,7 +36365,9 @@
 							"time": 8.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32980,7 +36382,9 @@
 							"time": 8.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -32995,7 +36399,9 @@
 							"time": 8.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33010,7 +36416,9 @@
 							"time": 8.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33025,7 +36433,9 @@
 							"time": 9.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33040,7 +36450,9 @@
 							"time": 9.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33055,7 +36467,9 @@
 							"time": 9.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33070,7 +36484,9 @@
 							"time": 10.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33085,7 +36501,9 @@
 							"time": 10.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33100,7 +36518,9 @@
 							"time": 10.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -33125,7 +36545,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -33144,7 +36566,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -33163,7 +36587,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -33182,7 +36608,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -33201,7 +36629,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -33220,7 +36650,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -33239,7 +36671,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -33258,7 +36692,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -33277,7 +36713,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -33296,7 +36734,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -33315,7 +36755,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -33334,7 +36776,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -33353,7 +36797,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -33372,7 +36818,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -33391,7 +36839,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -33410,7 +36860,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -33429,7 +36881,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33444,7 +36898,9 @@
 							"time": 0.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33459,7 +36915,9 @@
 							"time": 0.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33474,7 +36932,9 @@
 							"time": 0.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33489,7 +36949,9 @@
 							"time": 0.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33504,7 +36966,9 @@
 							"time": 0,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33519,7 +36983,9 @@
 							"time": 1.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33534,7 +37000,9 @@
 							"time": 1.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33549,7 +37017,9 @@
 							"time": 1.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33564,7 +37034,9 @@
 							"time": 2.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33579,7 +37051,9 @@
 							"time": 2.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33594,7 +37068,9 @@
 							"time": 2.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33609,7 +37085,9 @@
 							"time": 3.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33624,7 +37102,9 @@
 							"time": 3.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33639,7 +37119,9 @@
 							"time": 3.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33654,7 +37136,9 @@
 							"time": 4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33669,7 +37153,9 @@
 							"time": 3.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33684,7 +37170,9 @@
 							"time": 4.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33699,7 +37187,9 @@
 							"time": 4.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33714,7 +37204,9 @@
 							"time": 4.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33729,7 +37221,9 @@
 							"time": 4.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33744,7 +37238,9 @@
 							"time": 5.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33759,7 +37255,9 @@
 							"time": 5.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33774,7 +37272,9 @@
 							"time": 5.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33789,7 +37289,9 @@
 							"time": 6.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33804,7 +37306,9 @@
 							"time": 6.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33819,7 +37323,9 @@
 							"time": 6.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33834,7 +37340,9 @@
 							"time": 7.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33849,7 +37357,9 @@
 							"time": 7.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33864,7 +37374,9 @@
 							"time": 7.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33879,7 +37391,9 @@
 							"time": 8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33894,7 +37408,9 @@
 							"time": 7.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33909,7 +37425,9 @@
 							"time": 8.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33924,7 +37442,9 @@
 							"time": 8.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33939,7 +37459,9 @@
 							"time": 8.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33954,7 +37476,9 @@
 							"time": 8.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33969,7 +37493,9 @@
 							"time": 9.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33984,7 +37510,9 @@
 							"time": 9.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -33999,7 +37527,9 @@
 							"time": 9.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34014,7 +37544,9 @@
 							"time": 10.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34029,7 +37561,9 @@
 							"time": 10.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -34054,7 +37588,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -34073,7 +37609,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -34092,7 +37630,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -34111,7 +37651,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -34130,7 +37672,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -34149,7 +37693,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -34168,7 +37714,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -34187,7 +37735,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -34206,7 +37756,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -34225,7 +37777,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -34244,7 +37798,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -34263,7 +37819,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -34282,7 +37840,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -34301,7 +37861,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -34320,7 +37882,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -34339,7 +37903,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -34358,7 +37924,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34373,7 +37941,9 @@
 							"time": 0.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34388,7 +37958,9 @@
 							"time": 0.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34403,7 +37975,9 @@
 							"time": 0.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34418,7 +37992,9 @@
 							"time": 0.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34433,7 +38009,9 @@
 							"time": 1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34448,7 +38026,9 @@
 							"time": 1.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34463,7 +38043,9 @@
 							"time": 1.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34478,7 +38060,9 @@
 							"time": 1.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34493,7 +38077,9 @@
 							"time": 2.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34508,7 +38094,9 @@
 							"time": 2.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34523,7 +38111,9 @@
 							"time": 2.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34538,7 +38128,9 @@
 							"time": 3.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34553,7 +38145,9 @@
 							"time": 3.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34568,7 +38162,9 @@
 							"time": 3.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34583,7 +38179,9 @@
 							"time": 3.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34598,7 +38196,9 @@
 							"time": 4.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34613,7 +38213,9 @@
 							"time": 4.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34628,7 +38230,9 @@
 							"time": 4.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34643,7 +38247,9 @@
 							"time": 4.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34658,7 +38264,9 @@
 							"time": 5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34673,7 +38281,9 @@
 							"time": 5.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34688,7 +38298,9 @@
 							"time": 5.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34703,7 +38315,9 @@
 							"time": 5.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34718,7 +38332,9 @@
 							"time": 6.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34733,7 +38349,9 @@
 							"time": 6.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34748,7 +38366,9 @@
 							"time": 6.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34763,7 +38383,9 @@
 							"time": 7.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34778,7 +38400,9 @@
 							"time": 7.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34793,7 +38417,9 @@
 							"time": 7.4,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34808,7 +38434,9 @@
 							"time": 7.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34823,7 +38451,9 @@
 							"time": 8.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34838,7 +38468,9 @@
 							"time": 8.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34853,7 +38485,9 @@
 							"time": 8.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34868,7 +38502,9 @@
 							"time": 8.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34883,7 +38519,9 @@
 							"time": 9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34898,7 +38536,9 @@
 							"time": 9.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34913,7 +38553,9 @@
 							"time": 9.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34928,7 +38570,9 @@
 							"time": 9.8,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34943,7 +38587,9 @@
 							"time": 10.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -34958,7 +38604,9 @@
 							"time": 10.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -34983,7 +38631,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35002,7 +38652,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35021,7 +38673,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35040,7 +38694,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35059,7 +38715,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35078,7 +38736,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35097,7 +38757,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35116,7 +38778,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35135,7 +38799,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35154,7 +38820,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35173,7 +38841,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35192,7 +38862,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35211,7 +38883,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35230,7 +38904,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35249,7 +38925,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35268,7 +38946,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35287,7 +38967,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35302,7 +38984,9 @@
 							"time": 0.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35317,7 +39001,9 @@
 							"time": 0.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35332,7 +39018,9 @@
 							"time": 0.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35347,7 +39035,9 @@
 							"time": 0.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35362,7 +39052,9 @@
 							"time": 1.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35377,7 +39069,9 @@
 							"time": 1.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35392,7 +39086,9 @@
 							"time": 1.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35407,7 +39103,9 @@
 							"time": 1.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35422,7 +39120,9 @@
 							"time": 2.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35437,7 +39137,9 @@
 							"time": 2.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35452,7 +39154,9 @@
 							"time": 2.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35467,7 +39171,9 @@
 							"time": 3.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35482,7 +39188,9 @@
 							"time": 3.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35497,7 +39205,9 @@
 							"time": 3.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35512,7 +39222,9 @@
 							"time": 3.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35527,7 +39239,9 @@
 							"time": 4.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35542,7 +39256,9 @@
 							"time": 4.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35557,7 +39273,9 @@
 							"time": 4.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35572,7 +39290,9 @@
 							"time": 4.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35587,7 +39307,9 @@
 							"time": 5.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35602,7 +39324,9 @@
 							"time": 5.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35617,7 +39341,9 @@
 							"time": 5.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35632,7 +39358,9 @@
 							"time": 5.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35647,7 +39375,9 @@
 							"time": 6.35,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35662,7 +39392,9 @@
 							"time": 6.5,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35677,7 +39409,9 @@
 							"time": 6.65,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35692,7 +39426,9 @@
 							"time": 7.15,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35707,7 +39443,9 @@
 							"time": 7.3,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35722,7 +39460,9 @@
 							"time": 7.45,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35737,7 +39477,9 @@
 							"time": 7.95,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35752,7 +39494,9 @@
 							"time": 8.1,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35767,7 +39511,9 @@
 							"time": 8.25,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35782,7 +39528,9 @@
 							"time": 8.75,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35797,7 +39545,9 @@
 							"time": 8.9,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35812,7 +39562,9 @@
 							"time": 9.05,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35827,7 +39579,9 @@
 							"time": 9.55,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35842,7 +39596,9 @@
 							"time": 9.7,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35857,7 +39613,9 @@
 							"time": 9.85,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "scale",
@@ -35872,7 +39630,9 @@
 							"time": 0,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "catmullrom"
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				}
@@ -35885,13 +39645,14 @@
 			"override": false,
 			"length": 1.3,
 			"snapping": 20,
-			"selected": false,
+			"selected": true,
+			"saved": true,
+			"path": "",
 			"anim_time_update": "",
 			"blend_weight": "",
 			"start_delay": "",
 			"loop_delay": "",
-			"affected_bones": [],
-			"affected_bones_is_a_whitelist": false,
+			"excluded_bones": [],
 			"animators": {
 				"70a0798f-71f8-5a17-fb75-59eba18ea91c": {
 					"name": "bone",
@@ -35914,7 +39675,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35933,7 +39696,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35952,7 +39717,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -35977,7 +39744,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -35996,7 +39765,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36015,7 +39786,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -36040,7 +39813,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36059,7 +39834,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36078,7 +39855,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -36103,7 +39882,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36122,7 +39903,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36141,7 +39924,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0.66277, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -0.66277, 0]
+							"bezier_right_value": [0, -0.66277, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36160,7 +39945,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0.66277, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -0.66277, 0]
+							"bezier_right_value": [0, -0.66277, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -36185,7 +39972,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36204,7 +39993,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36223,7 +40014,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0.66277, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -0.66277, 0]
+							"bezier_right_value": [0, -0.66277, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36242,7 +40035,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0.66277, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -0.66277, 0]
+							"bezier_right_value": [0, -0.66277, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -36267,7 +40062,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36286,7 +40083,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36305,7 +40104,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 1.05466, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -1.05466, 0]
+							"bezier_right_value": [0, -1.05466, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36324,7 +40125,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 1.05466, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -1.05466, 0]
+							"bezier_right_value": [0, -1.05466, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -36349,7 +40152,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36368,7 +40173,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36387,7 +40194,9 @@
 							"bezier_left_time": [-0.1, -0.05996, -0.1],
 							"bezier_left_value": [0, 0.83811, 0],
 							"bezier_right_time": [0.1, 0.05996, 0.1],
-							"bezier_right_value": [0, -0.83811, 0]
+							"bezier_right_value": [0, -0.83811, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36406,7 +40215,9 @@
 							"bezier_left_time": [-0.1, -0.01557, -0.1],
 							"bezier_left_value": [0, 0.36392, 0],
 							"bezier_right_time": [0.1, 0.01557, 0.1],
-							"bezier_right_value": [0, -0.36392, 0]
+							"bezier_right_value": [0, -0.36392, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -36431,7 +40242,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36450,7 +40263,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36469,7 +40284,9 @@
 							"bezier_left_time": [-0.1, -0.05996, -0.1],
 							"bezier_left_value": [0, 0.83811, 0],
 							"bezier_right_time": [0.1, 0.05996, 0.1],
-							"bezier_right_value": [0, -0.83811, 0]
+							"bezier_right_value": [0, -0.83811, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36488,7 +40305,9 @@
 							"bezier_left_time": [-0.1, -0.01557, -0.1],
 							"bezier_left_value": [0, 0.36392, 0],
 							"bezier_right_time": [0.1, 0.01557, 0.1],
-							"bezier_right_value": [0, -0.36392, 0]
+							"bezier_right_value": [0, -0.36392, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -36513,7 +40332,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 2.95145, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -2.95145, 0]
+							"bezier_right_value": [0, -2.95145, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36532,7 +40353,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36551,7 +40374,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36570,7 +40395,9 @@
 							"bezier_left_time": [-0.1, -0.04821, -0.1],
 							"bezier_left_value": [0, 0.73526, 0],
 							"bezier_right_time": [0.1, 0.04821, 0.1],
-							"bezier_right_value": [0, -0.73526, 0]
+							"bezier_right_value": [0, -0.73526, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -36595,7 +40422,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 2.95145, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -2.95145, 0]
+							"bezier_right_value": [0, -2.95145, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36614,7 +40443,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36633,7 +40464,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36652,7 +40485,9 @@
 							"bezier_left_time": [-0.1, -0.04821, -0.1],
 							"bezier_left_value": [0, 0.73526, 0],
 							"bezier_right_time": [0.1, 0.04821, 0.1],
-							"bezier_right_value": [0, -0.73526, 0]
+							"bezier_right_value": [0, -0.73526, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -36677,7 +40512,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 2.95145, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -2.95145, 0]
+							"bezier_right_value": [0, -2.95145, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36696,7 +40533,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36715,7 +40554,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36734,7 +40575,9 @@
 							"bezier_left_time": [-0.1, -0.04821, -0.1],
 							"bezier_left_value": [0, 0.73526, 0],
 							"bezier_right_time": [0.1, 0.04821, 0.1],
-							"bezier_right_value": [0, -0.73526, 0]
+							"bezier_right_value": [0, -0.73526, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -36759,7 +40602,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36778,7 +40623,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36797,7 +40644,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.08361, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.08361, 0]
+							"bezier_right_value": [0, -3.08361, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36816,7 +40665,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.08361, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.08361, 0]
+							"bezier_right_value": [0, -3.08361, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -36841,7 +40692,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.08361, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.08361, 0]
+							"bezier_right_value": [0, -3.08361, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36860,7 +40713,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36879,7 +40734,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36898,7 +40755,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.08361, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.08361, 0]
+							"bezier_right_value": [0, -3.08361, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -36923,7 +40782,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36942,7 +40803,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36961,7 +40824,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.25468, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.25468, 0]
+							"bezier_right_value": [0, -3.25468, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -36980,7 +40845,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.25468, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.25468, 0]
+							"bezier_right_value": [0, -3.25468, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -37005,7 +40872,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.1693, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.1693, 0]
+							"bezier_right_value": [0, -3.1693, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37024,7 +40893,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37043,7 +40914,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37062,7 +40935,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.1693, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.1693, 0]
+							"bezier_right_value": [0, -3.1693, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -37087,7 +40962,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.1693, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.1693, 0]
+							"bezier_right_value": [0, -3.1693, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37106,7 +40983,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37125,7 +41004,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37144,7 +41025,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.1693, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.1693, 0]
+							"bezier_right_value": [0, -3.1693, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -37169,7 +41052,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37188,7 +41073,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37207,7 +41094,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.19307, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.19307, 0]
+							"bezier_right_value": [0, -3.19307, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37226,7 +41115,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.19307, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.19307, 0]
+							"bezier_right_value": [0, -3.19307, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -37251,7 +41142,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.19307, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.19307, 0]
+							"bezier_right_value": [0, -3.19307, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37270,7 +41163,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37289,7 +41184,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37308,7 +41205,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.19307, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.19307, 0]
+							"bezier_right_value": [0, -3.19307, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -37333,7 +41232,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.19307, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.19307, 0]
+							"bezier_right_value": [0, -3.19307, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37352,7 +41253,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37371,7 +41274,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37390,7 +41295,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.19307, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.19307, 0]
+							"bezier_right_value": [0, -3.19307, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -37415,7 +41322,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.1693, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.1693, 0]
+							"bezier_right_value": [0, -3.1693, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37434,7 +41343,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37453,7 +41364,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37472,7 +41385,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.1693, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.1693, 0]
+							"bezier_right_value": [0, -3.1693, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -37497,7 +41412,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37516,7 +41433,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37535,7 +41454,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.1693, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.1693, 0]
+							"bezier_right_value": [0, -3.1693, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37554,7 +41475,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.1693, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.1693, 0]
+							"bezier_right_value": [0, -3.1693, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -37579,7 +41502,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.25468, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.25468, 0]
+							"bezier_right_value": [0, -3.25468, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37598,7 +41523,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37617,7 +41544,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37636,7 +41565,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.25468, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.25468, 0]
+							"bezier_right_value": [0, -3.25468, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -37661,7 +41592,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.08361, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.08361, 0]
+							"bezier_right_value": [0, -3.08361, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37680,7 +41613,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37699,7 +41634,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37718,7 +41655,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.08361, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.08361, 0]
+							"bezier_right_value": [0, -3.08361, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -37743,7 +41682,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.08361, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.08361, 0]
+							"bezier_right_value": [0, -3.08361, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37762,7 +41703,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37781,7 +41724,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37800,7 +41745,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 3.08361, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -3.08361, 0]
+							"bezier_right_value": [0, -3.08361, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -37825,7 +41772,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 2.95145, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -2.95145, 0]
+							"bezier_right_value": [0, -2.95145, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37844,7 +41793,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37863,7 +41814,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37882,7 +41835,9 @@
 							"bezier_left_time": [-0.1, -0.04821, -0.1],
 							"bezier_left_value": [0, 0.73526, 0],
 							"bezier_right_time": [0.1, 0.04821, 0.1],
-							"bezier_right_value": [0, -0.73526, 0]
+							"bezier_right_value": [0, -0.73526, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -37907,7 +41862,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 2.95145, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -2.95145, 0]
+							"bezier_right_value": [0, -2.95145, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37926,7 +41883,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37945,7 +41904,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -37964,7 +41925,9 @@
 							"bezier_left_time": [-0.1, -0.04821, -0.1],
 							"bezier_left_value": [0, 0.73526, 0],
 							"bezier_right_time": [0.1, 0.04821, 0.1],
-							"bezier_right_value": [0, -0.73526, 0]
+							"bezier_right_value": [0, -0.73526, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -37989,7 +41952,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -38008,7 +41973,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -38027,7 +41994,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 2.95145, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -2.95145, 0]
+							"bezier_right_value": [0, -2.95145, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -38046,7 +42015,9 @@
 							"bezier_left_time": [-0.1, -0.04821, -0.1],
 							"bezier_left_value": [0, 0.73526, 0],
 							"bezier_right_time": [0.1, 0.04821, 0.1],
-							"bezier_right_value": [0, -0.73526, 0]
+							"bezier_right_value": [0, -0.73526, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -38071,7 +42042,9 @@
 							"bezier_left_time": [-0.1, -0.01557, -0.1],
 							"bezier_left_value": [0, 0.36392, 0],
 							"bezier_right_time": [0.1, 0.01557, 0.1],
-							"bezier_right_value": [0, -0.36392, 0]
+							"bezier_right_value": [0, -0.36392, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -38090,7 +42063,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -38109,7 +42084,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -38128,7 +42105,9 @@
 							"bezier_left_time": [-0.1, -0.05996, -0.1],
 							"bezier_left_value": [0, 0.83811, 0],
 							"bezier_right_time": [0.1, 0.05996, 0.1],
-							"bezier_right_value": [0, -0.83811, 0]
+							"bezier_right_value": [0, -0.83811, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -38153,7 +42132,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -38172,7 +42153,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -38191,7 +42174,9 @@
 							"bezier_left_time": [-0.1, -0.05996, -0.1],
 							"bezier_left_value": [0, 0.83811, 0],
 							"bezier_right_time": [0.1, 0.05996, 0.1],
-							"bezier_right_value": [0, -0.83811, 0]
+							"bezier_right_value": [0, -0.83811, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -38210,7 +42195,9 @@
 							"bezier_left_time": [-0.1, -0.01557, -0.1],
 							"bezier_left_value": [0, 0.36392, 0],
 							"bezier_right_time": [0.1, 0.01557, 0.1],
-							"bezier_right_value": [0, -0.36392, 0]
+							"bezier_right_value": [0, -0.36392, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -38235,7 +42222,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -38254,7 +42243,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -38273,7 +42264,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 1.05466, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -1.05466, 0]
+							"bezier_right_value": [0, -1.05466, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -38292,7 +42285,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 1.05466, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -1.05466, 0]
+							"bezier_right_value": [0, -1.05466, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -38317,7 +42312,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -38336,7 +42333,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -38355,7 +42354,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0.66277, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -0.66277, 0]
+							"bezier_right_value": [0, -0.66277, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -38374,7 +42375,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0.66277, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -0.66277, 0]
+							"bezier_right_value": [0, -0.66277, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				},
@@ -38399,7 +42402,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -38418,7 +42423,9 @@
 							"bezier_left_time": [-0.1, -0.15333, -0.1],
 							"bezier_left_value": [0, -0.00045, 0],
 							"bezier_right_time": [0.1, 0.15333, 0.1],
-							"bezier_right_value": [0, 0.00045, 0]
+							"bezier_right_value": [0, 0.00045, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -38437,7 +42444,9 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0.66277, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -0.66277, 0]
+							"bezier_right_value": [0, -0.66277, 0],
+							"easing": "linear",
+							"easingArgs": []
 						},
 						{
 							"channel": "position",
@@ -38456,11 +42465,14 @@
 							"bezier_left_time": [-0.1, -0.1, -0.1],
 							"bezier_left_value": [0, 0.66277, 0],
 							"bezier_right_time": [0.1, 0.1, 0.1],
-							"bezier_right_value": [0, -0.66277, 0]
+							"bezier_right_value": [0, -0.66277, 0],
+							"easing": "linear",
+							"easingArgs": []
 						}
 					]
 				}
 			}
 		}
-	]
+	],
+	"animation_controllers": []
 }


### PR DESCRIPTION
# Summary

This PR migrates the `petal-pipe-circle` AJ model file so we can summon it in-game again for Minecraft 1.21.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Reproducing in-game

```mcfunction
function _:summon
```

---

## Supplemental changes

N/A

<!--
describe what other changes this PR makes which aren't specific to its main purpose.
- does it contain a world backup? (recommended)
- does it contain other miscellaneous code cleanup?

format these extra changes with bullet points, preferrably.
-->
