### PR TITLE
✅ Add unit test for `Datapack initalized` message upon setup

### DIFF
--- a/datapacks/omega-flowey/data/omega-flowey/test/setup/should_log_initialized_message.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/test/setup/should_log_initialized_message.mcfunction
@@ -1,0 +1,10 @@
+# @batch omega-flowey:setup
+# @dummy
+
+# log should be not contain initialized message
+assert not chat 'Datapack initialized'
+
+function omega-flowey:setup
+
+# log should contain initialized message
+assert chat 'Datapack initialized'


### PR DESCRIPTION
# Summary

A chat message was added to the `setup` function so that you'd get direct feedback that the datapack successfully loaded when you ran `/reload`.

I wanted to add a test for this in https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/129 but couldn't get it to pass in CI.

The fix was to add the `# @dummy` test directive so the test server would find a player for the `tellraw` to have been sent to.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Reproducing in-game

In the test client:

```mcfunction
test runall
```

## Preview

CI passes :)

<!--
provide visuals (GIFs preferred) showing a before/after of your PR's purpose.
contrasts between in-game (Minecraft) and Undertale are also great.
-->

<!-- `in-game -- before` can be `N/A` if this is a new addition to the map -->

