### PR TITLE
🐛 💫 update `nose/move` animation step frames

### DIFF
--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/nose.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/nose.ajblueprint
@@ -1084,6 +1084,11 @@
 							"channel": "scale",
 							"data_points": [
 								{
+									"x": 1,
+									"y": 1,
+									"z": 1
+								},
+								{
 									"x": 0.9,
 									"y": "1.075",
 									"z": "1"
@@ -1093,13 +1098,18 @@
 							"time": 0.2,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "step",
+							"interpolation": "linear",
 							"easing": "linear",
 							"easingArgs": []
 						},
 						{
 							"channel": "scale",
 							"data_points": [
+								{
+									"x": 0.9,
+									"y": "1.075",
+									"z": "1"
+								},
 								{
 									"x": 1,
 									"y": 1,
@@ -1110,13 +1120,18 @@
 							"time": 0,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "step",
+							"interpolation": "linear",
 							"easing": "linear",
 							"easingArgs": []
 						},
 						{
 							"channel": "scale",
 							"data_points": [
+								{
+									"x": 0.9,
+									"y": "1.075",
+									"z": "1"
+								},
 								{
 									"x": 1,
 									"y": 1,
@@ -1127,13 +1142,18 @@
 							"time": 0.4,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "step",
+							"interpolation": "linear",
 							"easing": "linear",
 							"easingArgs": []
 						},
 						{
 							"channel": "scale",
 							"data_points": [
+								{
+									"x": 1,
+									"y": 1,
+									"z": 1
+								},
 								{
 									"x": 0.9,
 									"y": "1.075",
@@ -1144,24 +1164,7 @@
 							"time": 0.6,
 							"color": -1,
 							"uniform": false,
-							"interpolation": "step",
-							"easing": "linear",
-							"easingArgs": []
-						},
-						{
-							"channel": "scale",
-							"data_points": [
-								{
-									"x": 1,
-									"y": 1,
-									"z": 1
-								}
-							],
-							"uuid": "5f86ba49-8eeb-bb0d-4836-112e0ced860b",
-							"time": 0.8,
-							"color": -1,
-							"uniform": true,
-							"interpolation": "step",
+							"interpolation": "linear",
 							"easing": "linear",
 							"easingArgs": []
 						},
@@ -1172,13 +1175,18 @@
 									"x": 0.9,
 									"y": "1.075",
 									"z": "1"
+								},
+								{
+									"x": 1,
+									"y": 1,
+									"z": 1
 								}
 							],
-							"uuid": "414951f0-6f72-f94d-31fc-13fe0aa677db",
-							"time": 1,
+							"uuid": "5f86ba49-8eeb-bb0d-4836-112e0ced860b",
+							"time": 0.8,
 							"color": -1,
-							"uniform": false,
-							"interpolation": "step",
+							"uniform": true,
+							"interpolation": "linear",
 							"easing": "linear",
 							"easingArgs": []
 						},
@@ -1189,13 +1197,40 @@
 									"x": 1,
 									"y": 1,
 									"z": 1
+								},
+								{
+									"x": 0.9,
+									"y": "1.075",
+									"z": "1"
+								}
+							],
+							"uuid": "414951f0-6f72-f94d-31fc-13fe0aa677db",
+							"time": 1,
+							"color": -1,
+							"uniform": false,
+							"interpolation": "linear",
+							"easing": "linear",
+							"easingArgs": []
+						},
+						{
+							"channel": "scale",
+							"data_points": [
+								{
+									"x": 0.9,
+									"y": "1.075",
+									"z": "1"
+								},
+								{
+									"x": 1,
+									"y": 1,
+									"z": 1
 								}
 							],
 							"uuid": "6d19f8d3-d243-9f94-8846-a9ed53d83c1d",
 							"time": 1.2,
 							"color": -1,
 							"uniform": true,
-							"interpolation": "step",
+							"interpolation": "linear",
 							"easing": "linear",
 							"easingArgs": []
 						}


### PR DESCRIPTION
# Summary

- AJ v1.4.1 included a fix that made pre/post keyframes work properly
- this made me realize the step frames in `nose/move` was causing the animation to look bad/janky
- changing from `step` to `linear` and properly configuring the pre/post keyframes gives us a  nostril animation that looks better than before (likely close to what we originally intended in the animation)

---

## Reproducing in-game

```mcfunction
function _:boss_fight
```

## Preview

| before (post AJ v1.4.1) | after (fixed) |
|-|-|
|![before - bug](https://github.com/user-attachments/assets/177525eb-0b61-4f8c-a2d7-db1cd39f833d)|![after](https://github.com/user-attachments/assets/9baa594a-7e15-4607-bb5f-872d7c78211d)|

| before (pre AJ v1.4.1) | Undertale |
|-|-|
|![](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/assets/13565346/17568587-be97-483b-8b80-51148213d1b1)|<img width=300 src="https://user-images.githubusercontent.com/13565346/269501365-21a947ca-c6d3-4375-9681-8316784cb282.gif" /> |