### PR TITLE
🧑‍💻 run `setup` function on `/reload`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ We also recommend using [blockcolors.app](https://blockcolors.app/) to get a rep
 1. Download the [Fabric mod loader](https://fabricmc.net/) and install a new profile to your Minecraft launcher
 2. Download the [Fabric API](https://www.curseforge.com/minecraft/mc-mods/fabric-api/files) jar
 3. Download the latest release jar of [`packtest`](https://modrinth.com/mod/packtest)
-   1. You should probably download the same version that we're currently specifying in `./.github/workflows/validate.yml`
+   1. You should probably download the same version that we're currently specifying in `./.github/workflows/datapack.yml`
 4. Move the `Fabric API` and `packtest` jars into your `mods` folder in the Minecraft directory (typically `%appdata%/.minecraft/mods`)
 5. Run the new profile in your Minecraft launcher to launch a (lightly) modded instance that's able to run `packtest`'s new commands designed for testing
    1. Try: `test runall`

--- a/datapacks/omega-flowey/data/entity/function/reset.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/reset.mcfunction
@@ -1,0 +1,5 @@
+# Remove all animated java entities
+function entity:remove_animated_java_models
+
+# Kill all `omega-flowey-remastered` entities
+kill @e[tag=omega-flowey-remastered]

--- a/datapacks/omega-flowey/data/entity/function/setup.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/setup.mcfunction
@@ -1,7 +1,1 @@
-## Remove all animated java entities
-function entity:remove_animated_java_models
-
-## Kill all `omega-flowey-remastered` entities
-kill @e[tag=omega-flowey-remastered]
-
 function entity:hostile/omega-flowey/attack/reset_scores

--- a/datapacks/omega-flowey/data/minecraft/tags/function/load.json
+++ b/datapacks/omega-flowey/data/minecraft/tags/function/load.json
@@ -1,7 +1,6 @@
 {
   "replace": false,
   "values": [
-    "omega-flowey:setup/objectives",
-    "_:reset_scores"
+    "omega-flowey:setup"
   ]
 }

--- a/datapacks/omega-flowey/data/omega-flowey/function/reset.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/function/reset.mcfunction
@@ -2,3 +2,6 @@ function entity:reset
 
 # Completely wipe the scoreboard of all players
 scoreboard players reset *
+
+# Reset next group ID if there are no `groupable` entities
+execute unless entity @e[tag=groupable] run scoreboard players set #group.id.next group.id 0

--- a/datapacks/omega-flowey/data/omega-flowey/function/reset.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/function/reset.mcfunction
@@ -1,5 +1,4 @@
+function entity:reset
+
 # Completely wipe the scoreboard of all players
 scoreboard players reset *
-
-# Then setup scoreboard with required objectives and fake-players
-function omega-flowey:setup

--- a/datapacks/omega-flowey/data/omega-flowey/function/setup.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/function/setup.mcfunction
@@ -12,3 +12,5 @@ function entity:setup
 
 # Reset next group ID if there are no `groupable` entities
 execute unless entity @e[tag=groupable] run scoreboard players set #group.id.next group.id 0
+
+function utils:log { text_component: '[{"color": "aqua", "text": "Datapack initialized"}]'}

--- a/datapacks/omega-flowey/data/omega-flowey/function/setup.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/function/setup.mcfunction
@@ -10,7 +10,4 @@ function omega-flowey:setup/objectives
 
 function entity:setup
 
-# Reset next group ID if there are no `groupable` entities
-execute unless entity @e[tag=groupable] run scoreboard players set #group.id.next group.id 0
-
 function utils:log { text_component: '[{"color": "aqua", "text": "Datapack initialized"}]'}

--- a/datapacks/omega-flowey/data/omega-flowey/test/reset/should_reset_group_ids.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/test/reset/should_reset_group_ids.mcfunction
@@ -15,6 +15,6 @@ assert score #group.id.next group.id matches 1
 kill @e[tag=test.setup.should-reset-group-ids]
 assert score #group.id.next group.id matches 1
 
-function omega-flowey:setup
+function omega-flowey:reset
 
 assert score #group.id.next group.id matches 0

--- a/datapacks/omega-flowey/data/omega-flowey/test/reset/should_reset_group_ids.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/test/reset/should_reset_group_ids.mcfunction
@@ -1,4 +1,4 @@
-# @batch omega-flowey:setup
+# @batch omega-flowey:reset
 
 ## should wipe any preexisting scores
 

--- a/datapacks/omega-flowey/data/omega-flowey/test/reset/should_wipe_scores.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/test/reset/should_wipe_scores.mcfunction
@@ -1,4 +1,4 @@
-# @batch omega-flowey:setup
+# @batch omega-flowey:reset
 
 ## should wipe any preexisting scores
 


### PR DESCRIPTION
# Summary

If you were to switch to a branch with new e.g. `objectives` and forgot to manually run the `_:setup` function, you could easily get missing behavior due to said new objectives not existing.

This PR ensures that won't happen since in order to get the new functions/behavior you have to `/reload`, which will always run the base `setup` function.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Reproducing in-game

```mcfunction
reload
```

<!--
how to view the thing you added in-game (Minecraft), if applicable.
- are there certain commands to run?
- if not applicable, write `N/A`.

e.g.:
```mcfunction
function _:reset
function _:summon
function entity:hostile/omega-flowey/attack/x-bullets-lower/start
```
-->

## Preview

also added a log on `reload` so it's clear :)

![image](https://github.com/user-attachments/assets/78af6407-dd24-423b-b0bd-033af1e329b8)


<!--
provide visuals (GIFs preferred) showing a before/after of your PR's purpose.
contrasts between in-game (Minecraft) and Undertale are also great.
-->

<!-- `in-game -- before` can be `N/A` if this is a new addition to the map -->

---

## Supplemental changes

- https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/0ddb690bc278f3744bd3eb4d8a049ef150fc6f3e: 🐛 Fix wrong batch name for `reset` tests
- https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/4c3f2151aecbf795fb3bb89bca1363e9cf131190: ✅ Move "reset group IDs" behavior from `setup` to `reset` function
- https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/5d58dd3928688b3c54e2ce8c7306f3b62cf10fca: ✏️ Fix typo relating to local testing in README
<!--
describe what other changes this PR makes which aren't specific to its main purpose.
- does it contain a world backup? (recommended)
- does it contain other miscellaneous code cleanup?

format these extra changes with bullet points, preferrably.
-->
