### PR TITLE
⬆️ migrate model files to AJ `v1.1.0`

### DIFF
--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/bomb.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/bomb.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "4c9c08dd-d6a5-e642-5c10-64b0cd42e8a6",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\bomb.ajblueprint",
 		"last_used_export_namespace": "bomb"
@@ -1455,7 +1455,7 @@
 			"override": false,
 			"length": 0.6,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": true,
 			"path": "",
 			"anim_time_update": "",

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/dentata-snake-ball.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/dentata-snake-ball.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "04f4fdec-cc4d-27b1-2266-45572d03dcd6",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\dentata-snake-ball.ajblueprint",
 		"last_used_export_namespace": "dentata_snake_ball"
@@ -5789,7 +5789,7 @@
 			"override": false,
 			"length": 1.2,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": true,
 			"path": "",
 			"anim_time_update": "",

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/finger-gun-bullet.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/finger-gun-bullet.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "dd22041e-e017-2441-ed2c-b5068aac58e6",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\finger-gun-bullet.ajblueprint",
 		"last_used_export_namespace": "finger_gun_bullet"
@@ -1328,7 +1328,7 @@
 			"override": false,
 			"length": 0.75,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": true,
 			"path": "",
 			"anim_time_update": "",

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/finger-gun-laser.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/finger-gun-laser.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "967dbae2-a1da-11ee-8c90-0242ac120002",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\finger-gun-laser.ajblueprint",
 		"last_used_export_namespace": "finger_gun_laser"

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/finger-gun.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/finger-gun.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "c8dfcd62-79a1-3ca4-b1b9-ab17e3ddbc3e",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\finger-gun.ajblueprint",
 		"last_used_export_namespace": "finger_gun"
@@ -4571,7 +4571,7 @@
 			"override": false,
 			"length": 1.15,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": true,
 			"path": "",
 			"anim_time_update": "",

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/friendliness-pellet-ring.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/friendliness-pellet-ring.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "501d1aaa-ea51-86d3-3bf1-10e9f8004a5c",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\friendliness-pellet-ring.ajblueprint",
 		"last_used_export_namespace": "friendliness_pellet_ring"

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/friendliness-pellet.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/friendliness-pellet.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "38f101b2-d117-0908-0fe1-35225e73e0b4",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\friendliness-pellet.ajblueprint",
 		"last_used_export_namespace": "friendliness_pellet"
@@ -629,7 +629,7 @@
 			"override": false,
 			"length": 0.4,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": true,
 			"path": "",
 			"anim_time_update": "",

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/homing-vine-blinking-lane.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/homing-vine-blinking-lane.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "548e36d4-c419-e5a0-7385-8f1062b9691f",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\homing-vine-blinking-lane.ajblueprint",
 		"last_used_export_namespace": "homing_vine_blinking_lane"

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/homing-vine.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/homing-vine.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "36b84ded-f8a9-cbdc-bae4-05c4f6bdb170",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\homing-vine.ajblueprint",
 		"last_used_export_namespace": "homing_vine"
@@ -2213,7 +2213,7 @@
 			"override": false,
 			"length": 0.05,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": true,
 			"path": "",
 			"anim_time_update": "",

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/housefly.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/housefly.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "890a34a9-3930-0214-31a3-cabe57429bb9",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\housefly.ajblueprint",
 		"last_used_export_namespace": "housefly"
@@ -3337,7 +3337,7 @@
 			"override": false,
 			"length": 0.45,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": true,
 			"path": "",
 			"anim_time_update": "",

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/projectile-star.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/projectile-star.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "c523ec8c-2275-0b41-3dfe-72c0213741fe",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\projectile-star.ajblueprint",
 		"last_used_export_namespace": "projectile_star"
@@ -1655,7 +1655,7 @@
 			"override": false,
 			"length": 3,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": true,
 			"path": "",
 			"anim_time_update": "",

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/venus-fly-trap.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/venus-fly-trap.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "738b7804-b312-52bc-9340-268c67328f74",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\venus-fly-trap.ajblueprint",
 		"last_used_export_namespace": "venus_fly_trap"
@@ -2311,7 +2311,7 @@
 			"override": false,
 			"length": 0.5,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": true,
 			"path": "",
 			"anim_time_update": "",

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/large-side-vine.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/large-side-vine.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "b26906cf-6e5f-dd9c-47ed-0283dd0ce8b4",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\large-side-vine.ajblueprint",
 		"last_used_export_namespace": "large_side_vine"
@@ -6699,7 +6699,7 @@
 			"override": false,
 			"length": 3.2,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": true,
 			"path": "",
 			"anim_time_update": "",

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/lower-eye.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/lower-eye.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "2d31b9db-c641-46e6-a875-94380ff05f63",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\lower-eye.ajblueprint",
 		"last_used_export_namespace": "lower_eye"
@@ -2581,7 +2581,7 @@
 			"override": false,
 			"length": 6,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": true,
 			"path": "",
 			"anim_time_update": "",

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/mouth.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/mouth.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "371712ad-e756-9dec-8a99-cf345a25ce6f",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\mouth.ajblueprint",
 		"last_used_export_namespace": "mouth"
@@ -9652,8 +9652,8 @@
 	],
 	"variants": {
 		"default": {
-			"display_name": "Default",
 			"name": "default",
+			"display_name": "Default",
 			"uuid": "e5a672ae-3d66-a1e9-2d4b-ed966126a358",
 			"texture_map": {},
 			"excluded_nodes": []
@@ -9668,7 +9668,7 @@
 			"override": false,
 			"length": 9.9,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": false,
 			"path": "",
 			"anim_time_update": "",

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/nose.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/nose.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "be34281d-956c-1cd2-17a4-83f1c471a265",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\nose.ajblueprint",
 		"last_used_export_namespace": "nose"
@@ -875,7 +875,7 @@
 			"override": false,
 			"length": 1.2,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": true,
 			"path": "",
 			"anim_time_update": "",

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/petal_pipes/petal-pipe-circle.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/petal_pipes/petal-pipe-circle.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "0a67fc8d-a3ef-3cc4-dff1-42715f75494e",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\petal_pipes\\petal-pipe-circle.ajblueprint",
 		"last_used_export_namespace": "petal_pipe_circle"
@@ -39648,7 +39648,7 @@
 			"override": false,
 			"length": 1.3,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": true,
 			"path": "",
 			"anim_time_update": "",

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/petal_pipes/petal-pipe-middle.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/petal_pipes/petal-pipe-middle.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "25f5f2d3-a039-1127-7608-d1b5a35d1339",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\petal_pipes\\petal-pipe-middle.ajblueprint",
 		"last_used_export_namespace": "petal_pipe_middle"
@@ -109976,7 +109976,7 @@
 			"override": false,
 			"length": 1.3,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": true,
 			"path": "",
 			"anim_time_update": "",

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/tv-screen.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/tv-screen.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "de143d69-7d25-8ad1-c9e8-f45f431753b9",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\tv-screen.ajblueprint",
 		"last_used_export_namespace": "tv_screen"
@@ -623,7 +623,7 @@
 			"override": false,
 			"length": 0.6,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": true,
 			"path": "",
 			"anim_time_update": "",

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/upper-eye.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/upper-eye.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "8d5aadfe-a7ee-1de7-2688-397a2ec477e6",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\upper-eye.ajblueprint",
 		"last_used_export_namespace": "upper_eye"
@@ -1579,7 +1579,7 @@
 			"override": false,
 			"length": 16.8,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": true,
 			"path": "",
 			"anim_time_update": "",

--- a/resourcepack/assets/omega-flowey/models/entity/soul/act-button.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/soul/act-button.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "9a152a72-5ac5-fc42-ab47-836e60a50f4d",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\soul\\act-button.ajblueprint",
 		"last_used_export_namespace": "act_button"
@@ -9251,16 +9251,16 @@
 	],
 	"variants": {
 		"default": {
-			"display_name": "default",
 			"name": "default",
+			"display_name": "default",
 			"uuid": "af3b495a-74e9-5132-12eb-669728510bd4",
 			"texture_map": {},
 			"excluded_nodes": []
 		},
 		"list": [
 			{
-				"display_name": "selected",
 				"name": "selected",
+				"display_name": "selected",
 				"uuid": "8118c916-ef6c-aba9-d5c0-105f8c495168",
 				"texture_map": {
 					"1c3ee0e5-ab4a-ac92-0add-51d0b5f5ce33": "8b4117ca-f648-3486-90f0-a73a1510c741",
@@ -9334,7 +9334,7 @@
 			"override": false,
 			"length": 0.75,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": false,
 			"path": "",
 			"anim_time_update": "",

--- a/resourcepack/assets/omega-flowey/models/entity/soul/soul-0-bandaid.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/soul/soul-0-bandaid.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "d318c8fb-b217-4cad-6290-d4e647b209f1",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\soul\\soul-0-bandaid.ajblueprint",
 		"last_used_export_namespace": "soul_0_bandaid"

--- a/resourcepack/assets/omega-flowey/models/entity/soul/soul-0-sword.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/soul/soul-0-sword.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "674d0912-11ce-726c-2723-b7a00eb2e0ac",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\soul\\soul-0-sword.ajblueprint",
 		"last_used_export_namespace": "soul_0_sword"

--- a/resourcepack/assets/omega-flowey/models/entity/soul/soul-5-bullet.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/soul/soul-5-bullet.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "04ccd34b-0f97-bfde-9932-dfeaaec549c6",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\soul\\soul-5-bullet.ajblueprint",
 		"last_used_export_namespace": "soul_5_bullet"
@@ -10683,8 +10683,8 @@
 	],
 	"variants": {
 		"default": {
-			"display_name": "Default",
 			"name": "default",
+			"display_name": "Default",
 			"uuid": "c220d276-f88e-1732-a2ca-f9b34e1c8e49",
 			"texture_map": {},
 			"excluded_nodes": []

--- a/resourcepack/assets/omega-flowey/models/entity/soul/soul-5-crosshair.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/soul/soul-5-crosshair.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "201e54ef-18f9-09f6-5b11-5aa1f9c96255",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\soul\\soul-5-crosshair.ajblueprint",
 		"last_used_export_namespace": "soul_5_crosshair"
@@ -2536,16 +2536,16 @@
 	],
 	"variants": {
 		"default": {
-			"display_name": "Default",
 			"name": "default",
+			"display_name": "Default",
 			"uuid": "1b7848f7-9706-58af-df10-d81f0c154089",
 			"texture_map": {},
 			"excluded_nodes": []
 		},
 		"list": [
 			{
-				"display_name": "heart",
 				"name": "heart",
+				"display_name": "heart",
 				"uuid": "485a5a3c-cc4c-479b-2e51-b19c1663063e",
 				"texture_map": {
 					"d5ad2c8c-0fa6-db12-e119-b8324d25349b": "797174ae-5c58-4a83-a630-eefd51007c80",

--- a/resourcepack/assets/omega-flowey/models/entity/soul/soul-5-flower.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/soul/soul-5-flower.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "f934f0d9-4f0f-4686-655d-07bdbe2b3338",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\soul\\soul-5-flower.ajblueprint",
 		"last_used_export_namespace": "soul_5_flower"
@@ -8108,8 +8108,8 @@
 	],
 	"variants": {
 		"default": {
-			"display_name": "Default",
 			"name": "default",
+			"display_name": "Default",
 			"uuid": "e24cc3c0-77b4-e815-04f0-0940ca9cabfe",
 			"texture_map": {},
 			"excluded_nodes": []

--- a/resourcepack/assets/omega-flowey/models/entity/soul/soul-5-gun.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/soul/soul-5-gun.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "201e54ef-18f9-09f6-5b11-5aa1f9c96254",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\soul\\soul-5-gun.ajblueprint",
 		"last_used_export_namespace": "soul_5_gun"
@@ -5528,8 +5528,8 @@
 	],
 	"variants": {
 		"default": {
-			"display_name": "Default",
 			"name": "default",
+			"display_name": "Default",
 			"uuid": "1b7848f7-9706-58af-df10-d81f0c154089",
 			"texture_map": {},
 			"excluded_nodes": []

--- a/resourcepack/assets/omega-flowey/models/entity/soul/soul.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/soul/soul.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "0.5.10",
+		"format_version": "1.1.0",
 		"uuid": "953ff968-9e3b-f3b7-78d6-3e2254ba4dc0",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\soul\\soul.ajblueprint",
 		"last_used_export_namespace": "soul"
@@ -914,7 +914,7 @@
 			"override": false,
 			"length": 1.7,
 			"snapping": 20,
-			"selected": true,
+			"selected": false,
 			"saved": true,
 			"path": "",
 			"anim_time_update": "",


### PR DESCRIPTION
# Summary

This is just opening each `.ajblueprint` in the latest AJ version on the Blockbench store (v1.1.0) and saving.

Fortunately there's no significant diffs :)

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->
