### PR TITLE
⬆️ 💚 upgrade Blockbench in CICD to `4.11.0-beta.3`

### DIFF
--- a/.github/workflows/datapack.yml
+++ b/.github/workflows/datapack.yml
@@ -4,7 +4,7 @@ on: [push]
 
 env:
   ANIMATED_JAVA_URL: https://github.com/Animated-Java/animated-java/releases/download/v1.3.0/animated_java.js
-  BLOCKBENCH_URL: https://github.com/JannisX11/blockbench/releases/download/v4.11.0-beta.1/Blockbench_4.11.0-beta.1.deb
+  BLOCKBENCH_URL: https://github.com/JannisX11/blockbench/releases/download/v4.11.0-beta.3/Blockbench_4.11.0-beta.3.deb
   FABRIC_API: https://cdn.modrinth.com/data/P7dR8mSH/versions/HXzEJYgV/fabric-api-0.100.1%2B1.21.jar
   FABRIC_SERVER: https://meta.fabricmc.net/v2/versions/loader/1.21/0.15.11/1.0.1/server/jar
   PACKTEST: https://cdn.modrinth.com/data/XsKUhp45/versions/sQSunYHv/packtest-1.8-beta3-mc1.21.jar


### PR DESCRIPTION
# Summary

- we get log changes/errors that block the CICD AJ export process on beta versions since there are new beta versions available.
- quick and easy fix for this is to upgrade to the latest beta release of Blockbench

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Preview

see failing CICD `datapack/test` before. it passes after

