### PR TITLE
✨ 👷 generate AJ export files in `datapack/test` CI job

### DIFF
--- a/.github/actions/setup-animated-java-exports/action.yml
+++ b/.github/actions/setup-animated-java-exports/action.yml
@@ -11,7 +11,7 @@ runs:
     - uses: actions/cache/restore@v4
       id: cache-animated-java-exports
       with:
-        key: cache-animated-java-exports-vDEVTESTticket81-${{ env.BLOCKBENCH_URL }}-${{ env.ANIMATED_JAVA_URL }}-${{ hashFiles('resourcepack/assets/omega-flowey/models/**/*.ajblueprint')}}
+        key: cache-animated-java-exports-${{ env.BLOCKBENCH_URL }}-${{ env.ANIMATED_JAVA_URL }}-${{ hashFiles('resourcepack/assets/omega-flowey/models/**/*.ajblueprint')}}
         path: |
           datapacks/animated_java/data
           datapacks/animated_java/data.ajmeta

--- a/.github/actions/setup-animated-java-exports/action.yml
+++ b/.github/actions/setup-animated-java-exports/action.yml
@@ -1,0 +1,33 @@
+name: Setup Animated Java Exports
+description: >
+  Attempts to restore Animated Java export files from cache.
+  If cache not hit, installs Animated Java and runs our auto-exporter
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+    - uses: ./.github/actions/setup-yarn
+    - uses: actions/cache/restore@v4
+      id: cache-animated-java-exports
+      with:
+        key: cache-animated-java-exports-${{ env.BLOCKBENCH_URL }}-${{ env.ANIMATED_JAVA_URL }}-${{ hashFiles('resourcepack/assets/omega-flowey/models/**/*.ajblueprint')}}
+        path: |
+          datapacks/animated_java/data
+          datapacks/animated_java/data.ajmeta
+          resourcepack/assets.ajmeta
+          resourcepack/assets/animated_java
+          resourcepack/assets/minecraft/models/item/white_dye.json
+    - run: bash ${{ github.action_path }}/install-animated-java-and-run-auto-exporter.sh
+      if: ${{ steps.cache-animated-java-exports.outputs.cache-hit != 'true' }}
+      shell: bash
+    - uses: actions/cache/save@v4
+      if: ${{ steps.cache-animated-java-exports.outputs.cache-hit != 'true' }}
+      with:
+        key: ${{ steps.cache-animated-java-exports.outputs.cache-primary-key }}
+        path: |
+          datapacks/animated_java/data
+          datapacks/animated_java/data.ajmeta
+          resourcepack/assets.ajmeta
+          resourcepack/assets/animated_java
+          resourcepack/assets/minecraft/models/item/white_dye.json

--- a/.github/actions/setup-animated-java-exports/action.yml
+++ b/.github/actions/setup-animated-java-exports/action.yml
@@ -11,7 +11,7 @@ runs:
     - uses: actions/cache/restore@v4
       id: cache-animated-java-exports
       with:
-        key: cache-animated-java-exports-${{ env.BLOCKBENCH_URL }}-${{ env.ANIMATED_JAVA_URL }}-${{ hashFiles('resourcepack/assets/omega-flowey/models/**/*.ajblueprint')}}
+        key: cache-animated-java-exports-vDEVTESTticket81-${{ env.BLOCKBENCH_URL }}-${{ env.ANIMATED_JAVA_URL }}-${{ hashFiles('resourcepack/assets/omega-flowey/models/**/*.ajblueprint')}}
         path: |
           datapacks/animated_java/data
           datapacks/animated_java/data.ajmeta

--- a/.github/actions/setup-animated-java-exports/install-animated-java-and-run-auto-exporter.sh
+++ b/.github/actions/setup-animated-java-exports/install-animated-java-and-run-auto-exporter.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -x
+
+export DISPLAY=:99
+
+echo Download Blockbench debian package
+curl -Lo Blockbench.deb $BLOCKBENCH_URL
+
+echo Install Blockbench and required apps
+sudo apt-get -fy install xvfb xdotool ./Blockbench.deb
+
+echo Setup Blockbench args
+BLOCKBENCH_PATH=blockbench
+DATAPACK="$PWD/datapacks/animated_java"
+RESOURCEPACK="$PWD/resourcepack"
+
+echo Start headless X server
+Xvfb $DISPLAY &
+
+echo Start Blockbench and wait until initialized
+# Use the export script to pass-in the CLI args automatically, the same way we do when we run
+# `yarn start export` locally (for reproducability)
+yarn start "export.run --enable-logging" &> blockbench.log & tail -f -n1 blockbench.log | grep -qe "Update for version"
+
+echo Open dev tools and show console
+xdotool key ctrl+shift+i
+tail -f -n1 blockbench.log | grep -qe "Request Autofill.setAddresses failed."
+xdotool key ctrl+shift+p
+sleep 1
+xdotool type 'show console'
+sleep 1
+xdotool key Return
+sleep 1
+
+echo Install Animated Java plugin
+xdotool type --delay 30 "new Plugin().loadFromURL('${ANIMATED_JAVA_URL}');"
+sleep 1 && xdotool key Return
+tail -f -n1 blockbench.log | grep -qe "Minecraft fonts loaded!"
+
+echo Install Blockbench CLI plugin
+xdotool type --delay 30 'new Plugin().loadFromFile({ path:"./package-scripts/modules/bb-cli.js"});'
+sleep 1 && xdotool key Return
+tail -f -n1 blockbench.log | grep -qe "BB-CLI: importing script:"
+
+echo Export repository\'s Animated Java models
+tail -f -n1 blockbench.log | grep -qe "Finished exporting ajblueprints"

--- a/.github/workflows/datapack.yml
+++ b/.github/workflows/datapack.yml
@@ -3,7 +3,7 @@ name: datapack
 on: [push]
 
 env:
-  ANIMATED_JAVA_URL: "https://github.com/Animated-Java/animated-java/releases/download/v1.4.0/animated_java.js"
+  ANIMATED_JAVA_URL: "https://github.com/Animated-Java/animated-java/releases/download/v1.3.0/animated_java.js"
   BLOCKBENCH_URL: "https://github.com/JannisX11/blockbench/releases/download/v4.11.0-beta.1/Blockbench_4.11.0-beta.1.deb"
   FABRIC_API: https://cdn.modrinth.com/data/P7dR8mSH/versions/HXzEJYgV/fabric-api-0.100.1%2B1.21.jar
   FABRIC_SERVER: https://meta.fabricmc.net/v2/versions/loader/1.21/0.15.11/1.0.1/server/jar

--- a/.github/workflows/datapack.yml
+++ b/.github/workflows/datapack.yml
@@ -3,6 +3,8 @@ name: datapack
 on: [push]
 
 env:
+  ANIMATED_JAVA_URL: "https://github.com/Animated-Java/animated-java/releases/download/v1.4.0/animated_java.js"
+  BLOCKBENCH_URL: "https://github.com/JannisX11/blockbench/releases/download/v4.11.0-beta.1/Blockbench_4.11.0-beta.1.deb"
   FABRIC_API: https://cdn.modrinth.com/data/P7dR8mSH/versions/HXzEJYgV/fabric-api-0.100.1%2B1.21.jar
   FABRIC_SERVER: https://meta.fabricmc.net/v2/versions/loader/1.21/0.15.11/1.0.1/server/jar
   PACKTEST: https://cdn.modrinth.com/data/XsKUhp45/versions/sQSunYHv/packtest-1.8-beta3-mc1.21.jar
@@ -22,6 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-animated-java-exports
+        timeout-minutes: 4
+      - run: echo "$(cat blockbench.log)"
+        if: ${{ failure() || cancelled() }}
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'

--- a/.github/workflows/datapack.yml
+++ b/.github/workflows/datapack.yml
@@ -3,8 +3,8 @@ name: datapack
 on: [push]
 
 env:
-  ANIMATED_JAVA_URL: "https://github.com/Animated-Java/animated-java/releases/download/v1.3.0/animated_java.js"
-  BLOCKBENCH_URL: "https://github.com/JannisX11/blockbench/releases/download/v4.11.0-beta.1/Blockbench_4.11.0-beta.1.deb"
+  ANIMATED_JAVA_URL: 'https://github.com/Animated-Java/animated-java/releases/download/v1.3.0/animated_java.js'
+  BLOCKBENCH_URL: 'https://github.com/JannisX11/blockbench/releases/download/v4.11.0-beta.1/Blockbench_4.11.0-beta.1.deb'
   FABRIC_API: https://cdn.modrinth.com/data/P7dR8mSH/versions/HXzEJYgV/fabric-api-0.100.1%2B1.21.jar
   FABRIC_SERVER: https://meta.fabricmc.net/v2/versions/loader/1.21/0.15.11/1.0.1/server/jar
   PACKTEST: https://cdn.modrinth.com/data/XsKUhp45/versions/sQSunYHv/packtest-1.8-beta3-mc1.21.jar

--- a/.github/workflows/datapack.yml
+++ b/.github/workflows/datapack.yml
@@ -3,8 +3,8 @@ name: datapack
 on: [push]
 
 env:
-  ANIMATED_JAVA_URL: 'https://github.com/Animated-Java/animated-java/releases/download/v1.3.0/animated_java.js'
-  BLOCKBENCH_URL: 'https://github.com/JannisX11/blockbench/releases/download/v4.11.0-beta.1/Blockbench_4.11.0-beta.1.deb'
+  ANIMATED_JAVA_URL: https://github.com/Animated-Java/animated-java/releases/download/v1.3.0/animated_java.js
+  BLOCKBENCH_URL: https://github.com/JannisX11/blockbench/releases/download/v4.11.0-beta.1/Blockbench_4.11.0-beta.1.deb
   FABRIC_API: https://cdn.modrinth.com/data/P7dR8mSH/versions/HXzEJYgV/fabric-api-0.100.1%2B1.21.jar
   FABRIC_SERVER: https://meta.fabricmc.net/v2/versions/loader/1.21/0.15.11/1.0.1/server/jar
   PACKTEST: https://cdn.modrinth.com/data/XsKUhp45/versions/sQSunYHv/packtest-1.8-beta3-mc1.21.jar

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -83,7 +83,7 @@ module.exports = {
       },
     },
     export: {
-      default: series('nps export.run', 'echo finished exporting ajblueprints'),
+      default: 'nps export.run',
       run: `yarn exec "${blockbenchPath}" --script="${ajexportScriptPath}" --cwd="${process.cwd()}" --assets-dir="${assetsDir}" --datapack="${datapack}" --resourcepack="${resourcePack}"`,
       // forcibly purge the `animated_java` export-cache
       force: series(

--- a/package-scripts/modules/ajexport.js
+++ b/package-scripts/modules/ajexport.js
@@ -125,6 +125,8 @@ export async function script() {
   }
 
   updateLastExportedHashes(ajblueprintDir, lastExported);
+
+  log('Finished exporting ajblueprints');
 }
 
 /**


### PR DESCRIPTION
# Summary

(this is a cool one)

Resolves #81 -- see ticket for full context

This PR adds workflow/CICD support for AJ export files. Since we previously removed AJ export files from the repository (by adding them to `.gitignore`), no CICD jobs could reference them. This was particularly relevant for the MC unit test job (`datapack/test`).

Now, the `datapack/test` job sets up AJ export files prior to running. It attempts to restore from a cache key comprising of:
- AJ version
- Blockbench version
- the checksum of every `.ajblueprint` file in the repo

So if all of the above properties stay the same, it will restore from cache and not go through the entire Blockbench install + AJ export process.

---

If the cache does NOT hit, we do the following:

1. Download Blockbench
2. Install Blockbench and related X-server apps
3. Install the Animated Java plugin
4. Install our local `bb-cli.js` plugin
5. Run the auto-exporter
6. (save export files to cache)

---

## Reproducing

see GHA workflow logs:

- cache not found and run Blockbench-install workflow: https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/actions/runs/10710805840/job/29698295621#step:3:229
- cache restored successfully: https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/actions/runs/10710842717/job/29698401848#step:3:232

---

Future PRs will make use of AJ export files being accessible in CICD. e.g.:

- adding unit tests that reference `animated_java` functions
- ensuring each `.ajblueprint `is summon-able in-game (another, separate (?), unit test workflow)