### PR TITLE
📍 ⚔️ update phase 0 attack coordinates for Summit world

### DIFF
--- a/.github/actions/setup-animated-java-exports/install-animated-java-and-run-auto-exporter.sh
+++ b/.github/actions/setup-animated-java-exports/install-animated-java-and-run-auto-exporter.sh
@@ -20,7 +20,7 @@ Xvfb $DISPLAY &
 echo Start Blockbench and wait until initialized
 # Use the export script to pass-in the CLI args automatically, the same way we do when we run
 # `yarn start export` locally (for reproducability)
-yarn start "export.run --enable-logging" &> blockbench.log & tail -f -n1 blockbench.log | grep -qe "Update for version"
+yarn start "export.run --enable-logging" &> blockbench.log & tail -f -n1 blockbench.log | grep -qe "Update for version" -e "downloadedFile: '/home/runner/"
 
 echo Open dev tools and show console
 xdotool key ctrl+shift+i

--- a/datapacks/omega-flowey/data/_/function/summon.mcfunction
+++ b/datapacks/omega-flowey/data/_/function/summon.mcfunction
@@ -1,2 +1,4 @@
-function entity:hostile/omega-flowey/summon
+function entity:hostile/omega-flowey/summon/remove_preexisting_models
+execute at @e[type=minecraft:marker, tag=omega-flowey-remastered, tag=origin.boss_fight] rotated ~180 ~ run \
+  function entity:hostile/omega-flowey/summon/relative
 function entity:hostile/omega-flowey/animate

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/start.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/start.mcfunction
@@ -32,7 +32,7 @@ execute at @e[type=minecraft:marker, tag=omega-flowey-remastered, tag=origin.bos
       "directorial", \
       "boss_fight", \
       "boss_fight_new", \
-      "boss_fight.", \
+      "boss_fight.summit", \
     ] \
   }
 execute as @e[tag=boss_fight_new] at @s run function entity:directorial/boss_fight/summit/initialize

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/tick.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/tick.mcfunction
@@ -1,1 +1,2 @@
+execute if entity @s[tag=boss_fight.summit] run function entity:directorial/boss_fight/summit/loop
 execute if entity @s[tag=boss_fight_vanilla] run function entity:directorial/boss_fight/vanilla/loop

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/friendliness-pellets/executor/loop/summon_indicator.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/friendliness-pellets/executor/loop/summon_indicator.mcfunction
@@ -1,7 +1,8 @@
 ## summons an indicator at a player
 
 # Summon indicator
-execute at @r[team=player] run summon minecraft:marker ~ 33.0 ~ {CustomName: '"Friendliness-Pellets Indicator"', Tags:["omega-flowey-remastered","groupable","hostile","omega-flowey","attack","attack-indicator","attack-indicator-new","friendliness-pellets"], Passengers: [{id:"minecraft:item_display",Tags:["omega-flowey-remastered","hostile","omega-flowey","attack","friendliness-pellets"],transformation:[-1f,0f,1.2246467991473532e-16f,0f,0f,1f,0f,-0.125f,-1.2246467991473532e-16f,0f,-1f,0f,0f,0f,0f,1f],interpolation_duration:1,item_display:"head",item:{id:"minecraft:golden_sword",Count:1b,tag:{CustomModelData:4}}}]}
+# NOTE: this is -4 blocks from origin's Y coordinate
+execute at @r[team=player] run summon minecraft:marker ~ 63.0 ~ {CustomName: '"Friendliness-Pellets Indicator"', Tags:["omega-flowey-remastered","groupable","hostile","omega-flowey","attack","attack-indicator","attack-indicator-new","friendliness-pellets"], Passengers: [{id:"minecraft:item_display",Tags:["omega-flowey-remastered","hostile","omega-flowey","attack","friendliness-pellets"],transformation:[-1f,0f,1.2246467991473532e-16f,0f,0f,1f,0f,-0.125f,-1.2246467991473532e-16f,0f,-1f,0f,0f,0f,0f,1f],interpolation_duration:1,item_display:"head",item:{id:"minecraft:golden_sword",Count:1b,tag:{CustomModelData:4}}}]}
 
 # TODO(43): this is so unbelievably hacky
 # first indicator is 6 ticks slower before it starts summoning bullets

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/friendliness-pellets/executor/loop/summon_indicator.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/friendliness-pellets/executor/loop/summon_indicator.mcfunction
@@ -14,21 +14,6 @@ execute at @r[team=player] run summon minecraft:marker ~ 63.0 ~ { \
     "attack-indicator-new", \
     "friendliness-pellets" \
   ], \
-  Passengers: [ \
-    {\
-      id: "minecraft:item_display",\
-      Tags: [ "omega-flowey-remastered", "hostile", "omega-flowey", "attack", "friendliness-pellets" ], \
-      transformation: [ \
-        -1f, 0f, 1.2246467991473532e-16f, 0f, \
-        0f,1f,0f,-0.125f, \
-        -1.2246467991473532e-16f,0f,-1f,0f, \
-        0f,0f,0f,1f \
-      ], \
-      interpolation_duration: 1, \
-      item_display: "head", \
-      item: { id:"minecraft:golden_sword", Count:1b, tag: { CustomModelData:4 } } \
-    } \
-  ] \
 }
 
 # TODO(43): this is so unbelievably hacky

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/friendliness-pellets/executor/loop/summon_indicator.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/friendliness-pellets/executor/loop/summon_indicator.mcfunction
@@ -2,7 +2,34 @@
 
 # Summon indicator
 # NOTE: this is -4 blocks from origin's Y coordinate
-execute at @r[team=player] run summon minecraft:marker ~ 63.0 ~ {CustomName: '"Friendliness-Pellets Indicator"', Tags:["omega-flowey-remastered","groupable","hostile","omega-flowey","attack","attack-indicator","attack-indicator-new","friendliness-pellets"], Passengers: [{id:"minecraft:item_display",Tags:["omega-flowey-remastered","hostile","omega-flowey","attack","friendliness-pellets"],transformation:[-1f,0f,1.2246467991473532e-16f,0f,0f,1f,0f,-0.125f,-1.2246467991473532e-16f,0f,-1f,0f,0f,0f,0f,1f],interpolation_duration:1,item_display:"head",item:{id:"minecraft:golden_sword",Count:1b,tag:{CustomModelData:4}}}]}
+execute at @r[team=player] run summon minecraft:marker ~ 63.0 ~ { \
+  CustomName: '"Friendliness-Pellets Indicator"', \
+  Tags: [ \
+    "omega-flowey-remastered", \
+    "groupable", \
+    "hostile", \
+    "omega-flowey", \
+    "attack", \
+    "attack-indicator", \
+    "attack-indicator-new", \
+    "friendliness-pellets" \
+  ], \
+  Passengers: [ \
+    {\
+      id: "minecraft:item_display",\
+      Tags: [ "omega-flowey-remastered", "hostile", "omega-flowey", "attack", "friendliness-pellets" ], \
+      transformation: [ \
+        -1f, 0f, 1.2246467991473532e-16f, 0f, \
+        0f,1f,0f,-0.125f, \
+        -1.2246467991473532e-16f,0f,-1f,0f, \
+        0f,0f,0f,1f \
+      ], \
+      interpolation_duration: 1, \
+      item_display: "head", \
+      item: { id:"minecraft:golden_sword", Count:1b, tag: { CustomModelData:4 } } \
+    } \
+  ] \
+}
 
 # TODO(43): this is so unbelievably hacky
 # first indicator is 6 ticks slower before it starts summoning bullets

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/homing-vines/bullet/loop.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/homing-vines/bullet/loop.mcfunction
@@ -7,7 +7,7 @@ data merge storage utils:damage { damage: 2, radius: 1 }
 execute if entity @s[tag=!cant-damage] run function entity:utils/damage with storage utils:damage
 
 # Move while inside arena
-execute if entity @s[x=-25,dx=50,y=32,dy=10,z=-5,dz=23] run function entity:hostile/omega-flowey/attack/homing-vines/bullet/loop/move
+execute if entity @s[x=-203,dx=50,y=62,dy=10,z=55.0,dz=-23] run function entity:hostile/omega-flowey/attack/homing-vines/bullet/loop/move
 
 # TODO(41): validate/determine a value for how long until the homing-vines bullets terminate
 # Terminate after X seconds

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/homing-vines/indicator/initialize/randomize_bullet_position.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/homing-vines/indicator/initialize/randomize_bullet_position.mcfunction
@@ -4,21 +4,21 @@ execute store result score @s attack.position.x run data get entity @s Pos[0] 10
 execute store result score @s math.0 run random value -1500..1500
 scoreboard players operation @s attack.position.x += @s math.0
 
-# Bound `attack.position.x` within arena between x: [-21.00, 21.00]
-data merge storage utils:math.max { a: -2100 }
+# Bound `attack.position.x` within arena
+data merge storage utils:math.max { a: -19900 }
 execute store result storage utils:math.max b int 1 run scoreboard players get @s attack.position.x
 function utils:math/max
 execute store result score @s attack.position.x run data get storage utils:math.max out
-data merge storage utils:math.min { a: 2100 }
+data merge storage utils:math.min { a: -15700 }
 execute store result storage utils:math.min b int 1 run scoreboard players get @s attack.position.x
 function utils:math/min
 execute store result score @s attack.position.x run data get storage utils:math.min out
 
-# Randomize y-position to summon bullet at (y: [34.00..40.00])
-execute store result score @s attack.position.y run random value 3400..4000
+# Randomize y-position to summon bullet at
+execute store result score @s attack.position.y run random value 6400..7000
 
 # Set z-position to summon bullet at
-scoreboard players set @s attack.position.z -400
+scoreboard players set @s attack.position.z 5400
 
 execute store result storage attack:homing-vines x float 0.01 run scoreboard players get @s attack.position.x
 execute store result storage attack:homing-vines y float 0.01 run scoreboard players get @s attack.position.y

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/homing-vines/indicator/initialize/randomize_indicator_position.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/homing-vines/indicator/initialize/randomize_indicator_position.mcfunction
@@ -4,12 +4,12 @@ execute store result score @s attack.position.x run data get entity @s Pos[0] 10
 execute store result score @s math.0 run random value -50..50
 scoreboard players operation @s attack.position.x += @s math.0
 
-# Bound `attack.position.x` within arena between x: [-21.00, 21.00]
-data merge storage utils:math.max { a: -2100 }
+# Bound `attack.position.x` within arena
+data merge storage utils:math.max { a: -19900 }
 execute store result storage utils:math.max b int 1 run scoreboard players get @s attack.position.x
 function utils:math/max
 execute store result score @s attack.position.x run data get storage utils:math.max out
-data merge storage utils:math.min { a: 2100 }
+data merge storage utils:math.min { a: -15700 }
 execute store result storage utils:math.min b int 1 run scoreboard players get @s attack.position.x
 function utils:math/min
 execute store result score @s attack.position.x run data get storage utils:math.min out
@@ -20,12 +20,12 @@ execute store result score @s attack.position.z run data get entity @s Pos[2] 10
 execute store result score @s math.0 run random value -100..100
 scoreboard players operation @s attack.position.z += @s math.0
 
-# Bound `attack.position.z` within arena between z: [-3.00, 18.00]
-data merge storage utils:math.max { a: -300 }
+# Bound `attack.position.z` within arena
+data merge storage utils:math.max { a: 3200 }
 execute store result storage utils:math.max b int 1 run scoreboard players get @s attack.position.z
 function utils:math/max
 execute store result score @s attack.position.z run data get storage utils:math.max out
-data merge storage utils:math.min { a: 1800 }
+data merge storage utils:math.min { a: 5300 }
 execute store result storage utils:math.min b int 1 run scoreboard players get @s attack.position.z
 function utils:math/min
 execute store result score @s attack.position.z run data get storage utils:math.min out

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/homing-vines/indicator/loop/presummon_bullet/face_player_location.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/homing-vines/indicator/loop/presummon_bullet/face_player_location.mcfunction
@@ -1,6 +1,3 @@
-# Face player's positioned when indicator was summoned
-$teleport @s ~ ~ ~ facing $(x) $(y) $(z)
-
 # Flip yaw that bullet will summon with
 execute store result score @s math.0 run data get entity @s Rotation[0] 100
 scoreboard players add @s math.0 18000

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/homing-vines/indicator/loop/visualize_blinking_lane.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/homing-vines/indicator/loop/visualize_blinking_lane.mcfunction
@@ -1,5 +1,5 @@
 # Remove zero-view-range data now that the blinking_lane's rotation has updated
-$execute as $(blinking_lane_uuid) run data modify entity @s view_range set value 1
+$execute as $(blinking_lane_uuid) on passengers if entity @s[tag=aj.homing_vine_blinking_lane.bone.root] run data modify entity @s view_range set value 1
 
 # Play blinking sound once
 playsound omega-flowey:attack.homing-vines.blinking hostile @a ~ ~ ~ 3 1 1

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/indicator/initialize.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/indicator/initialize.mcfunction
@@ -6,6 +6,11 @@ scoreboard players operation @s attack.cone = #attack-x-bullets-lower attack.con
 
 scoreboard players operation @s attack.bullets.remaining = @s attack.bullets.total
 
+# Determine if this indicator belongs to the right/left eye
+# HARDCODED BOUND FOR DEVELOPMENT SPEED => x: -178.0
+execute store result score @s math.0 run data get entity @s Pos[0] 100
+execute if score @s math.0 matches -17800.. run tag @s add indicator.left
+
 # Remove tags
 tag @s remove attack-indicator-new
 

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/indicator/initialize/face_player.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/indicator/initialize/face_player.mcfunction
@@ -20,12 +20,8 @@ scoreboard players operation @s math.0 = @s attack.bullets.total
 scoreboard players remove @s math.0 1
 scoreboard players operation @s attack.d-phi /= @s math.0
 
-# Determine if this is left/right eye
-scoreboard players set @s math.0 0
-execute if entity @e[tag=aj.lower_eye.bone.pupil,distance=..2,y_rotation=169..171] run scoreboard players set @s math.0 1
-
 # Flip `attack.d-phi` for one of the eyes
-scoreboard players operation @s[scores={math.0=1}] attack.d-phi *= #-1 mathf.const
+scoreboard players operation @s[tag=indicator.left] attack.d-phi *= #-1 mathf.const
 
 # # Randomly offset `attack.cone` by half `attack.d-phi` to increase entropy of attack pattern (50% chance)
 # execute store result score @s math.1 run random value 0..1

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/indicator/initialize/face_player.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/indicator/initialize/face_player.mcfunction
@@ -27,8 +27,8 @@ execute if entity @e[tag=aj.lower_eye.bone.pupil,distance=..2,y_rotation=169..17
 # Flip `attack.d-phi` for one of the eyes
 scoreboard players operation @s[scores={math.0=1}] attack.d-phi *= #-1 mathf.const
 
-# Randomly offset `attack.cone` by half `attack.d-phi` to increase entropy of attack pattern (50% chance)
-execute store result score @s math.1 run random value 0..1
-scoreboard players operation @s[scores={math.1=0}] math.0 = @s attack.d-phi
-scoreboard players operation @s[scores={math.1=0}] math.0 /= #2 mathf.const
-scoreboard players operation @s[scores={math.1=0}] attack.phi += @s math.0
+# # Randomly offset `attack.cone` by half `attack.d-phi` to increase entropy of attack pattern (50% chance)
+# execute store result score @s math.1 run random value 0..1
+# scoreboard players operation @s[scores={math.1=0}] math.0 = @s attack.d-phi
+# scoreboard players operation @s[scores={math.1=0}] math.0 /= #2 mathf.const
+# scoreboard players operation @s[scores={math.1=0}] attack.phi += @s math.0

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/start.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/start.mcfunction
@@ -1,5 +1,4 @@
 ## Summon x-bullets-lower executor
-# TODO(48): add error when try to start `x-bullets` attack when the corresponding eye entity model doesn't exist
 summon minecraft:marker ~ ~ ~ {CustomName: '"X-Bullets-Lower Executor"', Tags:["omega-flowey-remastered","hostile","omega-flowey","attack","attack-executor","attack-executor-new","x-bullets-lower"]}
 
 # Initialize attack-executor

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-upper/start.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-upper/start.mcfunction
@@ -1,5 +1,4 @@
 ## Summon x-bullets-upper executor
-# TODO(48): add error when try to start `x-bullets` attack when the corresponding eye entity model doesn't exist
 summon minecraft:marker ~ ~ ~ {CustomName: '"X-Bullets-Upper Executor"', Tags:["omega-flowey-remastered","hostile","omega-flowey","attack","attack-executor","attack-executor-new","x-bullets-upper"]}
 
 # Initialize attack-executor

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/relative.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/relative.mcfunction
@@ -2,15 +2,15 @@ function entity:hostile/omega-flowey/summon/remove_preexisting_models
 
 ## Large side vines
 # Right large side vine
-execute positioned ^-24.5 ^3.5 ^4.5 rotated ~135 ~-10 run function animated_java:large_side_vine/summon { args: {} }
+execute positioned ^-27.0 ^3.5 ^4.5 rotated ~135 ~-10 run function animated_java:large_side_vine/summon { args: {} }
 tag @e[tag=aj.large_side_vine.root] add large_side_vine.right
 # Left large side vine
-execute positioned ^27.5 ^3.5 ^4.5 rotated ~215 ~-10 run function animated_java:large_side_vine/summon { args: {} }
+execute positioned ^27.0 ^3.5 ^4.5 rotated ~215 ~-10 run function animated_java:large_side_vine/summon { args: {} }
 tag @e[tag=aj.large_side_vine.root,tag=!large_side_vine.right] add large_side_vine.left
 
 ## Lower eyes
 # Right-eye
-execute positioned ^-4.5 ^5.5 ^6.5 rotated ~170 ~-20 run function animated_java:lower_eye/summon { args: {} }
+execute positioned ^-5.5 ^5.5 ^6.5 rotated ~170 ~-20 run function animated_java:lower_eye/summon { args: {} }
 tag @e[type=minecraft:item_display, tag=aj.lower_eye.root] add lower_eye.right
 # Left-eye
 execute positioned ^5.5 ^5.5 ^6.5 rotated ~10 ~20 run function animated_java:lower_eye/summon { args: {} }
@@ -18,7 +18,7 @@ tag @e[type=minecraft:item_display, tag=aj.lower_eye.root, tag=!lower_eye.right]
 
 ## Lower petal pipes
 # Right-lower petal pipe
-execute positioned ^-10.5 ^7.5 ^ rotated ~-10 ~20 run function animated_java:petal_pipe_circle/summon { args: {} }
+execute positioned ^-11.5 ^7.5 ^ rotated ~-10 ~20 run function animated_java:petal_pipe_circle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_circle.root] add petal_pipe.right
 # Left-lower petal pipe
 execute positioned ^11.5 ^7.5 ^ rotated ~-170 ~-20 run function animated_java:petal_pipe_circle/summon { args: {} }
@@ -27,10 +27,10 @@ tag @e[tag=aj.petal_pipe_circle.root] add petal_pipe_lower
 
 ## Middle petal pipes
 # Right-middle petal pipe
-execute positioned ^-13.5 ^11.5 ^6.5 rotated ~-20 ~40 run function animated_java:petal_pipe_middle/summon { args: {} }
+execute positioned ^-15.0 ^11.5 ^6.5 rotated ~-20 ~40 run function animated_java:petal_pipe_middle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_middle.root] add petal_pipe.right
 # Left-middle petal pipe
-execute positioned ^14.5 ^11.5 ^6.5 rotated ~-160 ~-40 run function animated_java:petal_pipe_middle/summon { args: {} }
+execute positioned ^15.0 ^11.5 ^6.5 rotated ~-160 ~-40 run function animated_java:petal_pipe_middle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_middle.root,tag=!petal_pipe.right] add petal_pipe.left
 
 ## Mouth
@@ -45,13 +45,13 @@ execute as @e[tag=aj.tv_screen.root, tag=tv-screen-new] run function entity:host
 
 ## Upper eyes
 # Right-eye
-execute positioned ^-15.5 ^11.5 ^9.5 rotated ~160 ~-40 run function animated_java:upper_eye/summon { args: {} }
+execute positioned ^-16.0 ^11.5 ^9.5 rotated ~160 ~-40 run function animated_java:upper_eye/summon { args: {} }
 # Left-eye
-execute positioned ^16.5 ^11.5 ^9.5 rotated ~20 ~40 run function animated_java:upper_eye/summon { args: {} }
+execute positioned ^16.0 ^11.5 ^9.5 rotated ~20 ~40 run function animated_java:upper_eye/summon { args: {} }
 
 ## Upper petal pipes
 # Right-upper petal pipe
-execute positioned ^-10.5 ^26.5 ^17.5 rotated ~-10 ~45 run function animated_java:petal_pipe_circle/summon { args: {} }
+execute positioned ^-11.5 ^26.5 ^17.5 rotated ~-10 ~45 run function animated_java:petal_pipe_circle/summon { args: {} }
 tag @e[tag=aj.petal_pipe_circle.root,tag=!petal_pipe_lower] add petal_pipe.right
 # Left-upper petal pipe
 execute positioned ^11.5 ^26.5 ^17.5 rotated ~-170 ~-45 run function animated_java:petal_pipe_circle/summon { args: {} }

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/relative.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/summon/relative.mcfunction
@@ -11,8 +11,10 @@ tag @e[tag=aj.large_side_vine.root,tag=!large_side_vine.right] add large_side_vi
 ## Lower eyes
 # Right-eye
 execute positioned ^-4.5 ^5.5 ^6.5 rotated ~170 ~-20 run function animated_java:lower_eye/summon { args: {} }
+tag @e[type=minecraft:item_display, tag=aj.lower_eye.root] add lower_eye.right
 # Left-eye
 execute positioned ^5.5 ^5.5 ^6.5 rotated ~10 ~20 run function animated_java:lower_eye/summon { args: {} }
+tag @e[type=minecraft:item_display, tag=aj.lower_eye.root, tag=!lower_eye.right] add lower_eye.left
 
 ## Lower petal pipes
 # Right-lower petal pipe

--- a/datapacks/omega-flowey/data/omega-flowey/function/summit/room/setup.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/function/summit/room/setup.mcfunction
@@ -3,7 +3,7 @@ kill @e[tag=omega-flowey-remastered,tag=decorative]
 function omega-flowey:summit/room/setup/outside
 
 kill @e[type=minecraft:marker, tag=omega-flowey-remastered, tag=origin]
-summon minecraft:marker -178 67 62 { \
+summon minecraft:marker -177.5 67 62.5 { \
   CustomName:'"Omega-Flowey Boss-fight Origin"', \
   Tags: [ \
     "omega-flowey-remastered", \

--- a/datapacks/omega-flowey/data/omega-flowey/function/summit/room/setup.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/function/summit/room/setup.mcfunction
@@ -2,8 +2,9 @@ kill @e[tag=omega-flowey-remastered,tag=decorative]
 
 function omega-flowey:summit/room/setup/outside
 
+# NOTE: player should have y-coord of -4 blocks from Origin's Y coord
 kill @e[type=minecraft:marker, tag=omega-flowey-remastered, tag=origin]
-summon minecraft:marker -177.5 67 62.5 { \
+summon minecraft:marker -177.5 67.0 62.5 { \
   CustomName:'"Omega-Flowey Boss-fight Origin"', \
   Tags: [ \
     "omega-flowey-remastered", \

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -51,7 +51,7 @@ module.exports = {
       default: `node ${watchScriptPath}`,
     },
     sync: {
-      default: 'nps sync.world',
+      default: 'nps sync.summit',
       world: {
         default: 'nps sync.world.up',
         down: `node ./package-scripts/sync-world --down ${worldSyncArgs}`,

--- a/package-scripts/sync-world.js
+++ b/package-scripts/sync-world.js
@@ -86,7 +86,7 @@ const syncDown = async (options) => {
   /** We can only temp backup the current world if it already exists */
   if (await exists(worldPath)) {
     console.log('Backing up your current world as a precautionary measure...');
-    const name = await createTempWorldBackupName();
+    const name = await createTempWorldBackupName(options);
     const path = `${tempBackupPath}/${name}`;
     await backupWorld({ ...options, backupPath: path, useColor: false });
 

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "omega-flowey-minecraft-remastered",
   "packageManager": "yarn@3.6.3",
   "scripts": {
-    "down": "nps sync.world.down",
+    "down": "nps sync.summit.down",
     "lint": "nps lint",
     "lint.fix": "nps lint.fix",
     "start": "nps",
-    "sync": "nps sync.world"
+    "sync": "nps sync"
   },
   "engines": {
     "node": ">=16.10"

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/homing-vine-blinking-lane.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/homing-vine-blinking-lane.ajblueprint
@@ -24,7 +24,7 @@
 		"texture_folder": "",
 		"enable_advanced_data_pack_settings": false,
 		"data_pack": "G:/Coding/omega-flowey-minecraft-remastered/datapacks/animated_java",
-		"summon_commands": "data merge entity @s {CustomName: '\"Homing-Vines Blinking Lane\"', view_range: 0 }\ntag @s add omega-flowey-remastered\ntag @s add groupable\ntag @s add hostile\ntag @s add omega-flowey\ntag @s add attack\ntag @s add homing-vines\ntag @s add homing-vines-blinking-lane\ntag @s add homing-vines-blinking-lane-new",
+		"summon_commands": "tag @s add omega-flowey-remastered\ntag @s add groupable\ntag @s add hostile\ntag @s add omega-flowey\ntag @s add attack\ntag @s add homing-vines\ntag @s add homing-vines-blinking-lane\ntag @s add homing-vines-blinking-lane-new",
 		"ticking_commands": "",
 		"interpolation_duration": 1,
 		"teleportation_duration": 1,
@@ -133,7 +133,8 @@
 			"configs": {
 				"default": {
 					"inherit_settings": true,
-					"nbt": ""
+					"nbt": "{CustomName: '\"Homing-Vines Blinking Lane\"', view_range: 0, teleport_duration: 0  }",
+					"use_nbt": true
 				},
 				"variants": {}
 			},


### PR DESCRIPTION
# Summary

Plan atm is to only use attacks from `vanilla` phase 0, so this PR makes sure each one runs and summons entities/bullets/etc. as expected.

This includes:
- `friendliness-pellets`
- `homing-vines`
- `x-bullets-lower`
- `x-bullets-upper`

We also fix some non-position-related bugs for these attacks

---

## Reproducing
```mcfunction
function _:summon
function _:attack/friendliness-pellets
function _:attack/homing-vines
function _:attack/x-bullets-lower
function _:attack/x-bullets-upper
```

## Preview

see recording of every attack: https://youtu.be/BKPU9toZt6M

---

## Supplemental changes

- [`dfb452c` (#179)](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/179/commits/dfb452ce91dddb831b1fad11813a43c759b2ab10): 📦 sync summit world
- [`2ddea54` (#179)](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/179/commits/2ddea549cf9fec01d0879e81fc5e09662e67304b): 🐛 fix world sync-down not working
- [`995a1bf` (#179)](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/179/commits/995a1bfeb503dd1bd7e7d4f79f2075e11640e5ac): 🐛 🎥 add missing tag and heartbeat command to boss-fight logic
- [`0afad5c` (#179)](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/179/commits/0afad5c7881c53ae8330a10079d8ee62f5451556): 💡 remove stale TODOs
- [`e9c85a1` (#179)](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/179/commits/e9c85a1912193f79c86e3fc66ac0b18272beda1c): 💩 temp disable `x-bullets-lower` 50% attack.cone offset code
- [`ddffec3` (#179)](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/179/commits/ddffec3d67b115ad3a39c2afe782b771aad8d077): 🔨 change default sync to be `summit` instead of main world
- [`a0e22d8` (#179)](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/179/commits/a0e22d88e4b7bf98b50d940d3a2b8a36bcb1b6c0): 🐛 💫 fix blinking-lane being visible before yaw-adjustment is complete 
- [`4e79c3f` (#179)](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/179/commits/4e79c3f0bb77a412e23fadde1cc7ba57417f4688): 👷 make Blockbench in CI not hang when new version exists 