### PR TITLE
📍 👻 update `soul_5` summon coordinates

### DIFF
--- a/datapacks/omega-flowey/data/entity/function/soul/shared/call_for_help_display/summon.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/soul/shared/call_for_help_display/summon.mcfunction
@@ -1,4 +1,4 @@
-summon block_display -2.5 49.5 -34.0 \
+summon block_display -175.0 79.5 84.0 \
     {Tags:["omega-flowey-remastered","soul","call-for-help-display","call-for-help-display-new"], \
     Passengers:[{id:"minecraft:text_display", \
             Tags:["omega-flowey-remastered","soul","call-for-help-display","call-for-help-display-new"], \
@@ -8,7 +8,7 @@ summon block_display -2.5 49.5 -34.0 \
             alignment:"center", \
             line_width:210, \
             default_background:false, \
-            Rotation:[-180f,0f], \
+            Rotation:[0f,0f], \
             transformation:[30.0000f,0.0000f,0.0000f,0.0000f, \
                             0.0000f,30.0000f,0.0000f,0.5000f, \
                             0.0000f,0.0000f,30.0000f,0.0000f, \

--- a/datapacks/omega-flowey/data/entity/function/soul/soul_5/crosshair/summon.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/soul/soul_5/crosshair/summon.mcfunction
@@ -1,5 +1,5 @@
 # Summon crosshair at random radius around this player (radius = 4 blocks)
-$execute rotated $(next_bullet_angle_from_player) 0 positioned ^ ^ ^4 positioned ~ 33.0 ~ run function animated_java:soul_5_crosshair/summon { args: { variant: $(next_crosshair_variant) } }
+$execute rotated $(next_bullet_angle_from_player) 0 positioned ^ ^ ^4 positioned ~ 63.0 ~ run function animated_java:soul_5_crosshair/summon { args: { variant: $(next_crosshair_variant) } }
 
 # Initialize crosshair
 execute as @e[tag=soul-crosshair-new] at @s run function entity:soul/soul_5/crosshair/initialize with storage soul:soul_5.indicator

--- a/datapacks/omega-flowey/data/entity/function/soul/soul_5/indicator/initialize/saved.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/soul/soul_5/indicator/initialize/saved.mcfunction
@@ -2,4 +2,4 @@
 tag @s remove shaking
 
 # Return to starting position
-teleport @s 0 33.1 -68
+teleport @s -178.0 63.1 117.5

--- a/datapacks/omega-flowey/data/entity/function/soul/soul_5/indicator/loop/aiming/next_crosshair/randomize_yaw/check_valid.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/soul/soul_5/indicator/loop/aiming/next_crosshair/randomize_yaw/check_valid.mcfunction
@@ -1,6 +1,6 @@
 # this position is invalid if the placement is too close to the indicator
 scoreboard players set @s math.bool 1
 
-$execute rotated $(next_bullet_angle_from_player) 0 positioned ^ ^ ^4 positioned ~ 33.1 ~ \
+$execute rotated $(next_bullet_angle_from_player) 0 positioned ^ ^ ^4 positioned ~ 63.1 ~ \
   if entity @e[type=minecraft:item_display,tag=soul_5,tag=soul-indicator,distance=..3] run \
   scoreboard players set @s math.bool 0

--- a/datapacks/omega-flowey/data/entity/function/soul/soul_5/indicator/summon.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/soul/soul_5/indicator/summon.mcfunction
@@ -1,5 +1,5 @@
 # Summon bullet
-execute positioned 0 33.1 -68 rotated 0 0 run function animated_java:soul_5_gun/summon { args: {} }
+execute positioned -178.0 63.1 117.5 rotated 180 0 run function animated_java:soul_5_gun/summon { args: {} }
 
 # Initialize bullet
 execute as @e[tag=soul-indicator-new] at @s run function entity:soul/soul_5/indicator/initialize

--- a/datapacks/omega-flowey/data/entity/function/soul/soul_5/shared/terminate_unless_in_region.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/soul/soul_5/shared/terminate_unless_in_region.mcfunction
@@ -1,5 +1,5 @@
 $execute store result score @s $(x_score) run data get entity @s Pos[0] 100
 $execute store result score @s $(z_score) run data get entity @s Pos[2] 100
-$execute unless score @s $(x_score) matches -3100..3200 run tag @s add should-terminate
-$execute unless score @s $(z_score) matches -9600..-4600 run tag @s add should-terminate
+$execute unless score @s $(x_score) matches -20950..-14650 run tag @s add should-terminate
+$execute unless score @s $(z_score) matches 9600..14600 run tag @s add should-terminate
 $execute if entity @s[tag=should-terminate] run $(terminate_command)


### PR DESCRIPTION
# Summary

We plan on showcasing soul event 5 (gun) during the Summit. To facilitate this, we update the hard-coded coordinates to the new Summit arena's rotation and (temporary) position.

---

## Reproducing

```mcfunction
function _:soul/5
```
