### PR TITLE
🧱 🎥 add Summit boss-fight summon infrastructure

### DIFF
--- a/datapacks/omega-flowey/data/_/function/boss_fight.mcfunction
+++ b/datapacks/omega-flowey/data/_/function/boss_fight.mcfunction
@@ -1,1 +1,1 @@
-function entity:directorial/boss_fight/vanilla/start
+function entity:directorial/boss_fight/summit/start

--- a/datapacks/omega-flowey/data/_/function/boss_fight/stop.mcfunction
+++ b/datapacks/omega-flowey/data/_/function/boss_fight/stop.mcfunction
@@ -1,3 +1,3 @@
-function entity:remove_animated_java_models
+function entity:remove_animated_java_models/boss_fight
 kill @e[tag=boss_fight]
 stopsound @a record

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/initialize.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/initialize.mcfunction
@@ -2,7 +2,7 @@
 
 # Summon Omega Flowey entity if it doesn't exist
 execute unless entity @e[type=minecraft:item_display, tag=aj.tv_screen.root, tag=!tv_screen.outside] \
-  at @e[type=minecraft:marker, tag=omega-flowey-remastered, tag=origin.boss_fight] run \
+  at @e[type=minecraft:marker, tag=omega-flowey-remastered, tag=origin.boss_fight] rotated ~180 ~ run \
   function entity:hostile/omega-flowey/summon/relative
 
 # Set all attack parameters to default

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/initialize.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/initialize.mcfunction
@@ -29,4 +29,4 @@ function entity:hostile/omega-flowey/animate
 tag @s remove boss_fight_new
 
 # Initialize attack phase
-function entity:directorial/boss_fight/vanilla/phase/attack/initialize
+function entity:directorial/boss_fight/summit/phase/attack/initialize

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/initialize.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/initialize.mcfunction
@@ -1,7 +1,9 @@
 ## Initializes the boss fight
 
 # Summon Omega Flowey entity if it doesn't exist
-execute unless entity @e[tag=aj.tv_screen.root] run function entity:hostile/omega-flowey/summon { args: {} }
+execute unless entity @e[type=minecraft:item_display, tag=aj.tv_screen.root] \
+  at @e[type=minecraft:marker, tag=omega-flowey-remastered, tag=origin.boss_fight] run \
+  function entity:hostile/omega-flowey/summon/relative
 
 # Set all attack parameters to default
 function entity:hostile/omega-flowey/attack/reset_scores

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/initialize.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/initialize.mcfunction
@@ -1,0 +1,32 @@
+## Initializes the boss fight
+
+# Summon Omega Flowey entity if it doesn't exist
+execute unless entity @e[tag=aj.tv_screen.root] run function entity:hostile/omega-flowey/summon { args: {} }
+
+# Set all attack parameters to default
+function entity:hostile/omega-flowey/attack/reset_scores
+
+# Set scores
+scoreboard players set @s boss-fight.attack.delay -1
+scoreboard players set @s boss-fight.attack.phase.i 0
+scoreboard players set @s boss-fight.attack.phase.total 6
+scoreboard players set @s boss-fight.progress.phase.i 0
+scoreboard players set @s boss-fight.progress.phase.total 6
+
+# Flags that represent whether a soul event has been completed or not.
+# Used to determine what animation / variant to use for petal pipe models (default / disabled)
+scoreboard players set #boss-fight.soul_0.complete boss-fight.flag 0
+scoreboard players set #boss-fight.soul_1.complete boss-fight.flag 0
+scoreboard players set #boss-fight.soul_2.complete boss-fight.flag 0
+scoreboard players set #boss-fight.soul_3.complete boss-fight.flag 0
+scoreboard players set #boss-fight.soul_4.complete boss-fight.flag 0
+scoreboard players set #boss-fight.soul_5.complete boss-fight.flag 0
+
+# Begin animating Omega Flowey entity
+function entity:hostile/omega-flowey/animate
+
+# Remove tag
+tag @s remove boss_fight_new
+
+# Initialize attack phase
+function entity:directorial/boss_fight/vanilla/phase/attack/initialize

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/initialize.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/initialize.mcfunction
@@ -1,7 +1,7 @@
 ## Initializes the boss fight
 
 # Summon Omega Flowey entity if it doesn't exist
-execute unless entity @e[type=minecraft:item_display, tag=aj.tv_screen.root] \
+execute unless entity @e[type=minecraft:item_display, tag=aj.tv_screen.root, tag=!tv_screen.outside] \
   at @e[type=minecraft:marker, tag=omega-flowey-remastered, tag=origin.boss_fight] run \
   function entity:hostile/omega-flowey/summon/relative
 

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/loop.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/loop.mcfunction
@@ -1,0 +1,9 @@
+## Runs every tick off entities tagged `boss_fight_vanilla`
+
+# Run loop logic based on what phase the boss_fight is in
+execute if entity @s[tag=boss_fight.phase.attack] run function entity:directorial/boss_fight/vanilla/phase/attack/loop
+execute if entity @s[tag=boss_fight.phase.soul] run function entity:directorial/boss_fight/vanilla/phase/soul/loop
+execute if entity @s[tag=boss_fight.phase.warn] run function entity:directorial/boss_fight/vanilla/phase/warn/loop
+
+# Run music-loop logic
+execute if entity @s[tag=is_looping_music] run function entity:directorial/boss_fight/music/loop

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/loop.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/loop.mcfunction
@@ -1,9 +1,9 @@
-## Runs every tick off entities tagged `boss_fight_vanilla`
+## Runs every tick off entities tagged `boss_fight_summit`
 
 # Run loop logic based on what phase the boss_fight is in
-execute if entity @s[tag=boss_fight.phase.attack] run function entity:directorial/boss_fight/vanilla/phase/attack/loop
-execute if entity @s[tag=boss_fight.phase.soul] run function entity:directorial/boss_fight/vanilla/phase/soul/loop
-execute if entity @s[tag=boss_fight.phase.warn] run function entity:directorial/boss_fight/vanilla/phase/warn/loop
+execute if entity @s[tag=boss_fight.phase.attack] run function entity:directorial/boss_fight/summit/phase/attack/loop
+execute if entity @s[tag=boss_fight.phase.soul] run function entity:directorial/boss_fight/summit/phase/soul/loop
+execute if entity @s[tag=boss_fight.phase.warn] run function entity:directorial/boss_fight/summit/phase/warn/loop
 
 # Run music-loop logic
 execute if entity @s[tag=is_looping_music] run function entity:directorial/boss_fight/music/loop

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/initialize.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/initialize.mcfunction
@@ -1,8 +1,8 @@
 # Split on phase score
-execute if score @s boss-fight.attack.phase.i matches 0 run function entity:directorial/boss_fight/vanilla/phase/attack/initialize/0
-execute if score @s boss-fight.attack.phase.i matches 1 run function entity:directorial/boss_fight/vanilla/phase/attack/initialize/1
-execute if score @s boss-fight.attack.phase.i matches 2 run function entity:directorial/boss_fight/vanilla/phase/attack/initialize/2
-execute if score @s boss-fight.attack.phase.i matches 4 run function entity:directorial/boss_fight/vanilla/phase/attack/initialize/4
+execute if score @s boss-fight.attack.phase.i matches 0 run function entity:directorial/boss_fight/summit/phase/attack/initialize/0
+execute if score @s boss-fight.attack.phase.i matches 1 run function entity:directorial/boss_fight/summit/phase/attack/initialize/1
+execute if score @s boss-fight.attack.phase.i matches 2 run function entity:directorial/boss_fight/summit/phase/attack/initialize/2
+execute if score @s boss-fight.attack.phase.i matches 4 run function entity:directorial/boss_fight/summit/phase/attack/initialize/4
 
 # Set scores
 scoreboard players set @s boss-fight.attack.clock.i -1

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/initialize.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/initialize.mcfunction
@@ -1,0 +1,14 @@
+# Split on phase score
+execute if score @s boss-fight.attack.phase.i matches 0 run function entity:directorial/boss_fight/vanilla/phase/attack/initialize/0
+execute if score @s boss-fight.attack.phase.i matches 1 run function entity:directorial/boss_fight/vanilla/phase/attack/initialize/1
+execute if score @s boss-fight.attack.phase.i matches 2 run function entity:directorial/boss_fight/vanilla/phase/attack/initialize/2
+execute if score @s boss-fight.attack.phase.i matches 4 run function entity:directorial/boss_fight/vanilla/phase/attack/initialize/4
+
+# Set scores
+scoreboard players set @s boss-fight.attack.clock.i -1
+
+# Add tags
+tag @s add boss_fight.phase.attack
+
+# Remove tv_screen.soul model(s) if they exist
+execute as @e[tag=aj.tv_screen.root,tag=tv_screen.soul] run function animated_java:tv_screen/remove/this

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/initialize/0.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/initialize/0.mcfunction
@@ -1,0 +1,10 @@
+## Set scores
+# Length of music (up to the WARNING sound)
+scoreboard players set @s boss-fight.attack.clock.total 463
+
+# Play music
+playsound omega-flowey:music.phase.0 record @a ~ ~ ~ 10 1
+
+## Add tags
+# Use logic to decrease chance of repeating attacks during `attack/random`
+tag @s add attack.random.consider_previous_trials

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/initialize/1.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/initialize/1.mcfunction
@@ -1,0 +1,10 @@
+## Set scores
+# Length of music (up to the WARNING sound)
+scoreboard players set @s boss-fight.attack.clock.total 414
+
+# Play music
+playsound omega-flowey:music.phase.1 record @a ~ ~ ~ 10 1
+
+## Add tags
+# Use logic to decrease chance of repeating attacks during `attack/random`
+tag @s add attack.random.consider_previous_trials

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/initialize/2.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/initialize/2.mcfunction
@@ -1,0 +1,8 @@
+## Set scores
+# Length of phase (up to the WARNING sound)
+scoreboard players set @s boss-fight.attack.clock.total 320
+# delay before starting first attack
+scoreboard players set @s boss-fight.attack.delay 7
+
+# Setup music-repeating infrastructure
+function entity:directorial/boss_fight/music/initialize/boss_fight_vanilla_attack_phase_repeat_0

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/initialize/2.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/initialize/2.mcfunction
@@ -5,4 +5,4 @@ scoreboard players set @s boss-fight.attack.clock.total 320
 scoreboard players set @s boss-fight.attack.delay 7
 
 # Setup music-repeating infrastructure
-function entity:directorial/boss_fight/music/initialize/boss_fight_vanilla_attack_phase_repeat_0
+function entity:directorial/boss_fight/music/initialize/boss_fight_summit_attack_phase_repeat_0

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/initialize/4.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/initialize/4.mcfunction
@@ -1,0 +1,2 @@
+# same as attack phase 2's initialization
+function entity:directorial/boss_fight/vanilla/phase/attack/initialize/2

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/initialize/4.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/initialize/4.mcfunction
@@ -1,2 +1,2 @@
 # same as attack phase 2's initialization
-function entity:directorial/boss_fight/vanilla/phase/attack/initialize/2
+function entity:directorial/boss_fight/summit/phase/attack/initialize/2

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/loop.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/loop.mcfunction
@@ -1,0 +1,11 @@
+scoreboard players add @s boss-fight.attack.clock.i 1
+
+# Decrement attack.delay
+execute if score @s boss-fight.attack.delay matches 0.. run scoreboard players remove @s boss-fight.attack.delay 1
+execute if score @s boss-fight.attack.delay matches 0.. run return 0
+
+# Start new attack after delay
+execute unless entity @s[tag=boss_fight.is_attacking] run function entity:directorial/boss_fight/vanilla/phase/attack/loop/next_attack
+
+# Terminate
+execute if score @s boss-fight.attack.clock.i >= @s boss-fight.attack.clock.total run function entity:directorial/boss_fight/vanilla/phase/attack/terminate

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/loop.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/loop.mcfunction
@@ -5,7 +5,7 @@ execute if score @s boss-fight.attack.delay matches 0.. run scoreboard players r
 execute if score @s boss-fight.attack.delay matches 0.. run return 0
 
 # Start new attack after delay
-execute unless entity @s[tag=boss_fight.is_attacking] run function entity:directorial/boss_fight/vanilla/phase/attack/loop/next_attack
+execute unless entity @s[tag=boss_fight.is_attacking] run function entity:directorial/boss_fight/summit/phase/attack/loop/next_attack
 
 # Terminate
-execute if score @s boss-fight.attack.clock.i >= @s boss-fight.attack.clock.total run function entity:directorial/boss_fight/vanilla/phase/attack/terminate
+execute if score @s boss-fight.attack.clock.i >= @s boss-fight.attack.clock.total run function entity:directorial/boss_fight/summit/phase/attack/terminate

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/loop/next_attack.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/loop/next_attack.mcfunction
@@ -1,8 +1,8 @@
 # Split on phase score
-execute if score @s boss-fight.attack.phase.i matches 0 run function entity:directorial/boss_fight/vanilla/phase/attack/loop/next_attack/0
-execute if score @s boss-fight.attack.phase.i matches 1 run function entity:directorial/boss_fight/vanilla/phase/attack/loop/next_attack/1
-execute if score @s boss-fight.attack.phase.i matches 2 run function entity:directorial/boss_fight/vanilla/phase/attack/loop/next_attack/2
-execute if score @s boss-fight.attack.phase.i matches 4 run function entity:directorial/boss_fight/vanilla/phase/attack/loop/next_attack/4
+execute if score @s boss-fight.attack.phase.i matches 0 run function entity:directorial/boss_fight/summit/phase/attack/loop/next_attack/0
+execute if score @s boss-fight.attack.phase.i matches 1 run function entity:directorial/boss_fight/summit/phase/attack/loop/next_attack/1
+execute if score @s boss-fight.attack.phase.i matches 2 run function entity:directorial/boss_fight/summit/phase/attack/loop/next_attack/2
+execute if score @s boss-fight.attack.phase.i matches 4 run function entity:directorial/boss_fight/summit/phase/attack/loop/next_attack/4
 
 # Add tag
 tag @s add boss_fight.is_attacking

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/loop/next_attack.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/loop/next_attack.mcfunction
@@ -1,0 +1,8 @@
+# Split on phase score
+execute if score @s boss-fight.attack.phase.i matches 0 run function entity:directorial/boss_fight/vanilla/phase/attack/loop/next_attack/0
+execute if score @s boss-fight.attack.phase.i matches 1 run function entity:directorial/boss_fight/vanilla/phase/attack/loop/next_attack/1
+execute if score @s boss-fight.attack.phase.i matches 2 run function entity:directorial/boss_fight/vanilla/phase/attack/loop/next_attack/2
+execute if score @s boss-fight.attack.phase.i matches 4 run function entity:directorial/boss_fight/vanilla/phase/attack/loop/next_attack/4
+
+# Add tag
+tag @s add boss_fight.is_attacking

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/loop/next_attack/0.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/loop/next_attack/0.mcfunction
@@ -1,0 +1,1 @@
+function entity:hostile/omega-flowey/attack/random/attack_phase/0

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/loop/next_attack/1.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/loop/next_attack/1.mcfunction
@@ -1,0 +1,1 @@
+function entity:hostile/omega-flowey/attack/random/attack_phase/1

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/loop/next_attack/2.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/loop/next_attack/2.mcfunction
@@ -1,0 +1,1 @@
+function entity:hostile/omega-flowey/attack/random/attack_phase/2

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/loop/next_attack/4.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/loop/next_attack/4.mcfunction
@@ -1,0 +1,1 @@
+function entity:hostile/omega-flowey/attack/random/attack_phase/4

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/terminate.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/terminate.mcfunction
@@ -1,0 +1,12 @@
+# Increment attack phase
+scoreboard players add @s boss-fight.attack.phase.i 1
+# Wrap around total phases (6)
+scoreboard players operation @s boss-fight.attack.phase.i %= @s boss-fight.attack.phase.total
+
+# Next phase
+function entity:directorial/boss_fight/vanilla/phase/warn/initialize
+
+# Remove tags
+tag @s remove attack.random.consider_previous_trials
+function entity:hostile/omega-flowey/attack/random/remove_previous_tags
+tag @s remove boss_fight.phase.attack

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/terminate.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/attack/terminate.mcfunction
@@ -4,7 +4,7 @@ scoreboard players add @s boss-fight.attack.phase.i 1
 scoreboard players operation @s boss-fight.attack.phase.i %= @s boss-fight.attack.phase.total
 
 # Next phase
-function entity:directorial/boss_fight/vanilla/phase/warn/initialize
+function entity:directorial/boss_fight/summit/phase/warn/initialize
 
 # Remove tags
 tag @s remove attack.random.consider_previous_trials

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/initialize.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/initialize.mcfunction
@@ -1,0 +1,20 @@
+# Split on phase score
+execute if score @s boss-fight.progress.phase.i matches 0 run function entity:directorial/boss_fight/vanilla/phase/soul/initialize/0
+
+## Set scores
+# the negative time duration is how long the static length lasts (25 ticks)
+scoreboard players set @s boss-fight.progress.clock.i -26
+scoreboard players set @s boss-fight.progress.clock.total 27
+
+function entity:directorial/boss_fight/vanilla/phase/soul/static
+
+# Move players to soul arena
+execute as @a at @s unless entity @s[team=!player,team=!spectator] run teleport @s ~ ~ ~-75.0
+
+# Add tags
+tag @s add boss_fight.phase.soul
+
+# Delete main flowey models for performance reasons
+function entity:hostile/omega-flowey/summon/remove_preexisting_models/except_tv_screen
+execute as @e[tag=aj.soul.root,tag=soul.warning] run function animated_java:soul/remove/this
+execute as @e[tag=aj.tv_screen.root,tag=tv_screen.boss_fight] run function animated_java:tv_screen/remove/this

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/initialize.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/initialize.mcfunction
@@ -1,12 +1,12 @@
 # Split on phase score
-execute if score @s boss-fight.progress.phase.i matches 0 run function entity:directorial/boss_fight/vanilla/phase/soul/initialize/0
+execute if score @s boss-fight.progress.phase.i matches 0 run function entity:directorial/boss_fight/summit/phase/soul/initialize/0
 
 ## Set scores
 # the negative time duration is how long the static length lasts (25 ticks)
 scoreboard players set @s boss-fight.progress.clock.i -26
 scoreboard players set @s boss-fight.progress.clock.total 27
 
-function entity:directorial/boss_fight/vanilla/phase/soul/static
+function entity:directorial/boss_fight/summit/phase/soul/static
 
 # Move players to soul arena
 execute as @a at @s unless entity @s[team=!player,team=!spectator] run teleport @s ~ ~ ~-75.0

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop.mcfunction
@@ -1,4 +1,4 @@
 # we check the score's larger range first because we could otherwise unintentionally
 # run both loop functions in one tick if `pre_static` incremented the score from -1 -> 0
-execute if score @s boss-fight.progress.clock.i matches 0.. run function entity:directorial/boss_fight/vanilla/phase/soul/loop/post_static
-execute if score @s boss-fight.progress.clock.i matches ..-1 run function entity:directorial/boss_fight/vanilla/phase/soul/loop/pre_static
+execute if score @s boss-fight.progress.clock.i matches 0.. run function entity:directorial/boss_fight/summit/phase/soul/loop/post_static
+execute if score @s boss-fight.progress.clock.i matches ..-1 run function entity:directorial/boss_fight/summit/phase/soul/loop/pre_static

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop.mcfunction
@@ -1,0 +1,4 @@
+# we check the score's larger range first because we could otherwise unintentionally
+# run both loop functions in one tick if `pre_static` incremented the score from -1 -> 0
+execute if score @s boss-fight.progress.clock.i matches 0.. run function entity:directorial/boss_fight/vanilla/phase/soul/loop/post_static
+execute if score @s boss-fight.progress.clock.i matches ..-1 run function entity:directorial/boss_fight/vanilla/phase/soul/loop/pre_static

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/event_finished.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/event_finished.mcfunction
@@ -1,6 +1,6 @@
 tag @s remove has_active_soul_event
 
-function entity:directorial/boss_fight/vanilla/phase/soul/static
+function entity:directorial/boss_fight/summit/phase/soul/static
 
 # Delete floating soul model
 execute as @e[tag=aj.soul.root,tag=soul.soul_event] run function animated_java:soul/remove/this

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/event_finished.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/event_finished.mcfunction
@@ -1,0 +1,6 @@
+tag @s remove has_active_soul_event
+
+function entity:directorial/boss_fight/vanilla/phase/soul/static
+
+# Delete floating soul model
+execute as @e[tag=aj.soul.root,tag=soul.soul_event] run function animated_java:soul/remove/this

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/next_event.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/next_event.mcfunction
@@ -1,6 +1,6 @@
 # Split on phase score
-execute if score @s boss-fight.progress.phase.i matches 0 run function entity:directorial/boss_fight/vanilla/phase/soul/loop/next_event/0
-execute if score @s boss-fight.progress.phase.i matches 5 run function entity:directorial/boss_fight/vanilla/phase/soul/loop/next_event/5
+execute if score @s boss-fight.progress.phase.i matches 0 run function entity:directorial/boss_fight/summit/phase/soul/loop/next_event/0
+execute if score @s boss-fight.progress.phase.i matches 5 run function entity:directorial/boss_fight/summit/phase/soul/loop/next_event/5
 
 # Change tv screen variant
 execute as @e[tag=aj.tv_screen.root,tag=tv_screen.soul] run function animated_java:tv_screen/variants/default/apply

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/next_event.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/next_event.mcfunction
@@ -1,0 +1,11 @@
+# Split on phase score
+execute if score @s boss-fight.progress.phase.i matches 0 run function entity:directorial/boss_fight/vanilla/phase/soul/loop/next_event/0
+execute if score @s boss-fight.progress.phase.i matches 5 run function entity:directorial/boss_fight/vanilla/phase/soul/loop/next_event/5
+
+# Change tv screen variant
+execute as @e[tag=aj.tv_screen.root,tag=tv_screen.soul] run function animated_java:tv_screen/variants/default/apply
+
+# Summon and begin animating soul heart model in front of soul screen
+execute store result storage animate:soul soul_index int 1 run scoreboard players get @s boss-fight.progress.phase.i
+function entity:hostile/omega-flowey/summon/soul/soul with storage animate:soul
+execute as @e[tag=aj.soul.root,tag=soul.soul_event] run function entity:hostile/omega-flowey/animate/soul/soul

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/next_event/0.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/next_event/0.mcfunction
@@ -1,0 +1,1 @@
+function entity:soul/soul_0/start

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/next_event/5.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/next_event/5.mcfunction
@@ -1,0 +1,1 @@
+function entity:soul/soul_5/start

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/post_static.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/post_static.mcfunction
@@ -3,4 +3,4 @@ execute if entity @s[tag=has_active_soul_event] run return 0
 
 scoreboard players add @s boss-fight.progress.clock.i 1
 
-execute if score @s boss-fight.progress.clock.i = @s boss-fight.progress.clock.total run function entity:directorial/boss_fight/vanilla/phase/soul/terminate
+execute if score @s boss-fight.progress.clock.i = @s boss-fight.progress.clock.total run function entity:directorial/boss_fight/summit/phase/soul/terminate

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/post_static.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/post_static.mcfunction
@@ -1,0 +1,6 @@
+# wait until the soul event finishes before continuing the boss_fight's loop
+execute if entity @s[tag=has_active_soul_event] run return 0
+
+scoreboard players add @s boss-fight.progress.clock.i 1
+
+execute if score @s boss-fight.progress.clock.i = @s boss-fight.progress.clock.total run function entity:directorial/boss_fight/vanilla/phase/soul/terminate

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/pre_static.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/pre_static.mcfunction
@@ -1,0 +1,8 @@
+## Initial TV screen static, before the soul event starts
+scoreboard players add @s boss-fight.progress.clock.i 1
+
+# Start new soul event at clock index 0
+execute if score @s boss-fight.progress.clock.i matches 0 run function entity:directorial/boss_fight/vanilla/phase/soul/loop/next_event
+
+# Add tags
+tag @s add has_active_soul_event

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/pre_static.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/pre_static.mcfunction
@@ -2,7 +2,7 @@
 scoreboard players add @s boss-fight.progress.clock.i 1
 
 # Start new soul event at clock index 0
-execute if score @s boss-fight.progress.clock.i matches 0 run function entity:directorial/boss_fight/vanilla/phase/soul/loop/next_event
+execute if score @s boss-fight.progress.clock.i matches 0 run function entity:directorial/boss_fight/summit/phase/soul/loop/next_event
 
 # Add tags
 tag @s add has_active_soul_event

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/saved.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/saved.mcfunction
@@ -1,0 +1,6 @@
+# Mark this soul phase as being completed
+execute store result storage boss_fight:animate soul_index int 1 run scoreboard players get @s boss-fight.progress.phase.i
+function entity:directorial/boss_fight/vanilla/phase/soul/loop/saved/macro with storage boss_fight:animate
+
+# Increment progress phase
+scoreboard players add @s boss-fight.progress.phase.i 1

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/saved.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/saved.mcfunction
@@ -1,6 +1,6 @@
 # Mark this soul phase as being completed
 execute store result storage boss_fight:animate soul_index int 1 run scoreboard players get @s boss-fight.progress.phase.i
-function entity:directorial/boss_fight/vanilla/phase/soul/loop/saved/macro with storage boss_fight:animate
+function entity:directorial/boss_fight/summit/phase/soul/loop/saved/macro with storage boss_fight:animate
 
 # Increment progress phase
 scoreboard players add @s boss-fight.progress.phase.i 1

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/saved/macro.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/loop/saved/macro.mcfunction
@@ -1,0 +1,1 @@
+$scoreboard players set #boss-fight.soul_$(soul_index).complete boss-fight.flag 1

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/static.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/static.mcfunction
@@ -1,1 +1,1 @@
-execute as @e[tag=aj.tv_screen.root,tag=tv_screen.soul] at @s run function entity:directorial/boss_fight/vanilla/phase/soul/static/as_root
+execute as @e[tag=aj.tv_screen.root,tag=tv_screen.soul] at @s run function entity:directorial/boss_fight/summit/phase/soul/static/as_root

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/static.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/static.mcfunction
@@ -1,0 +1,1 @@
+execute as @e[tag=aj.tv_screen.root,tag=tv_screen.soul] at @s run function entity:directorial/boss_fight/vanilla/phase/soul/static/as_root

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/static/as_root.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/static/as_root.mcfunction
@@ -1,0 +1,4 @@
+# Play static sound
+playsound omega-flowey:boss-fight.static ambient @a ~ ~ ~ 10
+
+function animated_java:tv_screen/variants/static/apply

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/terminate.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/terminate.mcfunction
@@ -2,7 +2,7 @@
 tag @s remove boss_fight.phase.soul
 
 # Next phase
-function entity:directorial/boss_fight/vanilla/phase/attack/initialize
+function entity:directorial/boss_fight/summit/phase/attack/initialize
 
 # Move players to main arena
 execute as @a at @s unless entity @s[team=!player,team=!spectator] run teleport @s ~ ~ ~75.0

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/terminate.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/terminate.mcfunction
@@ -1,0 +1,12 @@
+# Remove tags
+tag @s remove boss_fight.phase.soul
+
+# Next phase
+function entity:directorial/boss_fight/vanilla/phase/attack/initialize
+
+# Move players to main arena
+execute as @a at @s unless entity @s[team=!player,team=!spectator] run teleport @s ~ ~ ~75.0
+
+# Re-summon main Omega Flowey models
+function entity:hostile/omega-flowey/summon
+function entity:hostile/omega-flowey/animate

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/warn/initialize.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/warn/initialize.mcfunction
@@ -1,0 +1,9 @@
+## Set scores
+# Length of the WARNING sound
+scoreboard players set @s boss-fight.warn.clock.total 101
+# Delay before WARNING sound starts playing/animating
+# (2s of grace period where we stop starting attacks, but dont display WARNING yet)
+scoreboard players set @s boss-fight.warn.clock.i -41
+
+# Add tags
+tag @s add boss_fight.phase.warn

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/warn/initialize/after_delay.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/warn/initialize/after_delay.mcfunction
@@ -1,0 +1,25 @@
+# Play WARNING sound
+execute at @e[tag=aj.tv_screen.root,tag=tv_screen.boss_fight] run playsound omega-flowey:boss-fight.alarm ambient @a ~ ~ ~ 10 1
+
+# Set tv screen to WARNING variant
+execute as @e[tag=aj.tv_screen.root,tag=tv_screen.boss_fight] run function entity:hostile/omega-flowey/animate/warning/tv_screen
+
+execute store result storage animate:soul soul_index int 1 run scoreboard players get @s boss-fight.progress.phase.i
+
+# Set applicable petal-pipe to soul-color variant
+function entity:hostile/omega-flowey/animate/pipe with storage animate:soul
+
+# Summon and begin animating soul heart model in front of WARNING screen
+function entity:hostile/omega-flowey/summon/warning/soul with storage animate:soul
+execute as @e[tag=aj.soul.root,tag=soul.warning] run function entity:hostile/omega-flowey/animate/warning/soul
+
+# Summon and begin animating soul tv_screen in other arena
+function entity:hostile/omega-flowey/summon/soul/tv_screen
+execute as @e[tag=aj.tv_screen.root,tag=tv_screen.soul] run function entity:hostile/omega-flowey/animate/soul/tv_screen
+
+# Terminate music-looping logic if it was running
+execute if entity @s[tag=is_looping_music] run function entity:directorial/boss_fight/music/terminate with entity @s data.looped_music
+
+# Play end-note at end of phases 2 and 4 (index score will be +1, so 3 and 5)
+execute if score @s boss-fight.attack.phase.i matches 3 run playsound omega-flowey:music.phase.repeat.end-note record @a ~ ~ ~ 10 1
+execute if score @s boss-fight.attack.phase.i matches 5 run playsound omega-flowey:music.phase.repeat.end-note record @a ~ ~ ~ 10 1

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/warn/loop.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/warn/loop.mcfunction
@@ -1,0 +1,7 @@
+scoreboard players add @s boss-fight.warn.clock.i 1
+
+# Begin WARNING animation at clock index 0
+execute if score @s boss-fight.warn.clock.i matches 0 run function entity:directorial/boss_fight/vanilla/phase/warn/initialize/after_delay
+
+# Terminate
+execute if score @s boss-fight.warn.clock.i >= @s boss-fight.warn.clock.total run function entity:directorial/boss_fight/vanilla/phase/warn/terminate

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/warn/loop.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/warn/loop.mcfunction
@@ -1,7 +1,7 @@
 scoreboard players add @s boss-fight.warn.clock.i 1
 
 # Begin WARNING animation at clock index 0
-execute if score @s boss-fight.warn.clock.i matches 0 run function entity:directorial/boss_fight/vanilla/phase/warn/initialize/after_delay
+execute if score @s boss-fight.warn.clock.i matches 0 run function entity:directorial/boss_fight/summit/phase/warn/initialize/after_delay
 
 # Terminate
-execute if score @s boss-fight.warn.clock.i >= @s boss-fight.warn.clock.total run function entity:directorial/boss_fight/vanilla/phase/warn/terminate
+execute if score @s boss-fight.warn.clock.i >= @s boss-fight.warn.clock.total run function entity:directorial/boss_fight/summit/phase/warn/terminate

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/warn/terminate.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/warn/terminate.mcfunction
@@ -1,0 +1,5 @@
+# Remove tags
+tag @s remove boss_fight.phase.warn
+
+# Next phase
+function entity:directorial/boss_fight/vanilla/phase/soul/initialize

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/warn/terminate.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/warn/terminate.mcfunction
@@ -2,4 +2,4 @@
 tag @s remove boss_fight.phase.warn
 
 # Next phase
-function entity:directorial/boss_fight/vanilla/phase/soul/initialize
+function entity:directorial/boss_fight/summit/phase/soul/initialize

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/start.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/start.mcfunction
@@ -4,5 +4,5 @@
 kill @e[tag=boss_fight]
 
 # Summon and initialize boss fight director
-summon minecraft:marker 0 33 0 { CustomName:'"Vanilla Boss Fight Director"', Tags:["omega-flowey-remastered","directorial","boss_fight","boss_fight_new","boss_fight_vanilla"] }
-execute as @e[tag=boss_fight_new] at @s run function entity:directorial/boss_fight/vanilla/initialize
+summon minecraft:marker 0 33 0 { CustomName:'"Summit Boss Fight Director"', Tags:["omega-flowey-remastered","directorial","boss_fight","boss_fight_new","boss_fight_summit"] }
+execute as @e[tag=boss_fight_new] at @s run function entity:directorial/boss_fight/summit/initialize

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/start.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/start.mcfunction
@@ -1,8 +1,18 @@
-## Summons the boss fight marker and initializes it
+## Summon and initialize the boss fight marker
 
 # Kill any pre-existing boss fights
-kill @e[tag=boss_fight]
+kill @e[type=minecraft:marker, tag=omega-flowey-remastered, tag=directorial, tag=boss_fight]
 
 # Summon and initialize boss fight director
-summon minecraft:marker 0 33 0 { CustomName:'"Summit Boss Fight Director"', Tags:["omega-flowey-remastered","directorial","boss_fight","boss_fight_new","boss_fight_summit"] }
+execute at @e[type=minecraft:marker, tag=omega-flowey-remastered, tag=origin.boss_fight] run \
+  summon minecraft:marker ~ ~ ~ { \
+    CustomName:'"Omega-Flowey Boss-fight Director"', \
+    Tags: [ \
+      "omega-flowey-remastered", \
+      "directorial", \
+      "boss_fight", \
+      "boss_fight_new", \
+      "boss_fight.", \
+    ] \
+  }
 execute as @e[tag=boss_fight_new] at @s run function entity:directorial/boss_fight/summit/initialize

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/start.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/start.mcfunction
@@ -3,6 +3,26 @@
 # Kill any pre-existing boss fights
 kill @e[type=minecraft:marker, tag=omega-flowey-remastered, tag=directorial, tag=boss_fight]
 
+# Assert boss fight origin exists
+scoreboard players set #omega-flowey.flag math.const 0
+execute if entity @e[type=minecraft:marker, tag=omega-flowey-remastered, tag=origin.boss_fight] run scoreboard players set #omega-flowey.flag math.const 1
+execute unless score #omega-flowey.flag math.const matches 1 run \
+  function utils:error { error: ' \
+    [ \
+      { \
+        "text": "", \
+        "color": "yellow", \
+        "extra": \
+          [ \
+            "Cannot start boss-fight: ", \
+            { "text": "origin marker ", "color": "aqua" }, \
+            "does not exist" \
+          ] \
+      } \
+    ]' \
+  }
+execute unless score #omega-flowey.flag math.const matches 1 run return 1
+
 # Summon and initialize boss fight director
 execute at @e[type=minecraft:marker, tag=omega-flowey-remastered, tag=origin.boss_fight] run \
   summon minecraft:marker ~ ~ ~ { \

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/start.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/start.mcfunction
@@ -1,0 +1,8 @@
+## Summons the boss fight marker and initializes it
+
+# Kill any pre-existing boss fights
+kill @e[tag=boss_fight]
+
+# Summon and initialize boss fight director
+summon minecraft:marker 0 33 0 { CustomName:'"Vanilla Boss Fight Director"', Tags:["omega-flowey-remastered","directorial","boss_fight","boss_fight_new","boss_fight_vanilla"] }
+execute as @e[tag=boss_fight_new] at @s run function entity:directorial/boss_fight/vanilla/initialize

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/animate.mcfunction
@@ -4,5 +4,5 @@ execute as @e[tag=aj.large_side_vine.root] run function entity:hostile/omega-flo
 execute as @e[tag=aj.lower_eye.root] run function animated_java:lower_eye/animations/look_around/play
 execute as @e[tag=aj.petal_pipe_circle.root] run function entity:hostile/omega-flowey/animate/petal_pipe_circle
 execute as @e[tag=aj.petal_pipe_middle.root] run function entity:hostile/omega-flowey/animate/petal_pipe_middle
-execute as @e[tag=aj.tv_screen.root] run function entity:hostile/omega-flowey/animate/tv-screen/default
+execute as @e[tag=aj.tv_screen.root,tag=tv_screen.boss_fight] run function entity:hostile/omega-flowey/animate/tv-screen/default
 execute as @e[tag=aj.upper_eye.root] run function animated_java:upper_eye/animations/look_around/play

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/relative.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/relative.mcfunction
@@ -2,56 +2,56 @@ function entity:hostile/omega-flowey/summon/remove_preexisting_models
 
 ## Large side vines
 # Right large side vine
-execute positioned -24.5 40.0 -8.5 rotated 135 -10 run function animated_java:large_side_vine/summon { args: {} }
+execute positioned ~-24.5 ~3.5 ~4.5 rotated ~135 ~-10 run function animated_java:large_side_vine/summon { args: {} }
 tag @e[tag=aj.large_side_vine.root] add large_side_vine.right
 # Left large side vine
-execute positioned 27.5 40.0 -8.5 rotated 215 -10 run function animated_java:large_side_vine/summon { args: {} }
+execute positioned ~27.5 ~3.5 ~4.5 rotated ~215 ~-10 run function animated_java:large_side_vine/summon { args: {} }
 tag @e[tag=aj.large_side_vine.root,tag=!large_side_vine.right] add large_side_vine.left
 
 ## Lower eyes
 # Right-eye
-execute positioned -4.5 42.0 -6.5 rotated 170 -20 run function animated_java:lower_eye/summon { args: {} }
+execute positioned ~-4.5 ~5.5 ~6.5 rotated ~170 ~-20 run function animated_java:lower_eye/summon { args: {} }
 # Left-eye
-execute positioned 5.5 42.0 -6.5 rotated 10 20 run function animated_java:lower_eye/summon { args: {} }
+execute positioned ~5.5 ~5.5 ~6.5 rotated ~10 ~20 run function animated_java:lower_eye/summon { args: {} }
 
 ## Lower petal pipes
 # Right-lower petal pipe
-execute positioned -10.5 44.0 -12.5 rotated -10 20 run function animated_java:petal_pipe_circle/summon { args: {} }
+execute positioned ~-10.5 ~7.5 ~ rotated ~-10 ~20 run function animated_java:petal_pipe_circle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_circle.root] add petal_pipe.right
 # Left-lower petal pipe
-execute positioned 11.5 44.0 -12.5 rotated -170 -20 run function animated_java:petal_pipe_circle/summon { args: {} }
+execute positioned ~11.5 ~7.5 ~ rotated ~-170 ~-20 run function animated_java:petal_pipe_circle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe.right] add petal_pipe.left
 tag @e[tag=aj.petal_pipe_circle.root] add petal_pipe_lower
 
 ## Middle petal pipes
 # Right-middle petal pipe
-execute positioned -13.5 48.0 -6.5 rotated -20 40 run function animated_java:petal_pipe_middle/summon { args: {} }
+execute positioned ~-13.5 ~11.5 ~6.5 rotated ~-20 ~40 run function animated_java:petal_pipe_middle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_middle.root] add petal_pipe.right
 # Left-middle petal pipe
-execute positioned 14.5 48.0 -6.5 rotated -160 -40 run function animated_java:petal_pipe_middle/summon { args: {} }
+execute positioned ~14.5 ~11.5 ~6.5 rotated ~-160 ~-40 run function animated_java:petal_pipe_middle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_middle.root,tag=!petal_pipe.right] add petal_pipe.left
 
 ## Mouth
-execute positioned 0.5 35.5 -3.15 rotated 0 9 run function animated_java:mouth/summon { args: {} }
+execute positioned ~ ~-1.5 ~9.35 rotated ~ ~9 run function animated_java:mouth/summon { args: {} }
 
 ## Nose
-execute positioned 0.5 37.0 -12.5 rotated 0 10 run function animated_java:nose/summon { args: {} }
+execute positioned ~ ~ ~ rotated ~ ~10 run function animated_java:nose/summon { args: {} }
 
 ## TV-screen
-execute positioned 0.5 49.0 -5.5 rotated 0 45 run function animated_java:tv_screen/summon { args: {} }
+execute positioned ~ ~12.5 ~7.5 rotated ~ ~45 run function animated_java:tv_screen/summon { args: {} }
 execute as @e[tag=aj.tv_screen.root, tag=tv-screen-new] run function entity:hostile/omega-flowey/summon/tv_screen/initialize
 
 ## Upper eyes
 # Right-eye
-execute positioned -15.5 48.0 -3.5 rotated 160 -40 run function animated_java:upper_eye/summon { args: {} }
+execute positioned ~-15.5 ~11.5 ~9.5 rotated ~160 ~-40 run function animated_java:upper_eye/summon { args: {} }
 # Left-eye
-execute positioned 16.5 48.0 -3.5 rotated 20 40 run function animated_java:upper_eye/summon { args: {} }
+execute positioned ~16.5 ~11.5 ~9.5 rotated ~20 ~40 run function animated_java:upper_eye/summon { args: {} }
 
 ## Upper petal pipes
 # Right-upper petal pipe
-execute positioned -10.5 63.0 4.5 rotated -10 45 run function animated_java:petal_pipe_circle/summon { args: {} }
+execute positioned ~-10.5 ~26.5 ~17.5 rotated ~-10 ~45 run function animated_java:petal_pipe_circle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe_lower] add petal_pipe.right
 # Left-upper petal pipe
-execute positioned 11.5 63.0 4.5 rotated -170 -45 run function animated_java:petal_pipe_circle/summon { args: {} }
+execute positioned ~11.5 ~26.5 ~17.5 rotated ~-170 ~-45 run function animated_java:petal_pipe_circle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe_lower,tag=!petal_pipe.right] add petal_pipe.left
 tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe_lower] add petal_pipe_upper

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/relative.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/relative.mcfunction
@@ -1,0 +1,57 @@
+function entity:hostile/omega-flowey/summon/remove_preexisting_models
+
+## Large side vines
+# Right large side vine
+execute positioned -25 40 -9 rotated 135 -10 run function animated_java:large_side_vine/summon { args: {} }
+tag @e[tag=aj.large_side_vine.root] add large_side_vine.right
+# Left large side vine
+execute positioned 27 40 -9 rotated 215 -10 run function animated_java:large_side_vine/summon { args: {} }
+tag @e[tag=aj.large_side_vine.root,tag=!large_side_vine.right] add large_side_vine.left
+
+## Lower eyes
+# Right-eye
+execute positioned -5 42 -7 rotated 170 -20 run function animated_java:lower_eye/summon { args: {} }
+# Left-eye
+execute positioned 5 42 -7 rotated 10 20 run function animated_java:lower_eye/summon { args: {} }
+
+## Lower petal pipes
+# Right-lower petal pipe
+execute positioned -11 44 -12.5 rotated -10 20 run function animated_java:petal_pipe_circle/summon { args: {} }
+tag @e[tag=aj.petal_pipe_circle.root] add petal_pipe.right
+# Left-lower petal pipe
+execute positioned 11 44 -12.5 rotated -170 -20 run function animated_java:petal_pipe_circle/summon { args: {} }
+tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe.right] add petal_pipe.left
+tag @e[tag=aj.petal_pipe_circle.root] add petal_pipe_lower
+
+## Middle petal pipes
+# Right-middle petal pipe
+execute positioned -14 48 -6.5 rotated -20 40 run function animated_java:petal_pipe_middle/summon { args: {} }
+tag @e[tag=aj.petal_pipe_middle.root] add petal_pipe.right
+# Left-middle petal pipe
+execute positioned 14 48 -6.5 rotated -160 -40 run function animated_java:petal_pipe_middle/summon { args: {} }
+tag @e[tag=aj.petal_pipe_middle.root,tag=!petal_pipe.right] add petal_pipe.left
+
+## Mouth
+execute positioned 0 35.5 -3.15 rotated 0 9 run function animated_java:mouth/summon { args: {} }
+
+## Nose
+execute positioned 0 37 -13 rotated 0 10 run function animated_java:nose/summon { args: {} }
+
+## TV-screen
+execute positioned 0 49 -6 rotated 0 45 run function animated_java:tv_screen/summon { args: {} }
+execute as @e[tag=aj.tv_screen.root, tag=tv-screen-new] run function entity:hostile/omega-flowey/summon/tv_screen/initialize
+
+## Upper eyes
+# Right-eye
+execute positioned -15.5 48 -4 rotated 160 -40 run function animated_java:upper_eye/summon { args: {} }
+# Left-eye
+execute positioned 16.5 48 -4 rotated 20 40 run function animated_java:upper_eye/summon { args: {} }
+
+## Upper petal pipes
+# Right-upper petal pipe
+execute positioned -11 63 4 rotated -10 45 run function animated_java:petal_pipe_circle/summon { args: {} }
+tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe_lower] add petal_pipe.right
+# Left-upper petal pipe
+execute positioned 11 63 4 rotated -170 -45 run function animated_java:petal_pipe_circle/summon { args: {} }
+tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe_lower,tag=!petal_pipe.right] add petal_pipe.left
+tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe_lower] add petal_pipe_upper

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/relative.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/relative.mcfunction
@@ -2,56 +2,56 @@ function entity:hostile/omega-flowey/summon/remove_preexisting_models
 
 ## Large side vines
 # Right large side vine
-execute positioned -25 40 -9 rotated 135 -10 run function animated_java:large_side_vine/summon { args: {} }
+execute positioned -24.5 40.0 -8.5 rotated 135 -10 run function animated_java:large_side_vine/summon { args: {} }
 tag @e[tag=aj.large_side_vine.root] add large_side_vine.right
 # Left large side vine
-execute positioned 27 40 -9 rotated 215 -10 run function animated_java:large_side_vine/summon { args: {} }
+execute positioned 27.5 40.0 -8.5 rotated 215 -10 run function animated_java:large_side_vine/summon { args: {} }
 tag @e[tag=aj.large_side_vine.root,tag=!large_side_vine.right] add large_side_vine.left
 
 ## Lower eyes
 # Right-eye
-execute positioned -5 42 -7 rotated 170 -20 run function animated_java:lower_eye/summon { args: {} }
+execute positioned -4.5 42.0 -6.5 rotated 170 -20 run function animated_java:lower_eye/summon { args: {} }
 # Left-eye
-execute positioned 5 42 -7 rotated 10 20 run function animated_java:lower_eye/summon { args: {} }
+execute positioned 5.5 42.0 -6.5 rotated 10 20 run function animated_java:lower_eye/summon { args: {} }
 
 ## Lower petal pipes
 # Right-lower petal pipe
-execute positioned -11 44 -12.5 rotated -10 20 run function animated_java:petal_pipe_circle/summon { args: {} }
+execute positioned -10.5 44.0 -12.5 rotated -10 20 run function animated_java:petal_pipe_circle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_circle.root] add petal_pipe.right
 # Left-lower petal pipe
-execute positioned 11 44 -12.5 rotated -170 -20 run function animated_java:petal_pipe_circle/summon { args: {} }
+execute positioned 11.5 44.0 -12.5 rotated -170 -20 run function animated_java:petal_pipe_circle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe.right] add petal_pipe.left
 tag @e[tag=aj.petal_pipe_circle.root] add petal_pipe_lower
 
 ## Middle petal pipes
 # Right-middle petal pipe
-execute positioned -14 48 -6.5 rotated -20 40 run function animated_java:petal_pipe_middle/summon { args: {} }
+execute positioned -13.5 48.0 -6.5 rotated -20 40 run function animated_java:petal_pipe_middle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_middle.root] add petal_pipe.right
 # Left-middle petal pipe
-execute positioned 14 48 -6.5 rotated -160 -40 run function animated_java:petal_pipe_middle/summon { args: {} }
+execute positioned 14.5 48.0 -6.5 rotated -160 -40 run function animated_java:petal_pipe_middle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_middle.root,tag=!petal_pipe.right] add petal_pipe.left
 
 ## Mouth
-execute positioned 0 35.5 -3.15 rotated 0 9 run function animated_java:mouth/summon { args: {} }
+execute positioned 0.5 35.5 -3.15 rotated 0 9 run function animated_java:mouth/summon { args: {} }
 
 ## Nose
-execute positioned 0 37 -13 rotated 0 10 run function animated_java:nose/summon { args: {} }
+execute positioned 0.5 37.0 -12.5 rotated 0 10 run function animated_java:nose/summon { args: {} }
 
 ## TV-screen
-execute positioned 0 49 -6 rotated 0 45 run function animated_java:tv_screen/summon { args: {} }
+execute positioned 0.5 49.0 -5.5 rotated 0 45 run function animated_java:tv_screen/summon { args: {} }
 execute as @e[tag=aj.tv_screen.root, tag=tv-screen-new] run function entity:hostile/omega-flowey/summon/tv_screen/initialize
 
 ## Upper eyes
 # Right-eye
-execute positioned -15.5 48 -4 rotated 160 -40 run function animated_java:upper_eye/summon { args: {} }
+execute positioned -15.5 48.0 -3.5 rotated 160 -40 run function animated_java:upper_eye/summon { args: {} }
 # Left-eye
-execute positioned 16.5 48 -4 rotated 20 40 run function animated_java:upper_eye/summon { args: {} }
+execute positioned 16.5 48.0 -3.5 rotated 20 40 run function animated_java:upper_eye/summon { args: {} }
 
 ## Upper petal pipes
 # Right-upper petal pipe
-execute positioned -11 63 4 rotated -10 45 run function animated_java:petal_pipe_circle/summon { args: {} }
+execute positioned -10.5 63.0 4.5 rotated -10 45 run function animated_java:petal_pipe_circle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe_lower] add petal_pipe.right
 # Left-upper petal pipe
-execute positioned 11 63 4 rotated -170 -45 run function animated_java:petal_pipe_circle/summon { args: {} }
+execute positioned 11.5 63.0 4.5 rotated -170 -45 run function animated_java:petal_pipe_circle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe_lower,tag=!petal_pipe.right] add petal_pipe.left
 tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe_lower] add petal_pipe_upper

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/relative.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/relative.mcfunction
@@ -2,56 +2,56 @@ function entity:hostile/omega-flowey/summon/remove_preexisting_models
 
 ## Large side vines
 # Right large side vine
-execute positioned ~-24.5 ~3.5 ~4.5 rotated ~135 ~-10 run function animated_java:large_side_vine/summon { args: {} }
+execute positioned ^-24.5 ^3.5 ^4.5 rotated ~135 ~-10 run function animated_java:large_side_vine/summon { args: {} }
 tag @e[tag=aj.large_side_vine.root] add large_side_vine.right
 # Left large side vine
-execute positioned ~27.5 ~3.5 ~4.5 rotated ~215 ~-10 run function animated_java:large_side_vine/summon { args: {} }
+execute positioned ^27.5 ^3.5 ^4.5 rotated ~215 ~-10 run function animated_java:large_side_vine/summon { args: {} }
 tag @e[tag=aj.large_side_vine.root,tag=!large_side_vine.right] add large_side_vine.left
 
 ## Lower eyes
 # Right-eye
-execute positioned ~-4.5 ~5.5 ~6.5 rotated ~170 ~-20 run function animated_java:lower_eye/summon { args: {} }
+execute positioned ^-4.5 ^5.5 ^6.5 rotated ~170 ~-20 run function animated_java:lower_eye/summon { args: {} }
 # Left-eye
-execute positioned ~5.5 ~5.5 ~6.5 rotated ~10 ~20 run function animated_java:lower_eye/summon { args: {} }
+execute positioned ^5.5 ^5.5 ^6.5 rotated ~10 ~20 run function animated_java:lower_eye/summon { args: {} }
 
 ## Lower petal pipes
 # Right-lower petal pipe
-execute positioned ~-10.5 ~7.5 ~ rotated ~-10 ~20 run function animated_java:petal_pipe_circle/summon { args: {} }
+execute positioned ^-10.5 ^7.5 ^ rotated ~-10 ~20 run function animated_java:petal_pipe_circle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_circle.root] add petal_pipe.right
 # Left-lower petal pipe
-execute positioned ~11.5 ~7.5 ~ rotated ~-170 ~-20 run function animated_java:petal_pipe_circle/summon { args: {} }
+execute positioned ^11.5 ^7.5 ^ rotated ~-170 ~-20 run function animated_java:petal_pipe_circle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe.right] add petal_pipe.left
 tag @e[tag=aj.petal_pipe_circle.root] add petal_pipe_lower
 
 ## Middle petal pipes
 # Right-middle petal pipe
-execute positioned ~-13.5 ~11.5 ~6.5 rotated ~-20 ~40 run function animated_java:petal_pipe_middle/summon { args: {} }
+execute positioned ^-13.5 ^11.5 ^6.5 rotated ~-20 ~40 run function animated_java:petal_pipe_middle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_middle.root] add petal_pipe.right
 # Left-middle petal pipe
-execute positioned ~14.5 ~11.5 ~6.5 rotated ~-160 ~-40 run function animated_java:petal_pipe_middle/summon { args: {} }
+execute positioned ^14.5 ^11.5 ^6.5 rotated ~-160 ~-40 run function animated_java:petal_pipe_middle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_middle.root,tag=!petal_pipe.right] add petal_pipe.left
 
 ## Mouth
-execute positioned ~ ~-1.5 ~9.35 rotated ~ ~9 run function animated_java:mouth/summon { args: {} }
+execute positioned ^ ^-1.5 ^9.35 rotated ~ ~9 run function animated_java:mouth/summon { args: {} }
 
 ## Nose
-execute positioned ~ ~ ~ rotated ~ ~10 run function animated_java:nose/summon { args: {} }
+execute positioned ^ ^ ^ rotated ~ ~10 run function animated_java:nose/summon { args: {} }
 
 ## TV-screen
-execute positioned ~ ~12.5 ~7.5 rotated ~ ~45 run function animated_java:tv_screen/summon { args: {} }
+execute positioned ^ ^12.5 ^7.5 rotated ~ ~45 run function animated_java:tv_screen/summon { args: {} }
 execute as @e[tag=aj.tv_screen.root, tag=tv-screen-new] run function entity:hostile/omega-flowey/summon/tv_screen/initialize
 
 ## Upper eyes
 # Right-eye
-execute positioned ~-15.5 ~11.5 ~9.5 rotated ~160 ~-40 run function animated_java:upper_eye/summon { args: {} }
+execute positioned ^-15.5 ^11.5 ^9.5 rotated ~160 ~-40 run function animated_java:upper_eye/summon { args: {} }
 # Left-eye
-execute positioned ~16.5 ~11.5 ~9.5 rotated ~20 ~40 run function animated_java:upper_eye/summon { args: {} }
+execute positioned ^16.5 ^11.5 ^9.5 rotated ~20 ~40 run function animated_java:upper_eye/summon { args: {} }
 
 ## Upper petal pipes
 # Right-upper petal pipe
-execute positioned ~-10.5 ~26.5 ~17.5 rotated ~-10 ~45 run function animated_java:petal_pipe_circle/summon { args: {} }
+execute positioned ^-10.5 ^26.5 ^17.5 rotated ~-10 ~45 run function animated_java:petal_pipe_circle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe_lower] add petal_pipe.right
 # Left-upper petal pipe
-execute positioned ~11.5 ~26.5 ~17.5 rotated ~-170 ~-45 run function animated_java:petal_pipe_circle/summon { args: {} }
+execute positioned ^11.5 ^26.5 ^17.5 rotated ~-170 ~-45 run function animated_java:petal_pipe_circle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe_lower,tag=!petal_pipe.right] add petal_pipe.left
 tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe_lower] add petal_pipe_upper

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/remove_preexisting_models.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/remove_preexisting_models.mcfunction
@@ -1,2 +1,2 @@
 function entity:hostile/omega-flowey/summon/remove_preexisting_models/except_tv_screen
-function animated_java:tv_screen/remove/all
+execute as @e[type=minecraft:item_display, tag=aj.tv_screen.root, tag=!tv_screen.outside] run function animated_java:tv_screen/remove/this

--- a/datapacks/omega-flowey/data/entity/function/remove_animated_java_models.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/remove_animated_java_models.mcfunction
@@ -1,25 +1,2 @@
-# Omega Flowey model
-function entity:hostile/omega-flowey/summon/remove_preexisting_models
-
-# Attack models
-function animated_java:bomb/remove/all
-function animated_java:dentata_snake_ball/remove/all
-function animated_java:finger_gun/remove/all
-function animated_java:finger_gun_bullet/remove/all
-function animated_java:finger_gun_laser/remove/all
-function animated_java:friendliness_pellet/remove/all
-function animated_java:friendliness_pellet_ring/remove/all
-function animated_java:homing_vine/remove/all
-function animated_java:homing_vine_blinking_lane/remove/all
-function animated_java:housefly/remove/all
-function animated_java:projectile_star/remove/all
-function animated_java:venus_fly_trap/remove/all
-
-# Soul models
-function animated_java:act_button/remove/all
-function animated_java:soul/remove/all
-function animated_java:soul_0_bandaid/remove/all
-function animated_java:soul_0_sword/remove/all
-
-# Summit models
-function animated_java:summit_petal_pipe_right/remove/all
+function entity:remove_animated_java_models/boss_fight
+function entity:remove_animated_java_models/summit

--- a/datapacks/omega-flowey/data/entity/function/remove_animated_java_models/boss_fight.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/remove_animated_java_models/boss_fight.mcfunction
@@ -20,3 +20,7 @@ function animated_java:act_button/remove/all
 function animated_java:soul/remove/all
 function animated_java:soul_0_bandaid/remove/all
 function animated_java:soul_0_sword/remove/all
+function animated_java:soul_5_bullet/remove/all
+function animated_java:soul_5_crosshair/remove/all
+function animated_java:soul_5_flower/remove/all
+function animated_java:soul_5_gun/remove/all

--- a/datapacks/omega-flowey/data/entity/function/remove_animated_java_models/boss_fight.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/remove_animated_java_models/boss_fight.mcfunction
@@ -1,0 +1,22 @@
+# Omega Flowey model
+function entity:hostile/omega-flowey/summon/remove_preexisting_models
+
+# Attack models
+function animated_java:bomb/remove/all
+function animated_java:dentata_snake_ball/remove/all
+function animated_java:finger_gun/remove/all
+function animated_java:finger_gun_bullet/remove/all
+function animated_java:finger_gun_laser/remove/all
+function animated_java:friendliness_pellet/remove/all
+function animated_java:friendliness_pellet_ring/remove/all
+function animated_java:homing_vine/remove/all
+function animated_java:homing_vine_blinking_lane/remove/all
+function animated_java:housefly/remove/all
+function animated_java:projectile_star/remove/all
+function animated_java:venus_fly_trap/remove/all
+
+# Soul models
+function animated_java:act_button/remove/all
+function animated_java:soul/remove/all
+function animated_java:soul_0_bandaid/remove/all
+function animated_java:soul_0_sword/remove/all

--- a/datapacks/omega-flowey/data/entity/function/remove_animated_java_models/summit.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/remove_animated_java_models/summit.mcfunction
@@ -1,0 +1,3 @@
+# Summit models
+function animated_java:summit_petal_pipe_right/remove/all
+execute as @e[type=minecraft:item_display, tag=aj.tv_screen.root, tag=tv_screen.outside] run function animated_java:tv_screen/remove/this

--- a/datapacks/omega-flowey/data/omega-flowey/function/summit/room/setup.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/function/summit/room/setup.mcfunction
@@ -1,3 +1,13 @@
 kill @e[tag=omega-flowey-remastered,tag=decorative]
 
 function omega-flowey:summit/room/setup/outside
+
+kill @e[type=minecraft:marker, tag=omega-flowey-remastered, tag=origin]
+summon minecraft:marker -178 67 62 { \
+  CustomName:'"Omega-Flowey Boss-fight Origin"', \
+  Tags: [ \
+    "omega-flowey-remastered", \
+    "origin", \
+    "origin.boss_fight", \
+  ] \
+}

--- a/omega-flowey.code-workspace
+++ b/omega-flowey.code-workspace
@@ -110,6 +110,14 @@
         "description": "Copy-paste files from one directory to another",
         "name": "copy-paste",
         "semver": null
+      },
+      {
+        "emoji": "🧮",
+        "entity": "&#x1F9EE;",
+        "code": ":abacus:",
+        "description": "Perform some math calculations",
+        "name": "math",
+        "semver": null
       }
     ],
     "gitmoji.showEmojiCode": true,

--- a/omega-flowey.code-workspace
+++ b/omega-flowey.code-workspace
@@ -118,6 +118,14 @@
         "description": "Perform some math calculations",
         "name": "math",
         "semver": null
+      },
+      {
+        "emoji": "📍",
+        "entity": "&#x1F4CD;",
+        "code": ":round_pushpin:",
+        "description": "Change the position/rotation of some entity(s)",
+        "name": "location",
+        "semver": null
       }
     ],
     "gitmoji.showEmojiCode": true,

--- a/omega-flowey.code-workspace
+++ b/omega-flowey.code-workspace
@@ -88,6 +88,14 @@
         "semver": null
       },
       {
+        "emoji": "🎥",
+        "entity": "&#x1F3A5;",
+        "code": ":movie_camera:",
+        "description": "Add functionality relating to director entities or cutscenes",
+        "name": "director",
+        "semver": null
+      },
+      {
         "emoji": "🎲",
         "entity": "&#x1F3B2;",
         "code": ":game_die:",


### PR DESCRIPTION
# Summary

This PR adds code and does some refactoring to support a new variant of the boss-fight, `summit` (non-vanilla), so we can easily summon the boss-fight at an arbitrary location and rotation. Namely, we:

- add an `origin` entity pattern to use as the "origin" of some entity (e.g. summon the Flowey model relative to the origin's position and rotation)
- add a relative-coordinate version of the `omega-flowey/summon` command for use with `origin` entities

---

## Reproducing
```mcfunction
function _:boss_fight
```

## Preview

||
|-|
|![preview-summoning](https://github.com/user-attachments/assets/149fd400-5bf7-4ce6-b518-e4b0a198921b)|

---

## Supplemental changes

- [`f22996a` (#177)](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/177/commits/f22996ac9ff66fe79ee9e7293d2ee7763078a2cb): 🧑‍💻 add director 🎥 emoji 
- [`b4deafc` (#177)](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/177/commits/b4deafcf5e5121364e379bb80834fd1839619422): 🧑‍💻 add math 🧮 emoji 
- [`ef1f1da` (#177)](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/177/commits/ef1f1da4092ae8f05949ade7a73b79fcbda82937): 🧑‍💻 add entity location 📍 emoji 
- [`c2f6260` (#177)](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/177/commits/c2f62603276edca9b0307ac68585c0787996174b): 🐛 add missing boss-fight models to remove function 