### PR TITLE
🚨 🍱 add lint rule to prevent empty summon commands in models

### DIFF
--- a/package-scripts/linting-rules/correct-ajblueprint-settings.js
+++ b/package-scripts/linting-rules/correct-ajblueprint-settings.js
@@ -7,25 +7,27 @@ const checkDatapack = (model) => {
   const expected = /datapacks\/animated_java\/?$/;
   const actual = model.blueprint_settings.data_pack;
   const match = expected.test(actual.replaceAll('\\', '/'));
-  if (!match) {
-    let error = `incorrect datapack ${chalk.blue('directory')}; `;
-    error += 'it should target ';
-    error += `${chalk.yellow('datapacks/animated_java')}`;
-    error += `\n\t\t found: ${chalk.red(actual)}`;
-    return [error];
+  if (match) {
+    return [];
   }
-  return [];
+
+  let error = `incorrect datapack ${chalk.blue('directory')}; `;
+  error += 'it should target ';
+  error += `${chalk.yellow('datapacks/animated_java')}`;
+  error += `\n\t\t found: ${chalk.red(actual)}`;
+  return [error];
 };
 
 const checkRigItem = (model) => {
   const expected = 'minecraft:white_dye';
   const actual = model.blueprint_settings.display_item;
-  if (actual !== 'minecraft:white_dye') {
-    let error = `incorrect ${chalk.blue('display_item')}; `;
-    error += `was \`${actual}\`, expected \`${expected}\``;
-    return [error];
+  if (actual === expected) {
+    return [];
   }
-  return [];
+
+  let error = `incorrect ${chalk.blue('display_item')}; `;
+  error += `was \`${actual}\`, expected \`${expected}\``;
+  return [error];
 };
 
 const checkSummonCommands = (model) => {

--- a/package-scripts/linting-rules/correct-ajblueprint-settings.js
+++ b/package-scripts/linting-rules/correct-ajblueprint-settings.js
@@ -28,6 +28,19 @@ const checkRigItem = (model) => {
   return [];
 };
 
+const checkSummonCommands = (model) => {
+  const summonCommands = model.blueprint_settings.summon_commands;
+  if (summonCommands !== '') {
+    return [];
+  }
+
+  let error = `invalid ${chalk.blue('summon_commands')} property; `;
+  error += `it should contain ${chalk.yellow(
+    '"tag @s add ..."',
+  )} commands at a minimum`;
+  return [error];
+};
+
 /**
  * Errors for wrong settings values in .ajblueprint files. Limited to trivial checks
  * (like a setting's defined value not matching an exact pattern).
@@ -42,7 +55,7 @@ const correctAjblueprintSettings = (file) => {
 
   const errors = [];
 
-  const settingsChecks = [checkDatapack, checkRigItem];
+  const settingsChecks = [checkDatapack, checkRigItem, checkSummonCommands];
   for (const settingsCheck of settingsChecks) {
     errors.push(...settingsCheck(ajblueprint));
   }


### PR DESCRIPTION
# Summary

A follow-up to https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/125 to prevent it from happening in the future

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---


## Preview

<!--
provide visuals (GIFs preferred) showing a before/after of your PR's purpose.
contrasts between in-game (Minecraft) and Undertale are also great.
-->

i set the `summon_commands` property in `bomb.ajblueprint` to an empty string to test the lint rule:

![image](https://github.com/user-attachments/assets/e55aa9dc-23f5-4b03-aaf5-91d58278603a)


<!-- `in-game -- before` can be `N/A` if this is a new addition to the map -->

---

## Supplemental changes

- https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/e78bcfdf08d8ef6c39cd10b01191b6797e86a6aa: ♻️ refactor `correct-ajblueprint-settings` to use guard clauses 

<!--
describe what other changes this PR makes which aren't specific to its main purpose.
- does it contain a world backup? (recommended)
- does it contain other miscellaneous code cleanup?

format these extra changes with bullet points, preferrably.
-->
