### PR TITLE
⚔️ decrease `x-bullets-upper` attack cone size

### DIFF
--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-upper/reset_scores.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-upper/reset_scores.mcfunction
@@ -2,7 +2,7 @@
 # TODO(46): validate these attack parameters
 scoreboard players set #attack-x-bullets-upper attack.bullets.clock.delay 1
 scoreboard players set #attack-x-bullets-upper attack.bullets.total 3
-scoreboard players set #attack-x-bullets-upper attack.cone 39
+scoreboard players set #attack-x-bullets-upper attack.cone 27
 scoreboard players set #attack-x-bullets-upper attack.executor.clock.delay 8
 scoreboard players set #attack-x-bullets-upper attack.executor.clock.length 56
 scoreboard players set #attack-x-bullets-upper attack.executor.rate 4


### PR DESCRIPTION
# Summary

In Undertale, the cone that the upper x-bullets summon towards the player in a cone that leds to the player needing to slowly move horizontally in order to:
- avoid the bullet directly approaching them
- avoid walking into the bullet to the left/right of them

Currently this attack's cone size in the map is too wide, so the player can just sprint horizontally at full speed without any movement nuance.

This PR decreases the cone size from `39` to `27` degrees so the attack isn't trivially easy to dodge.

(I think the original `39` degrees came from a sort-of measurement of the cone in Undertale, but that's less important than the attack's actual behavior in Minecraft)

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Reproducing in-game

```mcfunction
function _:attack/x-bullets-lower
```

## Preview

| in-game -- before | in-game -- after | undertale |
| ----------------- | ---------------- | --------- |
| ![before](https://github.com/user-attachments/assets/a7adaae7-fef9-44f4-a588-cd488b92231a)| ![after](https://github.com/user-attachments/assets/9be7501d-1ddb-43e6-b939-ce5adccb4dac) |![undertale](https://github.com/user-attachments/assets/65635a85-12ac-4528-9782-569e79c02108) |
| | | from https://youtu.be/8jmptY4uCkk?t=28 |