### PR TITLE
♻️ DRY common workflow env variables

### DIFF
--- a/.github/variables/shared.env
+++ b/.github/variables/shared.env
@@ -1,0 +1,6 @@
+ASSETS_DIR=null
+BLOCKBENCH_PATH=null
+DATAPACK=null
+MINECRAFT_PATH=null
+RESOURCEPACK=null
+WORLD_NAME=omega-flowey-remastered

--- a/.github/workflows/datapack.yml
+++ b/.github/workflows/datapack.yml
@@ -7,18 +7,14 @@ env:
   FABRIC_SERVER: https://meta.fabricmc.net/v2/versions/loader/1.21/0.15.11/1.0.1/server/jar
   PACKTEST: https://cdn.modrinth.com/data/XsKUhp45/versions/sQSunYHv/packtest-1.8-beta3-mc1.21.jar
 
-  ASSETS_DIR: null
-  BLOCKBENCH_PATH: null
-  DATAPACK: null
-  MINECRAFT_PATH: null
-  RESOURCEPACK: null
-  WORLD_NAME: omega-flowey-remastered
-
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: tw3lveparsecs/github-actions-set-variables@v0.2
+        with:
+          envFilePath: ./.github/variables/shared.env
       - name: Install Yarn 3.6.3
         run: corepack enable
       - name: Setup cache

--- a/.github/workflows/resourcepack.yml
+++ b/.github/workflows/resourcepack.yml
@@ -2,19 +2,14 @@ name: resourcepack
 
 on: [push]
 
-env:
-  ASSETS_DIR: null
-  BLOCKBENCH_PATH: null
-  DATAPACK: null
-  MINECRAFT_PATH: null
-  RESOURCEPACK: null
-  WORLD_NAME: omega-flowey-remastered
-
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: tw3lveparsecs/github-actions-set-variables@v0.2
+        with:
+          envFilePath: ./.github/variables/shared.env
       - name: Install Yarn 3.6.3
         run: corepack enable
       - name: Setup cache

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -2,19 +2,14 @@ name: scripts
 
 on: [push]
 
-env:
-  ASSETS_DIR: null
-  BLOCKBENCH_PATH: null
-  DATAPACK: null
-  MINECRAFT_PATH: null
-  RESOURCEPACK: null
-  WORLD_NAME: omega-flowey-remastered
-
 jobs:
   format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: tw3lveparsecs/github-actions-set-variables@v0.2
+        with:
+          envFilePath: ./.github/variables/shared.env
       - name: Install Yarn 3.6.3
         run: corepack enable
       - name: Setup cache
@@ -32,6 +27,9 @@ jobs:
     needs: format
     steps:
       - uses: actions/checkout@v4
+      - uses: tw3lveparsecs/github-actions-set-variables@v0.2
+        with:
+          envFilePath: ./.github/variables/shared.env
       - name: Install Yarn 3.6.3
         run: corepack enable
       - name: Setup cache


### PR DESCRIPTION
# Summary

GitHub Actions doesn't support sharing environment variables between workflows natively, but we can use some simple code in the following Action to accomplish this:

https://github.com/tw3lveparsecs/github-actions-set-variables

Now we don't have to copy-paste each environment variable into each workflow config file (DRY)

---

## Reproducing

see workflows passing

## Preview

![image](https://github.com/user-attachments/assets/8660c015-7168-4232-b75e-94aaa367343c)