### PR TITLE
🐛 👻 fix `soul-5-gun` hitbox damaging players post-SAVED

### DIFF
--- a/datapacks/omega-flowey/data/entity/function/soul/soul_5/indicator/locator.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/soul/soul_5/indicator/locator.mcfunction
@@ -1,1 +1,1 @@
-execute positioned ~ ~-1 ~ run function entity:utils/damage with entity @s data
+execute if score #soul_5.saved soul.flag matches 0 positioned ~ ~-1 ~ run function entity:utils/damage with entity @s data


### PR DESCRIPTION
# Summary

When `soul-5-gun`'s hitbox touches a player, it slightly damages them (to prevent cheesing the event by standing inside the gun).

After soul event 5 transitions to `SAVED` and the gun starts shooting flowers / healing the player, it should no longer damage the player upon contact.

Before, it would damage the player post-SAVED. This PR fixes this so it no longer damages the player post-SAVED.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Reproducing in-game

```mcfunction
function _:soul/5
```

## Preview

| before | after |
|-|-|
|![before](https://github.com/user-attachments/assets/f54d8e50-a1d2-4586-b0d2-d6a0e2fe7ee5)|![after](https://github.com/user-attachments/assets/2d313f75-7a92-472f-8e40-e88165dbef18)|

<!-- `in-game -- before` can be `N/A` if this is a new addition to the map -->
