### PR TITLE
⬆️ upgrade AJ in CICD to `v1.4.2`

### DIFF
--- a/.github/workflows/datapack.yml
+++ b/.github/workflows/datapack.yml
@@ -3,7 +3,7 @@ name: datapack
 on: [push]
 
 env:
-  ANIMATED_JAVA_URL: https://github.com/Animated-Java/animated-java/releases/download/v1.3.0/animated_java.js
+  ANIMATED_JAVA_URL: https://github.com/Animated-Java/animated-java/releases/download/v1.4.2/animated_java.js
   BLOCKBENCH_URL: https://github.com/JannisX11/blockbench/releases/download/v4.11.0-beta.3/Blockbench_4.11.0-beta.3.deb
   FABRIC_API: https://cdn.modrinth.com/data/P7dR8mSH/versions/HXzEJYgV/fabric-api-0.100.1%2B1.21.jar
   FABRIC_SERVER: https://meta.fabricmc.net/v2/versions/loader/1.21/0.15.11/1.0.1/server/jar


### PR DESCRIPTION
# Summary

prior version `1.3.0` had a bug where it wouldn't output variant functions correctly.

see: https://github.com/Animated-Java/animated-java/releases/tag/v1.4.0

<!--
what is the primary purpose of this PR?
- does it address any existing tickets?
- does it add a new model/attack?
-->
