### PR TITLE
🧑‍💻 add custom Gitmoji icons

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,7 @@
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
     "arcanis.vscode-zipfs",
-    "shardulm94.trailing-spaces"
+    "shardulm94.trailing-spaces",
+    "seatonjiang.gitmoji-vscode"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,11 +1,11 @@
 {
   "recommendations": [
-    "minecraftcommands.syntax-mcfunction",
-    "spgoding.datapack-language-server",
-    "esbenp.prettier-vscode",
-    "dbaeumer.vscode-eslint",
     "arcanis.vscode-zipfs",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "minecraftcommands.syntax-mcfunction",
+    "seatonjiang.gitmoji-vscode",
     "shardulm94.trailing-spaces",
-    "seatonjiang.gitmoji-vscode"
+    "spgoding.datapack-language-server"
   ]
 }

--- a/omega-flowey.code-workspace
+++ b/omega-flowey.code-workspace
@@ -88,6 +88,14 @@
         "semver": null
       },
       {
+        "emoji": "🎲",
+        "entity": "&#x1F3B2;",
+        "code": ":game_die:",
+        "description": "Add/change a feature relating to RNG/randomization",
+        "name": "random",
+        "semver": null
+      },
+      {
         "emoji": "📋",
         "entity": "&#x1F4CB;",
         "code": ":clipboard:",

--- a/omega-flowey.code-workspace
+++ b/omega-flowey.code-workspace
@@ -72,6 +72,14 @@
 
     "gitmoji.addCustomEmoji": [
       {
+        "emoji": "⚔️",
+        "entity": "&#x2694;",
+        "code": ":crossed_swords:",
+        "description": "Add functionality relating to boss-fight attacks",
+        "name": "attack",
+        "semver": null
+      },
+      {
         "emoji": "📋",
         "entity": "&#x1F4CB;",
         "code": ":clipboard:",

--- a/omega-flowey.code-workspace
+++ b/omega-flowey.code-workspace
@@ -80,6 +80,14 @@
         "semver": null
       },
       {
+        "emoji": "👻",
+        "entity": "&#x1F47B;",
+        "code": ":ghost:",
+        "description": "Add functionality relating to soul events",
+        "name": "soul",
+        "semver": null
+      },
+      {
         "emoji": "📋",
         "entity": "&#x1F4CB;",
         "code": ":clipboard:",

--- a/omega-flowey.code-workspace
+++ b/omega-flowey.code-workspace
@@ -70,6 +70,18 @@
       "./versions": true
     },
 
+    "gitmoji.addCustomEmoji": [
+      {
+        "emoji": "📋",
+        "entity": "&#x1F4CB;",
+        "code": ":clipboard:",
+        "description": "Copy-paste files from one directory to another",
+        "name": "copy-paste",
+        "semver": null
+      }
+    ],
+    "gitmoji.showEmojiCode": true,
+
     "terminal.integrated.cwd": "."
   }
 }


### PR DESCRIPTION
# Summary

In the past I've manually found emojis commonly relevant to Flowey development and pasted them in commit titles:
- ⚔️ attacks: https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/18db7dc02a9aa8b3954131464dbeb79aebd39890
- 👻 soul events: https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/ebf866f814f60653b0701cbb20f3321ff84555f0
- 🎲 randomization: [`e737865` (#118)](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/118/commits/e737865e5cfcc1e41b2244a733d391dd592c3a15)
- 📋 copy-pasting files/code: [`825742a` (#175)](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/175/commits/825742a051b4c6983bf86b4661c61a8f706461ad)

turns out we can add these to the [`Gitmoji`](https://github.com/seatonjiang/gitmoji-vscode) VSCode extension and have them show up in the `> Choose Gitmoji` command anyway :)

this is PR a nice QOL improvement for devs

---

## Preview

||
|-|
|![image](https://github.com/user-attachments/assets/b0927b8c-aad9-45f4-81fe-ebd84ddc58a9)|

---

## Supplemental changes

- 7a7533894b884e7dd6338071779863406208ab96: 🧑‍💻 ➕ add `Gitmoji` to recommended extensions
- 8dfc88490650ebcab96d07508620012169648a3d: 🎨 alphabetize recommended extensions