### PR TITLE
📍 ⚔️ update attack phase 1 coordinates for Summit world

### DIFF
--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/bomb/bullet/loop.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/bomb/bullet/loop.mcfunction
@@ -18,7 +18,7 @@ execute if score @s attack.clock.i matches 20 run function entity:hostile/omega-
 execute if score @s attack.clock.i matches 20.. run teleport @s ~ ~-2.2 ~
 
 # Stop falling after bomb falls through floor
-execute at @s if entity @s[x=-100,dx=200,y=33,dy=-20,z=-100,dz=200] run function entity:hostile/omega-flowey/attack/bomb/bullet/loop/stop_falling
+execute at @s if entity @s[x=-77.5,dx=-200,y=63,dy=-20,z=150,dz=-200] run function entity:hostile/omega-flowey/attack/bomb/bullet/loop/stop_falling
 
 # TODO(68): validate/determine a value for how long until the bomb bullets terminate
 # Terminate after X seconds

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/bomb/bullet/loop/stop_falling.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/bomb/bullet/loop/stop_falling.mcfunction
@@ -1,5 +1,5 @@
 # Keep consistent y-pos
-teleport @s ~ 33.0 ~
+teleport @s ~ 63.0 ~
 
 # Play animation if we just stopped falling
 execute unless entity @s[tag=is_done_falling] run function animated_java:bomb/animations/explode/play

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/bomb/indicator/loop/bullet/presummon.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/bomb/indicator/loop/bullet/presummon.mcfunction
@@ -1,8 +1,8 @@
-# Randomize x-position to summon bullet at (x: [-22..22])
-execute store result score @s attack.position.x run random value -220..220
+# Randomize x-position to summon bullet
+execute store result score @s attack.position.x run random value -1995..-1555
 
-# Randomize z-position to summon bullet at (z: [-4..19])
-execute store result score @s attack.position.z run random value -40..190
+# Randomize z-position to summon bullet
+execute store result score @s attack.position.z run random value 310..540
 
 # Store position
 execute store result storage attack:bomb x double 0.1 run scoreboard players get @s attack.position.x

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/bomb/indicator/loop/bullet/summon.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/bomb/indicator/loop/bullet/summon.mcfunction
@@ -1,3 +1,3 @@
 # Summon, initialize, and animate bullet (scale-in from 0)
-$execute positioned $(x) 60 $(z) run function animated_java:bomb/summon { args: { animation: 'summon', start_animation: true } }
+$execute positioned $(x) 90 $(z) run function animated_java:bomb/summon { args: { animation: 'summon', start_animation: true } }
 execute as @e[tag=attack-bullet-new] at @s run function entity:hostile/omega-flowey/attack/bomb/bullet/initialize

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/loop.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/loop.mcfunction
@@ -5,7 +5,7 @@ data merge storage utils:damage { damage: 2.5 }
 function entity:utils/damage with storage utils:damage
 
 # Bounce if hit edge of arena
-execute unless entity @s[x=-21,dx=42,z=-3,dz=21] run function entity:hostile/omega-flowey/attack/dentata-snakes/bullet/loop/maybe_bounce
+execute unless entity @s[x=-156.5,dx=-42,y=50,dy=40,z=53,dz=-21] run function entity:hostile/omega-flowey/attack/dentata-snakes/bullet/loop/maybe_bounce
 
 # Move forward at defined `attack.speed.z` velocity
 execute store result storage utils:move z float 0.01 run scoreboard players get @s attack.speed.z

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/loop/maybe_bounce.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/dentata-snakes/bullet/loop/maybe_bounce.mcfunction
@@ -1,12 +1,12 @@
-# Don't bounce if we've already escaped the arena (past top wall)
-execute if entity @s[x=-1000,dx=2000,y=30,dy=10,z=-4,dz=-1000,tag=can-escape-arena] run return 0
+# Don't bounce if we've already escaped the arena (past wall towards Flowey)
+execute if entity @s[x=822.5,dx=-2000,y=60,dy=10,z=54,dz=1000,tag=can-escape-arena] run return 0
 
 # TODO(42): adjust arena bounds based on new animated java model (visually, it clips into the wall right now)
-data merge storage attack:dentata-snakes.bounce { x_negative_x: -21, x_negative_dx: 50 }
-data merge storage attack:dentata-snakes.bounce { x_positive_x: 21, x_positive_dx: -50 }
-data merge storage attack:dentata-snakes.bounce { z_negative_z: -3, z_negative_dz: 25 }
-data merge storage attack:dentata-snakes.bounce { z_positive_z: 18, z_positive_dz: -25 }
-data merge storage attack:dentata-snakes.bounce { y: 30, dy: 10 }
+data merge storage attack:dentata-snakes.bounce { x_negative_x: -198.5, x_negative_dx: 50 }
+data merge storage attack:dentata-snakes.bounce { x_positive_x: -156.5, x_positive_dx: -50 }
+data merge storage attack:dentata-snakes.bounce { z_negative_z: 32, z_negative_dz: 25 }
+data merge storage attack:dentata-snakes.bounce { z_positive_z: 53, z_positive_dz: -25 }
+data merge storage attack:dentata-snakes.bounce { y: 60, dy: 10 }
 data merge storage attack:dentata-snakes.bounce { command_after_bouncing: 'execute if entity @s[tag=attack-bullet-head] run function entity:hostile/omega-flowey/attack/dentata-snakes/bullet/loop/after_bounce_as_bullet_head' }
 
 function entity:utils/bounce with storage attack:dentata-snakes.bounce

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/dentata-snakes/indicator/initialize.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/dentata-snakes/indicator/initialize.mcfunction
@@ -10,10 +10,10 @@ scoreboard players operation @s attack.bullets.total = #attack-dentata-snakes at
 tag @s remove attack-indicator-new
 
 # Randomize position to summon bullet at (x: [-15.00..15.00], z: -5)
-execute store result score @s attack.bullets.position.x run random value -1500..1500
-scoreboard players set @s attack.bullets.position.z -500
+execute store result score @s attack.bullets.position.x run random value -19250..-16250
+scoreboard players set @s attack.bullets.position.z 5500
 
-# Randomize initial yaw of bullets (-45 | 45 deg)
+# Randomize initial yaw of bullets
 execute store result score @s math.0 run random value 0..1
-execute if score @s math.0 matches 0 run data merge entity @s { Rotation:[45.0f, 0f] }
-execute if score @s math.0 matches 1 run data merge entity @s { Rotation:[-45.0f, 0f] }
+execute if score @s math.0 matches 0 run data merge entity @s { Rotation:[135.0f, 0f] }
+execute if score @s math.0 matches 1 run data merge entity @s { Rotation:[-135.0f, 0f] }

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/dentata-snakes/indicator/loop/summon_bullet.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/dentata-snakes/indicator/loop/summon_bullet.mcfunction
@@ -1,8 +1,8 @@
 ## Summon bullet
 # bullet head (begin animation)
-$execute if score @s attack.bullets.count matches 0 positioned $(x) 33.0 $(z) run function animated_java:dentata_snake_ball/summon { args: { animation: 'roll_bite', start_animation: true } }
+$execute if score @s attack.bullets.count matches 0 positioned $(x) 63.0 $(z) run function animated_java:dentata_snake_ball/summon { args: { animation: 'roll_bite', start_animation: true } }
 # bullet tail
-$execute unless score @s attack.bullets.count matches 0 positioned $(x) 33.0 $(z) run function animated_java:dentata_snake_ball/summon/tail
+$execute unless score @s attack.bullets.count matches 0 positioned $(x) 63.0 $(z) run function animated_java:dentata_snake_ball/summon/tail
 
 # Initialize bullet
 execute if score @s attack.bullets.count matches 0 as @e[tag=attack-bullet-new] run function entity:hostile/omega-flowey/attack/dentata-snakes/bullet/initialize/head

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/finger-guns/executor/loop/indicator/presummon.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/finger-guns/executor/loop/indicator/presummon.mcfunction
@@ -1,17 +1,17 @@
-# x-position will summon at either x: -21.00 or x: +21.00
-scoreboard players set @s attack.position.x 2100
-execute store result score @s math.0 run random value -1..0
-execute if score @s math.0 matches -1 run scoreboard players operation @s attack.position.x *= @s math.0
+# randomize x-position
+scoreboard players set @s attack.position.x -19850
+execute store result score @s math.0 run random value 0..1
+execute if score @s math.0 matches 1 run scoreboard players set @s attack.position.x -15650
 
-# face east if at -22.00, face west if at +22.00
-scoreboard players set @s attack.indicator.yaw 9000
-execute if score @s math.0 matches -1 run scoreboard players operation @s attack.indicator.yaw *= @s math.0
+# face east if at -156.5, face west if at -198.5
+scoreboard players set @s attack.indicator.yaw -9000
+execute if score @s math.0 matches 1 run scoreboard players set @s attack.indicator.yaw 9000
 
-# y-position will summon at y: 33.00
-scoreboard players set @s attack.position.y 3300
+# y-position
+scoreboard players set @s attack.position.y 6300
 
 # Randomize z-position to summon indicator at (z: [-3.5..19.5])
-execute store result score @s attack.position.z run random value -35..195
+execute store result score @s attack.position.z run random value 305..535
 
 # Store new position and yaw
 execute store result storage attack:finger-guns x double 0.01 run scoreboard players get @s attack.position.x

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/finger-guns/indicator/loop/bullet/summon.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/finger-guns/indicator/loop/bullet/summon.mcfunction
@@ -1,5 +1,5 @@
 # Summon bullet
-$execute positioned $(x) 35 $(z) run function animated_java:finger_gun_bullet/summon { args: { animation: 'shoot', start_animation: true } }
+$execute positioned $(x) 65 $(z) run function animated_java:finger_gun_bullet/summon { args: { animation: 'shoot', start_animation: true } }
 
 # Copy yaw to bullet
 execute store result storage attack:finger-guns yaw float 1 run data get entity @s Rotation[0] 100

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/finger-guns/indicator/loop/laser/summon.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/finger-guns/indicator/loop/laser/summon.mcfunction
@@ -1,5 +1,5 @@
 # Summon laser
-$execute positioned 0.5 33.5 $(z) run function animated_java:finger_gun_laser/summon { args: {} }
+$execute positioned -178.0 63.5 $(z) run function animated_java:finger_gun_laser/summon { args: {} }
 
 # Copy group id to laser
 execute store result storage group id int 1 run scoreboard players get @s group.id

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/finger-gun-laser.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/finger-gun-laser.ajblueprint
@@ -24,7 +24,7 @@
 		"texture_folder": "",
 		"enable_advanced_data_pack_settings": false,
 		"data_pack": "G:/Coding/omega-flowey-minecraft-remastered/datapacks/animated_java",
-		"summon_commands": "data merge entity @s { CustomName: \"'Finger-Guns Laser'\", Rotation: [90.0f, 0.0f] }\ntag @s add omega-flowey-remastered\ntag @s add groupable\ntag @s add hostile\ntag @s add omega-flowey\ntag @s add attack\ntag @s add finger-guns\ntag @s add finger-guns-laser\ntag @s add finger-guns-laser-new",
+		"summon_commands": "data merge entity @s { CustomName: \"'Finger-Guns Laser'\" }\ntag @s add omega-flowey-remastered\ntag @s add groupable\ntag @s add hostile\ntag @s add omega-flowey\ntag @s add attack\ntag @s add finger-guns\ntag @s add finger-guns-laser\ntag @s add finger-guns-laser-new",
 		"ticking_commands": "",
 		"interpolation_duration": 1,
 		"teleportation_duration": 1,
@@ -91,7 +91,8 @@
 			"configs": {
 				"default": {
 					"inherit_settings": true,
-					"nbt": ""
+					"nbt": "{ Rotation: [90.0f, 0.0f] }",
+					"use_nbt": true
 				},
 				"variants": {}
 			},
@@ -139,7 +140,7 @@
 		"default": {
 			"name": "default",
 			"display_name": "Default",
-			"uuid": "a22055b9-1a88-667a-009f-969ce18a88f1",
+			"uuid": "fc9c538c-05d1-72ee-1056-b5c1307db3ac",
 			"texture_map": {},
 			"excluded_nodes": [],
 			"is_default": true

--- a/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/homing-vine-blinking-lane.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/hostile/omega-flowey/attacks/homing-vine-blinking-lane.ajblueprint
@@ -24,7 +24,7 @@
 		"texture_folder": "",
 		"enable_advanced_data_pack_settings": false,
 		"data_pack": "G:/Coding/omega-flowey-minecraft-remastered/datapacks/animated_java",
-		"summon_commands": "tag @s add omega-flowey-remastered\ntag @s add groupable\ntag @s add hostile\ntag @s add omega-flowey\ntag @s add attack\ntag @s add homing-vines\ntag @s add homing-vines-blinking-lane\ntag @s add homing-vines-blinking-lane-new",
+		"summon_commands": "data merge entity @s {CustomName: '\"Homing-Vines Blinking Lane\"'}\ntag @s add omega-flowey-remastered\ntag @s add groupable\ntag @s add hostile\ntag @s add omega-flowey\ntag @s add attack\ntag @s add homing-vines\ntag @s add homing-vines-blinking-lane\ntag @s add homing-vines-blinking-lane-new",
 		"ticking_commands": "",
 		"interpolation_duration": 1,
 		"teleportation_duration": 1,
@@ -135,7 +135,7 @@
 			"configs": {
 				"default": {
 					"inherit_settings": true,
-					"nbt": "{CustomName: '\"Homing-Vines Blinking Lane\"', view_range: 0, teleport_duration: 0  }",
+					"nbt": "{ view_range: 0, teleport_duration: 0 }",
 					"use_nbt": true
 				},
 				"variants": {}


### PR DESCRIPTION
# Summary

In the event we want to mix-in some of attack phase 1's attacks to the Summit boss, I fixed them up here so they spawn properly.

These attacks are:

- `bomb`
- `dentata-snakes`
- `finger-guns`

We specifically chose to skip the `flies` attack here since the animations for it are far from complete (missing `venus_fly_trap` model growing animation).

We also fix a bug with the finger gun's laser, similar to the bug with homing-vines blinking-lane from https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/179.

---

## Reproducing

```mcfunction
function _:summon
function _:attack/bomb
function _:attack/dentata-snakes
function _:attack/finger-guns
```

## Preview

see recording of individual attacks: https://youtu.be/e3QUNXO8IPk

(note: video doesn't include the finger-guns laser bug fix)

---

## Supplemental changes

- [`29e5016` (#183)](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/183/commits/29e5016d128d7719cf25f12304f8ecc989550882): 🐛 fix finger-gun laser rotation flicker on summon 
- [`c536f0d` (#183)](https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/pull/183/commits/c536f0ddcf20ea74991bb9d91ffb4893a3fa783c): 🍱 revert `homing-vine-blinking-lane`'s `CustomName` NBT