### PR TITLE
🐛 fix `entity:setup` not resetting soul event params

### DIFF
--- a/datapacks/omega-flowey/data/_/function/reset_scores.mcfunction
+++ b/datapacks/omega-flowey/data/_/function/reset_scores.mcfunction
@@ -1,2 +1,1 @@
-function entity:hostile/omega-flowey/attack/reset_scores
-function entity:soul/reset_scores
+function entity:reset_scores

--- a/datapacks/omega-flowey/data/entity/function/reset_scores.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/reset_scores.mcfunction
@@ -1,0 +1,2 @@
+function entity:hostile/omega-flowey/attack/reset_scores
+function entity:soul/reset_scores

--- a/datapacks/omega-flowey/data/entity/function/setup.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/setup.mcfunction
@@ -1,1 +1,1 @@
-function entity:hostile/omega-flowey/attack/reset_scores
+function entity:reset_scores


### PR DESCRIPTION
# Summary

we incorrectly assumed every `reset_scores.mcfunction` would be under the `attack` directory. but soul events also exist.

this assumption led to us forgetting to call `function entity:soul/reset_scores` upon setup (`/reload`).

this PR refactors these functions so there's now a top-level `entity:reset_scores` function that is guaranteed to reset all parameters upon `/reload`

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->