### PR TITLE
🔧 make VSCode trim trailing whitespace on save

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "spgoding.datapack-language-server",
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
-    "arcanis.vscode-zipfs"
+    "arcanis.vscode-zipfs",
+    "shardulm94.trailing-spaces"
   ]
 }

--- a/omega-flowey.code-workspace
+++ b/omega-flowey.code-workspace
@@ -49,6 +49,7 @@
     },
     "editor.formatOnSave": true,
     "editor.tabSize": 2,
+    "editor.trimAutoWhitespace": true,
 
     "explorer.copyRelativePathSeparator": "/",
 


### PR DESCRIPTION
# Summary

Once Spyglass has formatting/CLI we can just catch this in CICD, but for now we should make it easier for contributors to remove trailing whitespace without having to think about it.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

<!--
how to view the thing you added in-game (Minecraft), if applicable.
- are there certain commands to run?
- if not applicable, write `N/A`.

e.g.:
```mcfunction
function _:reset
function _:summon
function entity:hostile/omega-flowey/attack/x-bullets-lower/start
```
-->

<!-- `in-game -- before` can be `N/A` if this is a new addition to the map -->

## Supplemental changes

- also add `Trailing Spaces` extension to recommended extensions list make them visible + obvious
 
<!--
describe what other changes this PR makes which aren't specific to its main purpose.
- does it contain a world backup? (recommended)
- does it contain other miscellaneous code cleanup?

format these extra changes with bullet points, preferrably.
-->
