### PR TITLE
decrease attack `x-bullets-lower` cone size

### DIFF
--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/reset_scores.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/reset_scores.mcfunction
@@ -1,5 +1,6 @@
 ## Set fake player scores back to defaults (if they were changed by a pre-initialize attack function)
 # TODO(46): validate these attack parameters
+# TODO: do the thing
 scoreboard players set #attack-x-bullets-lower attack.bullets.clock.delay 1
 scoreboard players set #attack-x-bullets-lower attack.bullets.total 7
 scoreboard players set #attack-x-bullets-lower attack.cone 20

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/reset_scores.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/reset_scores.mcfunction
@@ -2,7 +2,7 @@
 # TODO(46): validate these attack parameters
 scoreboard players set #attack-x-bullets-lower attack.bullets.clock.delay 1
 scoreboard players set #attack-x-bullets-lower attack.bullets.total 7
-scoreboard players set #attack-x-bullets-lower attack.cone 105
+scoreboard players set #attack-x-bullets-lower attack.cone 20
 scoreboard players set #attack-x-bullets-lower attack.executor.clock.delay 8
 scoreboard players set #attack-x-bullets-lower attack.executor.clock.length 56
 scoreboard players set #attack-x-bullets-lower attack.executor.rate 8


### PR DESCRIPTION
# Summary

This PR decreases the cone size of `x-bullets-lower`

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Reproducing in-game

```mcfunction
function _:attack/x-bullets-lower
```

## Preview

<!--
provide visuals (GIFs preferred) showing a before/after of your PR's purpose.
contrasts between in-game (Minecraft) and Undertale are also great.
-->

| in-game -- before | in-game -- after | undertale |
| ----------------- | ---------------- | --------- |
|                   |                  |           |

<!-- `in-game -- before` can be `N/A` if this is a new addition to the map -->

---

## Supplemental changes

<!--
describe what other changes this PR makes which aren't specific to its main purpose.
- does it contain a world backup? (recommended)
- does it contain other miscellaneous code cleanup?

format these extra changes with bullet points, preferrably.
-->
