### PR TITLE
🔥 Delete `watch.models` logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,20 +92,11 @@ Read the descriptions of the following scripts and run them when it is recommend
 
 1. `yarn start export`: run the AJ blueprint export script
 
-   1. add `ELECTRON_ENABLE_LOGGING=1` to your `.env` file to enable log-passthrough from Blockbench's renderer process to the main process. **Run this if your `watch.models` script (from `yarn start watch.experimental`) runs into an error while exporting AJ models.**
-
    We recommend running `yarn start export` at least once, and every time changes to `.ajblueprint` files occur from new incoming commits.
 
 2. `yarn start`: this keeps your local repository's content synced with your `.minecraft` directory -- datapack/resourcepack changes will reflect in-game
 
-  <s>
-   1. if you run `yarn start watch.experimental`, it also watches `.ajblueprint` files and runs our auto-exporter on them -- this reads all `.ajblueprint` files in your local repo and runs Animated Java's `Export Project` function on them.
-      1. we specifically _do not_ commit AJ's exported files to the repo since they are _very large_
-      2. the `watch.models` script _will not_ work if you already have Blockbench open, so don't expect it to do anything while that's the case
-      3. its a little janky and experimental still, so \*\*we recommend manually running `yarn start export` if you run into issues relating to Animated Java export files (missing models, animations, attacks not playing properly)
-  </s>
-
-We recommend keeping `yarn start` running at all times while working on the project.
+   We recommend keeping `yarn start` running at all times while working on the project.
 
 3. `yarn sync`: zips your Minecraft world and copies it to the repo as (`world.zip`). This is how we handle version-control for the actual Minecraft world. This is especially important to run and commit if you make any _physical changes_ to the world like breaking/placing blocks.
 

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -39,7 +39,6 @@ module.exports = {
     default: 'nps watch',
     watch: {
       default: `node ${watchScriptPath}`,
-      experimental: `node ${watchScriptPath} --experimental`,
     },
     sync: {
       default: 'nps sync.world',

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "dotenv": "16.3.1",
     "eslint": "8.56.0",
     "extract-zip": "2.0.1",
-    "find-process": "1.4.7",
     "fs-extra": "11.2.0",
     "glob": "10.3.10",
     "image-size": "1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -596,13 +596,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "commander@npm:5.1.0"
-  checksum: 0b7fec1712fbcc6230fcb161d8d73b4730fa91a21dc089515489402ad78810547683f058e2a9835929c212fead1d6a6ade70db28bbb03edbc2829a9ab7d69447
-  languageName: node
-  linkType: hard
-
 "common-tags@npm:^1.4.0":
   version: 1.8.2
   resolution: "common-tags@npm:1.8.2"
@@ -1123,19 +1116,6 @@ __metadata:
   dependencies:
     to-regex-range: ^5.0.1
   checksum: cc283f4e65b504259e64fd969bcf4def4eb08d85565e906b7d36516e87819db52029a76b6363d0f02d0d532f0033c9603b9e2d943d56ee3b0d4f7ad3328ff917
-  languageName: node
-  linkType: hard
-
-"find-process@npm:1.4.7":
-  version: 1.4.7
-  resolution: "find-process@npm:1.4.7"
-  dependencies:
-    chalk: ^4.0.0
-    commander: ^5.1.0
-    debug: ^4.1.1
-  bin:
-    find-process: bin/find-process.js
-  checksum: 1953e6a16af86ec033d613ddfcac24f68b7ca6cc7d7aadc037ede4ccad4f03c5571d3c95165842475bfa9432120be5c995cc234c9c02726fc886ac6cd85ece3b
   languageName: node
   linkType: hard
 
@@ -2252,7 +2232,6 @@ __metadata:
     dotenv: 16.3.1
     eslint: 8.56.0
     extract-zip: 2.0.1
-    find-process: 1.4.7
     fs-extra: 11.2.0
     glob: 10.3.10
     image-size: 1.1.1


### PR DESCRIPTION
# Summary

I never use this and we don't really recommend using it anyway.

Original motivation was so you didn't need to manually run `yarn start export`, but that's easy enough to do if you run into an issue in-game.

---

I tested `yarn start` and ensured in-game assets/functions still worked.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Reproducing

```sh
yarn start
```

<!--
how to view the thing you added in-game (Minecraft), if applicable.
- are there certain commands to run?
- if not applicable, write `N/A`.

e.g.:
```mcfunction
function _:reset
function _:summon
function entity:hostile/omega-flowey/attack/x-bullets-lower/start
```
-->

## Preview

N/A

<!-- `in-game -- before` can be `N/A` if this is a new addition to the map -->

---

## Supplemental changes

N/A
