### PR TITLE
🐛 👻 randomize `soul-0-bandaid` height to minimize overlapping

### DIFF
--- a/datapacks/omega-flowey/data/entity/function/soul/soul_0/bandaid/summon.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/soul/soul_0/bandaid/summon.mcfunction
@@ -1,5 +1,6 @@
 # Summon bandaid
-$execute positioned $(x) 34.5 $(z) rotated ~ 0 run function animated_java:soul_0_bandaid/summon { args: {} }
+$execute positioned $(x) $(y) $(z) rotated ~ 0 run function animated_java:soul_0_bandaid/summon { args: {} }
+
 
 # Initialize bandaid
 execute as @e[tag=bandaid-new] run function entity:soul/soul_0/bandaid/initialize

--- a/datapacks/omega-flowey/data/entity/function/soul/soul_0/bullet/initialize/saved.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/soul/soul_0/bullet/initialize/saved.mcfunction
@@ -7,7 +7,7 @@ execute if score @s soul.bullet.position.x matches -3071..3170 if score @s soul.
 # Summon bandaid at current position
 # ONLY if this sword is visible within the soul arena's bounds
 execute if score @s math.0 matches 1 store result storage soul:soul_0.bullet x float 0.01 run scoreboard players get @s soul.bullet.position.x
-execute if score @s math.0 matches 1 store result storage soul:soul_0.bullet y float 1 run random value 30..40
+execute if score @s math.0 matches 1 store result storage soul:soul_0.bullet y float 0.01 run random value 3400..3500
 execute if score @s math.0 matches 1 store result storage soul:soul_0.bullet z float 0.01 run scoreboard players get @s soul.bullet.position.z
 execute if score @s math.0 matches 1 run function entity:soul/soul_0/bandaid/summon with storage soul:soul_0.bullet
 

--- a/datapacks/omega-flowey/data/entity/function/soul/soul_0/bullet/initialize/saved.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/soul/soul_0/bullet/initialize/saved.mcfunction
@@ -7,6 +7,7 @@ execute if score @s soul.bullet.position.x matches -3071..3170 if score @s soul.
 # Summon bandaid at current position
 # ONLY if this sword is visible within the soul arena's bounds
 execute if score @s math.0 matches 1 store result storage soul:soul_0.bullet x float 0.01 run scoreboard players get @s soul.bullet.position.x
+execute if score @s math.0 matches 1 store result storage soul:soul_0.bullet y float 1 run random value 30..40
 execute if score @s math.0 matches 1 store result storage soul:soul_0.bullet z float 0.01 run scoreboard players get @s soul.bullet.position.z
 execute if score @s math.0 matches 1 run function entity:soul/soul_0/bandaid/summon with storage soul:soul_0.bullet
 


### PR DESCRIPTION
- closes #89 

This PR adds random jitter to Y axis values of soul_event0 Bandaid spawns to substantially reduce the clipping occuring from overlapping bandaid entities. The range of value allowed has to be relatively large as sub 1 unit changes still frequently result in clipping. Ugly clipping can still occur with this patch though its frequency should be dramatically reduced 

| before |
|-|
| ![image](https://github.com/user-attachments/assets/333da32f-90f8-45b9-8191-5fee27500767) |

---

|after|
|-|
| ![javaw_oAUOzViotB](https://github.com/user-attachments/assets/474dddc6-d945-4caf-9430-e7a1f0d2527c) ![javaw_vqbeM1Lh3a](https://github.com/user-attachments/assets/6972f825-89e3-4480-9a2b-d0907859fec5) |
