### PR TITLE
🔨 update world sync script to accept arbitrary paths

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -34,6 +34,12 @@ const allAnimatedJavaExportFiles = [
 const allAnimatedJavaExportFilesFormatted =
   allAnimatedJavaExportFiles.join(',');
 
+const floweyWorldSyncPath = './world.zip';
+const minecraftPath = process.env.MINECRAFT_PATH;
+const worldName = process.env.WORLD_NAME;
+const minecraftWorldPath = `${minecraftPath}/saves/${worldName}`;
+const worldSyncArgs = `--backup-path="${floweyWorldSyncPath}" --world-path="${minecraftWorldPath}"`;
+
 module.exports = {
   scripts: {
     default: 'nps watch',
@@ -44,8 +50,8 @@ module.exports = {
       default: 'nps sync.world',
       world: {
         default: 'nps sync.world.up',
-        down: 'node ./package-scripts/sync-world --down',
-        up: 'node ./package-scripts/sync-world --up',
+        down: `node ./package-scripts/sync-world --down ${worldSyncArgs}`,
+        up: `node ./package-scripts/sync-world --up ${worldSyncArgs}"`,
       },
     },
     lint: {

--- a/package-scripts/sync-world.js
+++ b/package-scripts/sync-world.js
@@ -111,8 +111,26 @@ const syncDown = async () => {
   console.log(successMessage);
 };
 
+const validateOptions = (options) => {
+  const { backupPath, worldPath } = options;
+
+  if (typeof backupPath !== 'string') {
+    throw new Error(`Invalid \`backupPath\` arg specified: ${backupPath}`);
+  }
+
+  if (typeof worldPath !== 'string') {
+    throw new Error(`Invalid \`worldPath\` arg specified: ${worldPath}`);
+  }
+};
+
 const main = async () => {
-  const { up, down } = minimist(process.argv.slice(2));
+  const { up, down, ...options } = minimist(process.argv.slice(2), {
+    alias: {
+      'backup-path': 'backupPath',
+      'world-path': 'worldPath',
+    },
+  });
+  validateOptions(options);
 
   if (up) {
     await syncUp();


### PR DESCRIPTION
# Summary

For Smithed Summit, it will be helpful for the sync script to support backing up the schematic world we'll be building on.

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->

---

## Reproducing

```
# backup an arbitrary world to the reop
yarn node ./package-scripts/sync-world --up --world-path="C:\Users\afro\AppData\Roaming\.minecraft\saves\some-world" --backup-path="./world-a.zip"

# test the backup by extracting the backed up world to another save
yarn node ./package-scripts/sync-world --up --world-path="C:\Users\afro\AppData\Roaming\.minecraft\saves\world-sync-test" --backup-path="./world-a.zip"
```

## Preview

N/A
