### PR TITLE
⬆️ migrate model files to AJ `v1.3.0`

### DIFF
--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/bomb.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/bomb.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "4c9c08dd-d6a5-e642-5c10-64b0cd42e8a6",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\bomb.ajblueprint",
 		"last_used_export_namespace": "bomb"
@@ -1375,7 +1375,8 @@
 			"display_name": "default",
 			"uuid": "f1a0ad49-dbd8-523a-4776-01368d72176b",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": [
 			{

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/dentata-snake-ball.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/dentata-snake-ball.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "04f4fdec-cc4d-27b1-2266-45572d03dcd6",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\dentata-snake-ball.ajblueprint",
 		"last_used_export_namespace": "dentata_snake_ball"
@@ -4807,7 +4807,8 @@
 			"display_name": "default",
 			"uuid": "51dfed36-734d-a608-4607-6351aff7e069",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": [
 			{

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/finger-gun-bullet.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/finger-gun-bullet.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "dd22041e-e017-2441-ed2c-b5068aac58e6",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\finger-gun-bullet.ajblueprint",
 		"last_used_export_namespace": "finger_gun_bullet"
@@ -1316,7 +1316,8 @@
 			"display_name": "default",
 			"uuid": "25e1e5e0-12ee-3d0f-2141-2eddc2e101a4",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": []
 	},

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/finger-gun-laser.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/finger-gun-laser.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "967dbae2-a1da-11ee-8c90-0242ac120002",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\finger-gun-laser.ajblueprint",
 		"last_used_export_namespace": "finger_gun_laser"
@@ -137,7 +137,8 @@
 			"display_name": "default",
 			"uuid": "216293ac-ba41-3ada-6f65-96eb22f315d7",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": []
 	},

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/finger-gun.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/finger-gun.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "c8dfcd62-79a1-3ca4-b1b9-ab17e3ddbc3e",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\finger-gun.ajblueprint",
 		"last_used_export_namespace": "finger_gun"
@@ -2043,7 +2043,8 @@
 			"display_name": "shot",
 			"uuid": "e3b2d1e5-5057-343d-365b-f3d698e91f2f",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": [
 			{

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/friendliness-pellet-ring.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/friendliness-pellet-ring.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "501d1aaa-ea51-86d3-3bf1-10e9f8004a5c",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\friendliness-pellet-ring.ajblueprint",
 		"last_used_export_namespace": "friendliness_pellet_ring"
@@ -830,7 +830,8 @@
 			"display_name": "default",
 			"uuid": "fa9d21f3-c549-d4ee-f491-a79c0b05b84e",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": [
 			{

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/friendliness-pellet.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/friendliness-pellet.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "38f101b2-d117-0908-0fe1-35225e73e0b4",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\friendliness-pellet.ajblueprint",
 		"last_used_export_namespace": "friendliness_pellet"
@@ -617,7 +617,8 @@
 			"display_name": "default",
 			"uuid": "b128252d-506b-b1ab-6fba-5b09194d2ef5",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": []
 	},

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/homing-vine-blinking-lane.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/homing-vine-blinking-lane.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "548e36d4-c419-e5a0-7385-8f1062b9691f",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\homing-vine-blinking-lane.ajblueprint",
 		"last_used_export_namespace": "homing_vine_blinking_lane"
@@ -180,7 +180,8 @@
 			"display_name": "default",
 			"uuid": "216293ac-ba41-3ada-6f65-96eb22f315d7",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": []
 	},

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/homing-vine.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/homing-vine.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "36b84ded-f8a9-cbdc-bae4-05c4f6bdb170",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\homing-vine.ajblueprint",
 		"last_used_export_namespace": "homing_vine"
@@ -2201,7 +2201,8 @@
 			"display_name": "default",
 			"uuid": "c4f5ae03-0852-324b-fd1b-356af03d9d51",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": []
 	},

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/housefly.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/housefly.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "890a34a9-3930-0214-31a3-cabe57429bb9",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\housefly.ajblueprint",
 		"last_used_export_namespace": "housefly"
@@ -3325,7 +3325,8 @@
 			"display_name": "default",
 			"uuid": "d6a3882a-bc7c-c59b-6a97-31e1203d98c0",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": []
 	},

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/projectile-star.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/projectile-star.ajblueprint
@@ -1484,7 +1484,7 @@
 			"ignore_inherited_scale": false,
 			"visibility": true,
 			"locked": false,
-			"config": null,
+			"config": {},
 			"uuid": "0ba00a22-bbf4-dc8d-9dcb-f0a6b1f56968",
 			"type": "locator"
 		}

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/projectile-star.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/projectile-star.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "c523ec8c-2275-0b41-3dfe-72c0213741fe",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\projectile-star.ajblueprint",
 		"last_used_export_namespace": "projectile_star"
@@ -1643,7 +1643,8 @@
 			"display_name": "default",
 			"uuid": "78f5b124-7f56-11d9-43af-cd02c50eab9b",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": []
 	},

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/venus-fly-trap.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/venus-fly-trap.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "738b7804-b312-52bc-9340-268c67328f74",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\attacks\\venus-fly-trap.ajblueprint",
 		"last_used_export_namespace": "venus_fly_trap"
@@ -2299,7 +2299,8 @@
 			"display_name": "default",
 			"uuid": "c0d926f5-2fce-7be5-1e89-439fe587d4f8",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": []
 	},

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/large-side-vine.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/large-side-vine.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "b26906cf-6e5f-dd9c-47ed-0283dd0ce8b4",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\large-side-vine.ajblueprint",
 		"last_used_export_namespace": "large_side_vine"
@@ -6334,7 +6334,8 @@
 			"display_name": "default",
 			"uuid": "79bbe9d2-bdfd-085e-aa50-d7fcb2e16344",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": []
 	},

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/lower-eye.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/lower-eye.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "2d31b9db-c641-46e6-a875-94380ff05f63",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\lower-eye.ajblueprint",
 		"last_used_export_namespace": "lower_eye"
@@ -2532,7 +2532,8 @@
 			"display_name": "default",
 			"uuid": "6fde0b59-c952-3d58-4087-1bfa481a613d",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": [
 			{

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/lower-eye.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/lower-eye.ajblueprint
@@ -1977,7 +1977,8 @@
 			"config": {
 				"use_entity": true,
 				"entity_type": "minecraft:marker",
-				"summon_commands": "data merge entity @s {}"
+				"summon_commands": "data merge entity @s {}",
+				"ticking_commands": ""
 			},
 			"uuid": "49f3d396-14a1-9064-26d7-32b47055e719",
 			"type": "locator"

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/mouth.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/mouth.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "371712ad-e756-9dec-8a99-cf345a25ce6f",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\mouth.ajblueprint",
 		"last_used_export_namespace": "mouth"
@@ -9656,7 +9656,8 @@
 			"display_name": "Default",
 			"uuid": "e5a672ae-3d66-a1e9-2d4b-ed966126a358",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": []
 	},

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/nose.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/nose.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "be34281d-956c-1cd2-17a4-83f1c471a265",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\nose.ajblueprint",
 		"last_used_export_namespace": "nose"
@@ -863,7 +863,8 @@
 			"display_name": "default",
 			"uuid": "05d4ccab-be17-d1b2-6e1d-e8844e64c952",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": []
 	},

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/petal_pipes/petal-pipe-circle.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/petal_pipes/petal-pipe-circle.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "0a67fc8d-a3ef-3cc4-dff1-42715f75494e",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\petal_pipes\\petal-pipe-circle.ajblueprint",
 		"last_used_export_namespace": "petal_pipe_circle"
@@ -6087,7 +6087,8 @@
 			"display_name": "default",
 			"uuid": "6fde0b59-c952-3d58-4087-1bfa481a613d",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": [
 			{

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/petal_pipes/petal-pipe-middle.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/petal_pipes/petal-pipe-middle.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "25f5f2d3-a039-1127-7608-d1b5a35d1339",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\petal_pipes\\petal-pipe-middle.ajblueprint",
 		"last_used_export_namespace": "petal_pipe_middle"
@@ -5986,7 +5986,8 @@
 			"display_name": "default",
 			"uuid": "d3b198f5-761c-b371-8166-506e011eccf0",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": [
 			{

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/tv-screen.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/tv-screen.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "de143d69-7d25-8ad1-c9e8-f45f431753b9",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\tv-screen.ajblueprint",
 		"last_used_export_namespace": "tv_screen"
@@ -592,7 +592,8 @@
 			"display_name": "default",
 			"uuid": "59805ee0-d249-bf4c-f01a-67b2cd10bd88",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": [
 			{

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/upper-eye.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/upper-eye.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "8d5aadfe-a7ee-1de7-2688-397a2ec477e6",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\hostile\\omega-flowey\\upper-eye.ajblueprint",
 		"last_used_export_namespace": "upper_eye"
@@ -1533,7 +1533,8 @@
 			"display_name": "default",
 			"uuid": "6fde0b59-c952-3d58-4087-1bfa481a613d",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": [
 			{

--- a/resourcepack/assets/omega-flowey/models/entity/soul/act-button.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/soul/act-button.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "9a152a72-5ac5-fc42-ab47-836e60a50f4d",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\soul\\act-button.ajblueprint",
 		"last_used_export_namespace": "act_button"
@@ -9255,7 +9255,8 @@
 			"display_name": "default",
 			"uuid": "af3b495a-74e9-5132-12eb-669728510bd4",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": [
 			{

--- a/resourcepack/assets/omega-flowey/models/entity/soul/soul-0-bandaid.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/soul/soul-0-bandaid.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "d318c8fb-b217-4cad-6290-d4e647b209f1",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\soul\\soul-0-bandaid.ajblueprint",
 		"last_used_export_namespace": "soul_0_bandaid"
@@ -2250,7 +2250,8 @@
 			"display_name": "default",
 			"uuid": "7aa2d550-0b70-6747-c95a-1e8a6e4f16c4",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": []
 	},

--- a/resourcepack/assets/omega-flowey/models/entity/soul/soul-0-sword.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/soul/soul-0-sword.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "674d0912-11ce-726c-2723-b7a00eb2e0ac",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\soul\\soul-0-sword.ajblueprint",
 		"last_used_export_namespace": "soul_0_sword"
@@ -1248,7 +1248,8 @@
 			"display_name": "default",
 			"uuid": "0afeecc0-d0da-023c-76a1-df1de888f370",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": []
 	},

--- a/resourcepack/assets/omega-flowey/models/entity/soul/soul-5-bullet.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/soul/soul-5-bullet.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "04ccd34b-0f97-bfde-9932-dfeaaec549c6",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\soul\\soul-5-bullet.ajblueprint",
 		"last_used_export_namespace": "soul_5_bullet"
@@ -10687,7 +10687,8 @@
 			"display_name": "Default",
 			"uuid": "c220d276-f88e-1732-a2ca-f9b34e1c8e49",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": []
 	},

--- a/resourcepack/assets/omega-flowey/models/entity/soul/soul-5-crosshair.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/soul/soul-5-crosshair.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "201e54ef-18f9-09f6-5b11-5aa1f9c96255",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\soul\\soul-5-crosshair.ajblueprint",
 		"last_used_export_namespace": "soul_5_crosshair"
@@ -2540,7 +2540,8 @@
 			"display_name": "Default",
 			"uuid": "1b7848f7-9706-58af-df10-d81f0c154089",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": [
 			{

--- a/resourcepack/assets/omega-flowey/models/entity/soul/soul-5-flower.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/soul/soul-5-flower.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "f934f0d9-4f0f-4686-655d-07bdbe2b3338",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\soul\\soul-5-flower.ajblueprint",
 		"last_used_export_namespace": "soul_5_flower"
@@ -8112,7 +8112,8 @@
 			"display_name": "Default",
 			"uuid": "e24cc3c0-77b4-e815-04f0-0940ca9cabfe",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": []
 	},

--- a/resourcepack/assets/omega-flowey/models/entity/soul/soul-5-gun.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/soul/soul-5-gun.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "201e54ef-18f9-09f6-5b11-5aa1f9c96254",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\soul\\soul-5-gun.ajblueprint",
 		"last_used_export_namespace": "soul_5_gun"
@@ -5532,7 +5532,8 @@
 			"display_name": "Default",
 			"uuid": "1b7848f7-9706-58af-df10-d81f0c154089",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": []
 	},

--- a/resourcepack/assets/omega-flowey/models/entity/soul/soul.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/soul/soul.ajblueprint
@@ -1,7 +1,7 @@
 {
 	"meta": {
 		"format": "animated_java_blueprint",
-		"format_version": "1.1.0",
+		"format_version": "1.3.0",
 		"uuid": "953ff968-9e3b-f3b7-78d6-3e2254ba4dc0",
 		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\soul\\soul.ajblueprint",
 		"last_used_export_namespace": "soul"
@@ -679,7 +679,8 @@
 			"display_name": "red",
 			"uuid": "b96f8c23-e688-b229-ca1c-42f9e4772d96",
 			"texture_map": {},
-			"excluded_nodes": []
+			"excluded_nodes": [],
+			"is_default": true
 		},
 		"list": [
 			{


### PR DESCRIPTION
# Summary

Opens each `.ajblueprint` in the latest AJ version on the Blockbench store (v1.3.0) and saving.

There was a bug with the `projectile_star` model that prevented it from auto-exporting. This was fixed: 6d598714e81adad0eaffd400d3fb1757d2360d32

---

## Reproducing

```sh
yarn start export
```
