### PR TITLE
✅ add tests to verify each AJ model is summonable

### DIFF
--- a/.github/actions/setup-animated-java-exports/action.yml
+++ b/.github/actions/setup-animated-java-exports/action.yml
@@ -13,8 +13,10 @@ runs:
       with:
         key: cache-animated-java-exports-${{ env.BLOCKBENCH_URL }}-${{ env.ANIMATED_JAVA_URL }}-${{ hashFiles('resourcepack/assets/omega-flowey/models/**/*.ajblueprint')}}
         path: |
-          datapacks/animated_java/data
           datapacks/animated_java/data.ajmeta
+          datapacks/animated_java/data/animated_java/function
+          datapacks/animated_java/data/animated_java/tags
+          datapacks/animated_java/data/minecraft
           resourcepack/assets.ajmeta
           resourcepack/assets/animated_java
           resourcepack/assets/minecraft/models/item/white_dye.json
@@ -26,8 +28,10 @@ runs:
       with:
         key: ${{ steps.cache-animated-java-exports.outputs.cache-primary-key }}
         path: |
-          datapacks/animated_java/data
           datapacks/animated_java/data.ajmeta
+          datapacks/animated_java/data/animated_java/function
+          datapacks/animated_java/data/animated_java/tags
+          datapacks/animated_java/data/minecraft
           resourcepack/assets.ajmeta
           resourcepack/assets/animated_java
           resourcepack/assets/minecraft/models/item/white_dye.json

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,10 @@ versions
 
 # auto-ajexport related
 last_exported_hashes.json
-datapacks/animated_java/data
 datapacks/animated_java/data.ajmeta
+datapacks/animated_java/data/animated_java/function
+datapacks/animated_java/data/animated_java/tags
+datapacks/animated_java/data/minecraft
 resourcepack/assets.ajmeta
 resourcepack/assets/animated_java
 resourcepack/assets/minecraft/models/item/white_dye.json

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/act_button.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/act_button.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:act_button/summon { args: {} }
+assert entity @e[tag=aj.act_button.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/bomb.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/bomb.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:bomb/summon { args: {} }
+assert entity @e[tag=aj.bomb.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/dentata_snake_ball.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/dentata_snake_ball.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:dentata_snake_ball/summon { args: {} }
+assert entity @e[tag=aj.dentata_snake_ball.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/finger_gun.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/finger_gun.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:finger_gun/summon { args: {} }
+assert entity @e[tag=aj.finger_gun.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/finger_gun_bullet.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/finger_gun_bullet.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:finger_gun_bullet/summon { args: {} }
+assert entity @e[tag=aj.finger_gun_bullet.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/finger_gun_laser.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/finger_gun_laser.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:finger_gun_laser/summon { args: {} }
+assert entity @e[tag=aj.finger_gun_laser.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/friendliness_pellet.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/friendliness_pellet.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:friendliness_pellet/summon { args: {} }
+assert entity @e[tag=aj.friendliness_pellet.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/friendliness_pellet_ring.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/friendliness_pellet_ring.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:friendliness_pellet_ring/summon { args: {} }
+assert entity @e[tag=aj.friendliness_pellet_ring.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/homing_vine.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/homing_vine.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:homing_vine/summon { args: {} }
+assert entity @e[tag=aj.homing_vine.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/homing_vine_blinking_lane.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/homing_vine_blinking_lane.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:homing_vine_blinking_lane/summon { args: {} }
+assert entity @e[tag=aj.homing_vine_blinking_lane.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/housefly.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/housefly.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:housefly/summon { args: {} }
+assert entity @e[tag=aj.housefly.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/large_side_vine.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/large_side_vine.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:large_side_vine/summon { args: {} }
+assert entity @e[tag=aj.large_side_vine.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/lower_eye.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/lower_eye.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:lower_eye/summon { args: {} }
+assert entity @e[tag=aj.lower_eye.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/mouth.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/mouth.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:mouth/summon { args: {} }
+assert entity @e[tag=aj.mouth.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/nose.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/nose.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:nose/summon { args: {} }
+assert entity @e[tag=aj.nose.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/petal_pipe_circle.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/petal_pipe_circle.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:petal_pipe_circle/summon { args: {} }
+assert entity @e[tag=aj.petal_pipe_circle.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/petal_pipe_middle.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/petal_pipe_middle.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:petal_pipe_middle/summon { args: {} }
+assert entity @e[tag=aj.petal_pipe_middle.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/projectile_star.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/projectile_star.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:projectile_star/summon { args: {} }
+assert entity @e[tag=aj.projectile_star.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/soul.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/soul.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:soul/summon { args: {} }
+assert entity @e[tag=aj.soul.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/soul_0_bandaid.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/soul_0_bandaid.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:soul_0_bandaid/summon { args: {} }
+assert entity @e[tag=aj.soul_0_bandaid.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/soul_0_sword.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/soul_0_sword.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:soul_0_sword/summon { args: {} }
+assert entity @e[tag=aj.soul_0_sword.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/soul_5_bullet.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/soul_5_bullet.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:soul_5_bullet/summon { args: {} }
+assert entity @e[tag=aj.soul_5_bullet.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/soul_5_crosshair.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/soul_5_crosshair.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:soul_5_crosshair/summon { args: {} }
+assert entity @e[tag=aj.soul_5_crosshair.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/soul_5_flower.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/soul_5_flower.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:soul_5_flower/summon { args: {} }
+assert entity @e[tag=aj.soul_5_flower.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/soul_5_gun.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/soul_5_gun.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:soul_5_gun/summon { args: {} }
+assert entity @e[tag=aj.soul_5_gun.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/tv_screen.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/tv_screen.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:tv_screen/summon { args: {} }
+assert entity @e[tag=aj.tv_screen.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/upper_eye.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/upper_eye.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:upper_eye/summon { args: {} }
+assert entity @e[tag=aj.upper_eye.root]

--- a/datapacks/animated_java/data/animated_java/test/ensure_summonable/venus_fly_trap.mcfunction
+++ b/datapacks/animated_java/data/animated_java/test/ensure_summonable/venus_fly_trap.mcfunction
@@ -1,0 +1,4 @@
+# @batch animated_java:ensure_summonable
+
+function animated_java:venus_fly_trap/summon { args: {} }
+assert entity @e[tag=aj.venus_fly_trap.root]


### PR DESCRIPTION
# Summary

This is the first set of tests that rely on https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/ad93d9d2ac2b12601cf4f60af95db283e8f4d5de.

After the CI job runs the auto exporter and generates AJ export files, we can reference them in our unit tests.

These tests perform very basic "can we actually summon and reference the model entity?" checks.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Reproducing

```
test runall
```

## Preview

![image](https://github.com/user-attachments/assets/60864add-cded-431a-98af-d2c8b4be82f0)

![image](https://github.com/user-attachments/assets/3ad0d1fa-c62b-4103-9968-695002daf468)

## Supplemental changes

The tests live under `datapcks/animated_java/data/animated_java/test`, so we had to update `.gitignore` to be more specific as to what files are actually AJ export files.