### PR TITLE
✨ add room setup logic and summon `tv-screen` model outside

### DIFF
--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon.mcfunction
@@ -39,7 +39,7 @@ execute positioned 0 37 -13 rotated 0 10 run function animated_java:nose/summon 
 
 ## TV-screen
 execute positioned 0 49 -6 rotated 0 45 run function animated_java:tv_screen/summon { args: {} }
-tag @e[tag=aj.tv_screen.root,tag=!tv_screen.soul,tag=!tv_screen.boss_fight] add tv_screen.boss_fight
+execute as @e[tag=aj.tv_screen.root, tag=tv-screen-new] run function entity:hostile/omega-flowey/summon/tv_screen/initialize
 
 ## Upper eyes
 # Right-eye

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/soul/tv_screen.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/soul/tv_screen.mcfunction
@@ -1,2 +1,2 @@
 execute positioned 0 49 -81 rotated 0 45 run function animated_java:tv_screen/summon { args: {} }
-tag @e[tag=aj.tv_screen.root,tag=!tv_screen.soul,tag=!tv_screen.boss_fight] add tv_screen.soul
+execute as @e[tag=aj.tv_screen.root, tag=tv-screen-new] run function entity:hostile/omega-flowey/summon/soul/tv_screen/initialize

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/soul/tv_screen/initialize.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/soul/tv_screen/initialize.mcfunction
@@ -1,0 +1,2 @@
+tag @s add tv_screen.soul
+tag @s remove tv-screen-new

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/tv_screen/initialize.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/tv_screen/initialize.mcfunction
@@ -1,0 +1,2 @@
+tag @s add tv_screen.boss_fight
+tag @s remove tv-screen-new

--- a/datapacks/omega-flowey/data/omega-flowey/function/setup.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/function/setup.mcfunction
@@ -11,4 +11,6 @@ function omega-flowey:setup/const
 
 function entity:setup
 
+function omega-flowey:summit/room/setup
+
 function utils:log { text_component: '[{"color": "aqua", "text": "Datapack initialized"}]'}

--- a/datapacks/omega-flowey/data/omega-flowey/function/summit/room/setup.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/function/summit/room/setup.mcfunction
@@ -1,0 +1,1 @@
+kill @e[tag=omega-flowey-remastered,tag=decorative]

--- a/datapacks/omega-flowey/data/omega-flowey/function/summit/room/setup.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/function/summit/room/setup.mcfunction
@@ -1,1 +1,3 @@
 kill @e[tag=omega-flowey-remastered,tag=decorative]
+
+function omega-flowey:summit/room/setup/outside

--- a/datapacks/omega-flowey/data/omega-flowey/function/summit/room/setup/outside.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/function/summit/room/setup/outside.mcfunction
@@ -1,0 +1,7 @@
+# Flowey TV screen, smiling
+execute as @e[type=minecraft:item_display, tag=omega-flowey-remastered, tag=aj.tv_screen.root, tag=tv_screen.outside] run \
+  function animated_java:tv_screen/remove/this
+execute positioned -123.47 87.25 33.35 rotated -158.2 12.52 run \
+  function animated_java:tv_screen/summon { args: { animation: 'move', start_animation: true, variant: 'smiling' } }
+execute as @e[type=minecraft:item_display, tag=omega-flowey-remastered, tag=aj.tv_screen.root, tag=tv-screen-new] run \
+  function omega-flowey:summit/room/setup/outside/tv_screen

--- a/datapacks/omega-flowey/data/omega-flowey/function/summit/room/setup/outside/tv_screen.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/function/summit/room/setup/outside/tv_screen.mcfunction
@@ -1,0 +1,2 @@
+tag @s add tv_screen.outside
+tag @s remove tv-screen-new

--- a/datapacks/omega-flowey/data/omega-flowey/function/summit/room/setup/outside/tv_screen.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/function/summit/room/setup/outside/tv_screen.mcfunction
@@ -1,2 +1,4 @@
 tag @s add tv_screen.outside
 tag @s remove tv-screen-new
+
+execute on passengers if entity @s[tag=aj.tv_screen.bone] run data modify entity @s view_range set value 2.5f

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/tv-screen.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/tv-screen.ajblueprint
@@ -24,7 +24,7 @@
 		"texture_folder": "",
 		"enable_advanced_data_pack_settings": false,
 		"data_pack": "G:/Coding/omega-flowey-minecraft-remastered/datapacks/animated_java",
-		"summon_commands": "tag @s add omega-flowey-remastered\ntag @s add omega-flowey\ntag @s add omega-flowey-tv-screen",
+		"summon_commands": "tag @s add omega-flowey-remastered\ntag @s add omega-flowey\ntag @s add omega-flowey-tv-screen\ntag @s add tv-screen-new",
 		"ticking_commands": "",
 		"interpolation_duration": 1,
 		"teleportation_duration": 1,


### PR DESCRIPTION
# Summary

This PR adds functions we can use going forward to store display entity summon commands concretely in the repo, instead of just being entities that live in the binary world zip.

For now, we add summon + initialize commands for the `tv-screen` model that is floating above our Summit booth.

---

## Reproducing in-game

```mcfunction
/reload
# or
/function omega-flowey:setup
# or
/function omega-flowey:summit/room/setup
```

## Preview

||
|-|
|![2024-09-20_22 39 31](https://github.com/user-attachments/assets/1f6ea82b-5198-4307-ba21-5d3c405dbc8a)|

---

## Supplemental changes

- [`0d53b52` (#173)](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/173/commits/0d53b52b90949704eda656f72ab44ffb29386018): ♻️ add `tv-screen-new` tag to tv_screen AJ models
