### PR TITLE
🐛 🔨 Fix platform inconsistency with file removal in dev scripts

### DIFF
--- a/package-scripts/sync-world.js
+++ b/package-scripts/sync-world.js
@@ -2,9 +2,10 @@ const archiver = require('archiver');
 const chalk = require('chalk');
 const dotenv = require('dotenv');
 const extract = require('extract-zip');
-const { createWriteStream, remove, stat, mkdir, exists } = require('fs-extra');
+const { createWriteStream, stat, mkdir, exists } = require('fs-extra');
 const { glob } = require('glob');
 const minimist = require('minimist');
+const { rimraf } = require('rimraf');
 
 const { assertEnvironmentVariables } = require('./utils');
 
@@ -60,7 +61,7 @@ const deleteOldBackups = async () => {
     const modifiedTime = (await stat(tempBackupPath)).mtime;
     if (Date.now() - modifiedTime > STALE_DURATION) {
       console.log('Deleting stale backup:', tempBackupPath);
-      await remove(tempBackupPath);
+      await rimraf(tempBackupPath);
     }
   }
 };
@@ -73,7 +74,7 @@ const createTempWorldBackupName = async () => {
 };
 
 const syncUp = async () => {
-  await remove(worldBackupPath);
+  await rimraf(worldBackupPath);
   await backupWorld(worldBackupPath);
 };
 
@@ -92,7 +93,7 @@ const syncDown = async () => {
     const path = `${tempBackupPath}/${name}`;
     await backupWorld(path, false);
 
-    await remove(minecraftWorldPath);
+    await rimraf(minecraftWorldPath);
   } else {
     console.log(
       'No pre-existing world save to backup, moving straight to extraction',

--- a/package-scripts/watch.js
+++ b/package-scripts/watch.js
@@ -1,10 +1,11 @@
 const chalk = require('chalk');
 const { watch } = require('chokidar');
 const dotenv = require('dotenv');
-const { copy, remove, readFile, writeFile } = require('fs-extra');
+const { copy, readFile, writeFile } = require('fs-extra');
 const { glob } = require('glob');
 const { difference, findKey } = require('lodash');
 const { parse } = require('path');
+const { rimraf } = require('rimraf');
 
 const { ajblueprintDir } = require('./shared-consts');
 const {
@@ -57,7 +58,7 @@ const watchDatapacks = async (showVerbose) => {
   const copyFilter = (path) => ignored.every((regex) => !regex.test(path));
 
   // Clean copy datapacks on script start
-  await remove(`${worldPath}/datapacks`);
+  await rimraf(`${worldPath}/datapacks`);
   await copy('datapacks', `${worldPath}/datapacks`, { filter: copyFilter });
 
   const watcher = watch('datapacks', {
@@ -78,7 +79,7 @@ const watchDatapacks = async (showVerbose) => {
     logPath(chalk.yellow('change:'), normalizePath(path));
   });
   watcher.on('unlink', async (path) => {
-    await remove(`${worldPath}/${path}`);
+    await rimraf(`${worldPath}/${path}`);
     logPath(chalk.red('delete:'), normalizePath(path));
   });
 };
@@ -111,7 +112,7 @@ const watchResourcepack = async (showVerbose) => {
   const copyFilter = (path) => ignored.every((regex) => !regex.test(path));
 
   // Delete all contents of resourcepack folder on script start
-  await remove(resourcePackBasePath);
+  await rimraf(resourcePackBasePath);
   await copy('resourcepack', resourcePackBasePath, { filter: copyFilter });
 
   const watcher = watch('resourcepack', {
@@ -134,7 +135,7 @@ const watchResourcepack = async (showVerbose) => {
     logPath(chalk.yellow('change:'), normalizePath(path));
   });
   watcher.on('unlink', async (path) => {
-    await remove(dest(path));
+    await rimraf(dest(path));
     logPath(chalk.red('delete:'), normalizePath(path));
   });
 };
@@ -157,9 +158,9 @@ const deleteExportedFiles = async (path) => {
     `resourcepack/assets/animated_java/models/item/${name}`,
   ];
   for (const path of pathsToDeleteEntirely) {
-    remove(path);
+    rimraf(path);
     if (!path.startsWith('datapacks')) {
-      remove(`${resourcePackBasePath}/${path.replace('resourcepack/', '')}`);
+      rimraf(`${resourcePackBasePath}/${path.replace('resourcepack/', '')}`);
     }
   }
 


### PR DESCRIPTION
# Summary

On Windows 11 (or at least on my laptop), important dev scripts fail when `fs-extra.remove()` is called. These scripts were:

- `yarn start`
- `yarn down`

To fix this, we switch to the `rimraf` package since it's cross-platform.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Reproducing

1. use a known problematic OS (Windows 11)
2. run either `yarn start` or `yarn down`
3. see error

<!--
how to view the thing you added in-game (Minecraft), if applicable.
- are there certain commands to run?
- if not applicable, write `N/A`.

e.g.:
```mcfunction
function _:reset
function _:summon
function entity:hostile/omega-flowey/attack/x-bullets-lower/start
```
-->

## Preview

N/A

<!-- `in-game -- before` can be `N/A` if this is a new addition to the map -->

---

## Supplemental changes

N/A

<!--
describe what other changes this PR makes which aren't specific to its main purpose.
- does it contain a world backup? (recommended)
- does it contain other miscellaneous code cleanup?

format these extra changes with bullet points, preferrably.
-->
