### PR TITLE
🐛 🚨 make trailing slash in datapack setting linter optional

### DIFF
--- a/package-scripts/linting-rules/correct-ajblueprint-settings.js
+++ b/package-scripts/linting-rules/correct-ajblueprint-settings.js
@@ -4,7 +4,7 @@ const { readFileSync } = require('fs');
 const applicableExtensions = ['.ajblueprint'];
 
 const checkDatapack = (model) => {
-  const expected = /datapacks\/animated_java\/$/;
+  const expected = /datapacks\/animated_java\/?$/;
   const actual = model.blueprint_settings.data_pack;
   const match = expected.test(actual.replaceAll('\\', '/'));
   if (!match) {


### PR DESCRIPTION
# Summary

This is a follow-up to https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/114.

In AJ v1.0.0, setting a path (e.g. `blueprint_settings.data_pack`) through Blockbench doesn't leave a trailing slash in the JSON file anymore.

Old (migrated) models still have this trailing slash. Both are valid, however, so our linting rule should accept paths with/without the trailing slash.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Reproducing

```sh
yarn lint
```

<!--
how to view the thing you added in-game (Minecraft), if applicable.
- are there certain commands to run?
- if not applicable, write `N/A`.

e.g.:
```mcfunction
function _:reset
function _:summon
function entity:hostile/omega-flowey/attack/x-bullets-lower/start
```
-->

## Preview

N/A

<!--
provide visuals (GIFs preferred) showing a before/after of your PR's purpose.
contrasts between in-game (Minecraft) and Undertale are also great.
-->

<!-- `in-game -- before` can be `N/A` if this is a new addition to the map -->

---

## Supplemental changes

N/A

<!--
describe what other changes this PR makes which aren't specific to its main purpose.
- does it contain a world backup? (recommended)
- does it contain other miscellaneous code cleanup?

format these extra changes with bullet points, preferrably.
-->
