### PR TITLE
🔧 add `.spyglassrc.json` and exclude patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,8 @@
 .yarn
 .pnp*
 
-audio
-versions
-
 # auto-ajexport related
-last_exported_hashes.json
+**/last_exported_hashes.json
 datapacks/animated_java/data
 datapacks/animated_java/data.ajmeta
 resourcepack/assets.ajmeta

--- a/.spyglassrc.json
+++ b/.spyglassrc.json
@@ -1,0 +1,13 @@
+{
+  "env": {
+    "exclude": [
+      ".*",
+      "tmp",
+      "build",
+      "**/last_exported_hashes.json",
+      "resourcepack/pack.mcmeta",
+      "datapacks/omega-flowey/data/*/test/",
+      "C:\\Users\\afro\\AppData\\Roaming\\.minecraft\\versions\\1.20.1\\1.20.1\\assets\\minecraft"
+    ]
+  }
+}


### PR DESCRIPTION
# Summary

this will prevent:
- the `build` directory from being parsed on project load
- our MC unit tests from raising IDE errors falsely (since they use modded commands from packtest)
- note all this requires being on my custom spyglass branch until it's merged:

https://github.com/TheAfroOfDoom/Spyglass/tree/watcher-ignore-exclude-config

---

overall generally much faster Spyglass load times, and probably faster performance in general since we're not watching nearly as many files
