### PR TITLE
♻️ Refactor log prefix out of `error` function and into generic `log` function

### DIFF
--- a/datapacks/omega-flowey/data/utils/function/error.mcfunction
+++ b/datapacks/omega-flowey/data/utils/function/error.mcfunction
@@ -1,3 +1,4 @@
 ## expects a text component in the `error` parameter
 # https://minecraft.wiki/w/Raw_JSON_text_format
-$tellraw @a ["", {"text":"["}, {"text":"Omega Flowey","color":"green"}, {"text":"] "}, {"text":"ERROR ☠","color":"red"}, {"text":" > ","color":"gray"}, $(error)]
+$data modify storage utils:log text_component set value '[{"text":"ERROR ☠","color":"red"}, {"text":" > ","color":"gray"}, $(error)]'
+function utils:log with storage utils:log

--- a/datapacks/omega-flowey/data/utils/function/log.mcfunction
+++ b/datapacks/omega-flowey/data/utils/function/log.mcfunction
@@ -1,0 +1,3 @@
+## expects a text component in the `text_component` parameter
+# https://minecraft.wiki/w/Raw_JSON_text_format
+$tellraw @a [{"text":"["}, {"text":"Omega Flowey","color":"green"}, {"text":"] "}, $(text_component)]


### PR DESCRIPTION
# Summary

This will be used in a follow-up PR for nicer logs on `/reload`.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Reproducing

view pre-existing errors with:

```mcfunction
function _:reset
function _:attack/x-bullets-lower
function _:attack/x-bullets-upper
```

## Preview

For the given command:

```mcfunction
function utils:log { text_component: '"test"'}
```

The chat outputs:

![image](https://github.com/user-attachments/assets/be06af95-1f5e-4587-b490-f729d2c5b6bb)
