### PR TITLE
🍱 add left/top summit petal pipe decorative models

### DIFF
--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/shared/stop/as_active_player.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/shared/stop/as_active_player.mcfunction
@@ -1,5 +1,6 @@
 function entity:directorial/boss_fight/shared/stop/as_spectator
 
+# NOTE: TAG_SUMMIT_HARDCODED
 # Teleport player to finish position unless stop reason is that:
 # - (3) they have left the arena bounds
 # - (4) they have died

--- a/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/terminate/final.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/directorial/boss_fight/summit/phase/soul/terminate/final.mcfunction
@@ -1,4 +1,2 @@
-# NOTE: TAG_SUMMIT_HARDCODED
-# Player location after boss-fight ends
 $execute as $(active_player_uuid) run function entity:directorial/boss_fight/summit/phase/soul/terminate/final/player
 function entity:directorial/boss_fight/shared/stop with storage omegaflowey:bossfight

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/friendliness-pellets/executor/terminate/boss_fight.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/friendliness-pellets/executor/terminate/boss_fight.mcfunction
@@ -1,7 +1,7 @@
 # Set scores
 # TODO(49): determine how to control how long we wait after this attack finishes before
 # letting boss fight start a new attack
-scoreboard players set @s boss-fight.attack.delay 20
+scoreboard players set @s boss-fight.attack.delay 10
 
 # Remove tags
 tag @s remove boss_fight.is_attacking

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/executor/terminate/boss_fight.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-lower/executor/terminate/boss_fight.mcfunction
@@ -1,7 +1,7 @@
 # Set scores
 # TODO(49): determine how to control how long we wait after this attack finishes before
 # letting boss fight start a new attack
-scoreboard players set @s boss-fight.attack.delay 10
+scoreboard players set @s boss-fight.attack.delay 0
 
 # Remove tags
 tag @s remove boss_fight.is_attacking

--- a/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-upper/executor/terminate/boss_fight.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/hostile/omega-flowey/attack/x-bullets-upper/executor/terminate/boss_fight.mcfunction
@@ -1,7 +1,7 @@
 # Set scores
 # TODO(49): determine how to control how long we wait after this attack finishes before
 # letting boss fight start a new attack
-scoreboard players set @s boss-fight.attack.delay 20
+scoreboard players set @s boss-fight.attack.delay 0
 
 # Remove tags
 tag @s remove boss_fight.is_attacking

--- a/datapacks/omega-flowey/data/entity/function/player/room/enter.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/player/room/enter.mcfunction
@@ -1,2 +1,1 @@
-function utils:log/self { text_component: ["enter booth"] }
 tag @s add omegaflowey.player

--- a/datapacks/omega-flowey/data/entity/function/player/room/exit.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/player/room/exit.mcfunction
@@ -1,4 +1,3 @@
-function utils:log/self { text_component: ["exit booth"] }
 tag @s remove omegaflowey.player
 
 # Remove all room tags if necessary

--- a/datapacks/omega-flowey/data/entity/function/player/room/spectator_box/enter.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/player/room/spectator_box/enter.mcfunction
@@ -1,2 +1,1 @@
-function utils:log/self { text_component: ["enter spectator_box"] }
 tag @s add omegaflowey.player.room.spectator_box

--- a/datapacks/omega-flowey/data/entity/function/player/room/spectator_box/exit.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/player/room/spectator_box/exit.mcfunction
@@ -1,2 +1,1 @@
-function utils:log/self { text_component: ["exit spectator_box"] }
 tag @s remove omegaflowey.player.room.spectator_box

--- a/datapacks/omega-flowey/data/entity/function/player/room/underground/enter.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/player/room/underground/enter.mcfunction
@@ -1,2 +1,1 @@
-function utils:log/self { text_component: ["enter underground"] }
 tag @s add omegaflowey.player.room.underground

--- a/datapacks/omega-flowey/data/entity/function/player/room/underground/exit.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/player/room/underground/exit.mcfunction
@@ -1,3 +1,2 @@
-function utils:log/self { text_component: ["exit underground"] }
 tag @s remove omegaflowey.player.room.underground
 tag @s remove omegaflowey.room.is_within.underground

--- a/datapacks/omega-flowey/data/omega-flowey/function/summit/room/cave/setup/text_displays.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/function/summit/room/cave/setup/text_displays.mcfunction
@@ -28,7 +28,8 @@ summon minecraft:text_display -133.5 44.0 44.99 { \
     "decorative-cave", \
     "now-playing-player-name", \
   ], \
-  alignment: "center", background: 0, \
+  alignment: "center", \
+  background: 0, \
   default_background: 0b, \
   line_width: 200, \
   see_through: 0b, \
@@ -113,7 +114,7 @@ summon minecraft:text_display -139.99 45.0 39.0 { \
     "players-in-queue-title", \
   ], \
   alignment: "center", \
-  background: 1073741824, \
+  background: 0, \
   default_background: false, \
   line_width: 200, \
   see_through: false, \
@@ -136,7 +137,7 @@ summon minecraft:text_display -139.99 43.3125 39.0 { \
     "players-in-queue-count", \
   ], \
   alignment: "center", \
-  background: 1073741824, \
+  background: 0, \
   default_background: false, \
   line_width: 200, \
   see_through: false, \
@@ -182,7 +183,7 @@ summon minecraft:text_display -133.5 42.6875 24.01 {\
     "description-github", \
   ], \
   alignment: "center", \
-  background: 1073741824, \
+  background: 0, \
   default_background: 0b, \
   line_width: 100, \
   see_through: 0b, \

--- a/datapacks/omega-flowey/data/omega-flowey/function/summit/room/outside/setup.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/function/summit/room/outside/setup.mcfunction
@@ -17,6 +17,9 @@ execute positioned -109.9375 90.0625 41.9375 rotated 200 15 run \
 function animated_java:summitpetalpipeleft/remove/all
 execute positioned -127.5625 74.0625 31.0 rotated 180.2 -5 run \
   function animated_java:summitpetalpipeleft/summon { args: { animation: 'move', start_animation: true } }
+function animated_java:summitpetalpipetop/remove/all
+execute positioned -123.125 101.5625 35.6875 rotated -116 0 run \
+  function animated_java:summitpetalpipetop/summon { args: { animation: 'move', start_animation: true } }
 
 function omega-flowey:summit/room/outside/setup/text_displays
 

--- a/datapacks/omega-flowey/data/omega-flowey/function/summit/room/outside/setup.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/function/summit/room/outside/setup.mcfunction
@@ -14,6 +14,9 @@ execute positioned -123.47 87.25 33.35 rotated -158.2 12.52 run \
 function animated_java:summit_petal_pipe_right/remove/all
 execute positioned -109.9375 90.0625 41.9375 rotated 200 15 run \
   function animated_java:summit_petal_pipe_right/summon { args: { animation: 'move', start_animation: true } }
+function animated_java:summitpetalpipeleft/remove/all
+execute positioned -127.5625 74.0625 31.0 rotated 180.2 -5 run \
+  function animated_java:summitpetalpipeleft/summon { args: { animation: 'move', start_animation: true } }
 
 function omega-flowey:summit/room/outside/setup/text_displays
 

--- a/datapacks/omega-flowey/data/omega-flowey/function/summit/room/pit/setup/text_displays.mcfunction
+++ b/datapacks/omega-flowey/data/omega-flowey/function/summit/room/pit/setup/text_displays.mcfunction
@@ -1,4 +1,4 @@
-summon minecraft:text_display -108.5 43.9375 38.75 {\
+summon minecraft:text_display -108.5 43.9375 38.5 {\
   Tags: [ \
     "omega-flowey-remastered", \
     "decorative", \

--- a/package-scripts/build.js
+++ b/package-scripts/build.js
@@ -209,7 +209,7 @@ const getSummitResourcepackPaths = () => {
     'pipe',
     'soul',
     'tv_screen',
-    'upper_eye',
+    'x_bullets_shared',
     'black.png',
     'white.png',
   ]);

--- a/resourcepack/assets/omega-flowey/models/entity/decorative/summit-petal-pipe-right.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/decorative/summit-petal-pipe-right.ajblueprint
@@ -2115,7 +2115,7 @@
 		"default": {
 			"name": "default",
 			"display_name": "Default",
-			"uuid": "67ca484e-e789-02ab-2d1f-fdf7faf876a5",
+			"uuid": "c05c66dd-caa3-3a6f-a10a-a2782ce3b48a",
 			"texture_map": {},
 			"excluded_nodes": [],
 			"is_default": true
@@ -2205,7 +2205,7 @@
 							"channel": "position",
 							"data_points": [
 								{
-									"x": 2,
+									"x": "1.5",
 									"y": "0.5",
 									"z": -1
 								}
@@ -2221,7 +2221,7 @@
 							"channel": "position",
 							"data_points": [
 								{
-									"x": -4,
+									"x": "-2",
 									"y": "-1",
 									"z": 1
 								}

--- a/resourcepack/assets/omega-flowey/models/entity/decorative/summitpetalpipeleft.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/decorative/summitpetalpipeleft.ajblueprint
@@ -1971,7 +1971,7 @@
 		"default": {
 			"name": "default",
 			"display_name": "Default",
-			"uuid": "92f4c1c9-3bf3-0e77-7267-d8529e3158cb",
+			"uuid": "ea59cd7b-8c6d-195c-5614-1031bbabd9ee",
 			"texture_map": {},
 			"excluded_nodes": [],
 			"is_default": true
@@ -2061,7 +2061,7 @@
 							"channel": "position",
 							"data_points": [
 								{
-									"x": 2,
+									"x": "1",
 									"y": "0.5",
 									"z": -1
 								}
@@ -2077,7 +2077,7 @@
 							"channel": "position",
 							"data_points": [
 								{
-									"x": -4,
+									"x": "-1",
 									"y": "-1",
 									"z": 1
 								}

--- a/resourcepack/assets/omega-flowey/models/entity/decorative/summitpetalpipeleft.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/decorative/summitpetalpipeleft.ajblueprint
@@ -2,12 +2,12 @@
 	"meta": {
 		"format": "animated_java_blueprint",
 		"format_version": "1.4.2",
-		"uuid": "f6b77d9e-e431-5bb1-fcca-35da857d7179",
-		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\decorative\\summit-petal-pipe-right.ajblueprint",
-		"last_used_export_namespace": "summit_petal_pipe_right"
+		"uuid": "8ff3aa4f-7e6f-00d9-ed98-53ab9cd2b1ad",
+		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\decorative\\summitpetalpipeleft.ajblueprint",
+		"last_used_export_namespace": "summitpetalpipeleft"
 	},
 	"blueprint_settings": {
-		"export_namespace": "summit_petal_pipe_right",
+		"export_namespace": "summitpetalpipeleft",
 		"show_bounding_box": false,
 		"auto_bounding_box": true,
 		"bounding_box": [48, 48],
@@ -45,102 +45,12 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-120, 32, -8],
-			"to": [-104, 80, 8],
-			"autouv": 0,
-			"color": 0,
-			"origin": [-84, -88, 4],
-			"faces": {
-				"north": {
-					"uv": [16, 0, 0, 48],
-					"texture": 0
-				},
-				"east": {
-					"uv": [16, 0, 0, 48],
-					"texture": 0
-				},
-				"south": {
-					"uv": [16, 0, 0, 48],
-					"texture": 0
-				},
-				"west": {
-					"uv": [16, 0, 0, 48],
-					"texture": 0
-				},
-				"up": {
-					"uv": [16, 0, 0, 16],
-					"texture": 0
-				},
-				"down": {
-					"uv": [16, 0, 0, 16],
-					"texture": 0
-				}
-			},
-			"type": "cube",
-			"uuid": "c91df189-5dcc-442c-c254-79a33d6e8549"
-		},
-		{
-			"name": "cube",
-			"box_uv": false,
-			"rescale": false,
-			"locked": false,
-			"light_emission": 0,
-			"render_order": "default",
-			"allow_mirror_modeling": true,
-			"from": [-120, 48, -24],
-			"to": [-104, 64, 24],
-			"autouv": 0,
-			"color": 0,
-			"origin": [-88, -152, 0],
-			"faces": {
-				"north": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
-					"texture": 0
-				},
-				"east": {
-					"uv": [16, 0, 0, 48],
-					"rotation": 90,
-					"texture": 0
-				},
-				"south": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
-					"texture": 0
-				},
-				"west": {
-					"uv": [16, 0, 0, 48],
-					"rotation": 90,
-					"texture": 0
-				},
-				"up": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
-					"texture": 0
-				},
-				"down": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
-					"texture": 0
-				}
-			},
-			"type": "cube",
-			"uuid": "2cacfd08-7f91-93db-ff8f-29507f6cdffa"
-		},
-		{
-			"name": "cube",
-			"box_uv": false,
-			"rescale": false,
-			"locked": false,
-			"light_emission": 0,
-			"render_order": "default",
-			"allow_mirror_modeling": true,
-			"from": [-436, -84, -28.8],
-			"to": [-136, -62.4, 57.6],
+			"from": [24, -29, -36.8],
+			"to": [324, -7.4, 49.6],
 			"autouv": 0,
 			"color": 0,
 			"export": false,
-			"origin": [-280, -84, -28.8],
+			"origin": [180, -29, -36.8],
 			"faces": {
 				"north": {
 					"uv": [0, 14, 16, 16]
@@ -174,12 +84,12 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-436, -62.4, -43.2],
-			"to": [-136, -33.6, 57.6],
+			"from": [24, -7.4, -51.2],
+			"to": [324, 21.4, 49.6],
 			"autouv": 0,
 			"color": 0,
 			"export": false,
-			"origin": [-280, -84, -28.8],
+			"origin": [180, -29, -36.8],
 			"faces": {
 				"north": {
 					"uv": [0, 14, 16, 16]
@@ -213,12 +123,12 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-421.6, -62.4, 57.6],
-			"to": [-150.4, 139.2, 86.4],
+			"from": [38.4, -7.4, 49.6],
+			"to": [309.6, 194.2, 78.4],
 			"autouv": 0,
 			"color": 0,
 			"export": false,
-			"origin": [-280, -84, -28.8],
+			"origin": [180, -29, -36.8],
 			"faces": {
 				"north": {
 					"uv": [0, 2, 16, 6]
@@ -252,12 +162,12 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-421.6, -26.4, 86.4],
-			"to": [-150.4, 139.2, 115.2],
+			"from": [38.4, 27.6, 78.4],
+			"to": [309.6, 193.2, 107.2],
 			"autouv": 0,
 			"color": 0,
 			"export": false,
-			"origin": [-280, -84, -28.8],
+			"origin": [180, -30, -36.8],
 			"faces": {
 				"north": {
 					"uv": [0, 2, 16, 6]
@@ -291,12 +201,12 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-436, 139.2, -43.2],
-			"to": [-136, 168, 57.6],
+			"from": [24, 194.2, -51.2],
+			"to": [324, 223, 49.6],
 			"autouv": 0,
 			"color": 0,
 			"export": false,
-			"origin": [-280, -84, -28.8],
+			"origin": [180, -29, -36.8],
 			"faces": {
 				"north": {
 					"uv": [16, 0, 0, 2]
@@ -330,12 +240,12 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-164.8, -33.6, -43.2],
-			"to": [-136, 139.2, 57.6],
+			"from": [295.2, 21.4, -51.2],
+			"to": [324, 194.2, 49.6],
 			"autouv": 0,
 			"color": 0,
 			"export": false,
-			"origin": [-280, -84, -28.8],
+			"origin": [180, -29, -36.8],
 			"faces": {
 				"north": {
 					"uv": [0, 6, 3, 15]
@@ -369,12 +279,12 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-436, -33.6, -43.2],
-			"to": [-407.2, 139.2, 57.6],
+			"from": [24, 21.4, -51.2],
+			"to": [52.8, 194.2, 49.6],
 			"autouv": 0,
 			"color": 0,
 			"export": false,
-			"origin": [-280, -84, -28.8],
+			"origin": [180, -29, -36.8],
 			"faces": {
 				"north": {
 					"uv": [13, 5, 16, 15]
@@ -408,12 +318,12 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-407.2, -33.6, -36],
-			"to": [-164.8, 139.2, 57.6],
+			"from": [52.8, 21.4, -44],
+			"to": [295.2, 194.2, 49.6],
 			"autouv": 0,
 			"color": 8,
 			"export": false,
-			"origin": [-280, -84, 43.2],
+			"origin": [180, -29, 35.2],
 			"faces": {
 				"north": {
 					"uv": [2, 0.7, 14, 9.61429]
@@ -444,7 +354,7 @@
 		},
 		{
 			"name": "warning",
-			"position": [-286, -8, -34.05],
+			"position": [174, 47, -42.05],
 			"rotation": [0, 0, 0],
 			"ignore_inherited_scale": false,
 			"visibility": true,
@@ -460,7 +370,7 @@
 		},
 		{
 			"name": "soul_event",
-			"position": [-286, 40, -34.05],
+			"position": [174, 95, -42.05],
 			"rotation": [0, 0, 0],
 			"ignore_inherited_scale": false,
 			"visibility": true,
@@ -482,45 +392,39 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-104, 48, -24],
-			"to": [-88, 64, 24],
+			"from": [-107.73333, -41, -8],
+			"to": [-91.73333, 7, 8],
 			"autouv": 0,
-			"color": 0,
-			"origin": [-72, -152, 0],
+			"color": 4,
+			"origin": [388.26667, -216, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"east": {
 					"uv": [16, 0, 0, 48],
-					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"west": {
 					"uv": [16, 0, 0, 48],
-					"rotation": 90,
 					"texture": 0
 				},
 				"up": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"down": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				}
 			},
 			"type": "cube",
-			"uuid": "96f1b387-1feb-9dc4-ceb9-36206a2895ca"
+			"uuid": "9889f7f0-ee6e-f742-ab33-28f511378ef2"
 		},
 		{
 			"name": "cube",
@@ -530,39 +434,45 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-104, 32, -8],
-			"to": [-88, 80, 8],
+			"from": [-107.73333, -25, -24],
+			"to": [-91.73333, -9, 24],
 			"autouv": 0,
-			"color": 0,
-			"origin": [-68, -88, 4],
+			"color": 4,
+			"origin": [384.26667, -280, -8],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
+					"rotation": 180,
 					"texture": 0
 				},
 				"east": {
 					"uv": [16, 0, 0, 48],
+					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
+					"rotation": 180,
 					"texture": 0
 				},
 				"west": {
 					"uv": [16, 0, 0, 48],
+					"rotation": 90,
 					"texture": 0
 				},
 				"up": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 16],
+					"rotation": 90,
 					"texture": 0
 				},
 				"down": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 16],
+					"rotation": 90,
 					"texture": 0
 				}
 			},
 			"type": "cube",
-			"uuid": "3c7b2b0d-275f-ac3a-635d-20fd998cc9d8"
+			"uuid": "78685d60-2b6a-630d-8c7e-9dcc38f626a3"
 		},
 		{
 			"name": "cube",
@@ -572,11 +482,11 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-88, 48, -24],
-			"to": [-72, 64, 24],
+			"from": [-91.73333, -25, -24],
+			"to": [-75.73333, -9, 24],
 			"autouv": 0,
-			"color": 0,
-			"origin": [-56, -152, 0],
+			"color": 4,
+			"origin": [400.26667, -280, -8],
 			"faces": {
 				"north": {
 					"uv": [16, 0, 0, 16],
@@ -610,7 +520,7 @@
 				}
 			},
 			"type": "cube",
-			"uuid": "e0507f50-b1d3-a3d0-d280-c45fa68cfd35"
+			"uuid": "bf9c66b0-b4eb-d988-fee8-a709ea428246"
 		},
 		{
 			"name": "cube",
@@ -620,11 +530,11 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-88, 32, -8],
-			"to": [-72, 80, 8],
+			"from": [-91.73333, -41, -8],
+			"to": [-75.73333, 7, 8],
 			"autouv": 0,
-			"color": 0,
-			"origin": [-52, -88, 4],
+			"color": 4,
+			"origin": [404.26667, -216, -4],
 			"faces": {
 				"north": {
 					"uv": [16, 0, 0, 48],
@@ -652,7 +562,7 @@
 				}
 			},
 			"type": "cube",
-			"uuid": "9c335465-0973-e565-0e5a-8e67aeced59e"
+			"uuid": "aad64195-279d-578f-d466-3b2cfc19327b"
 		},
 		{
 			"name": "cube",
@@ -662,39 +572,45 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-56, 16, -8],
-			"to": [-40, 64, 8],
+			"from": [-75.73333, -25, -24],
+			"to": [-59.73333, -9, 24],
 			"autouv": 0,
-			"color": 0,
-			"origin": [-20, -104, 4],
+			"color": 4,
+			"origin": [416.26667, -280, -8],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
+					"rotation": 180,
 					"texture": 0
 				},
 				"east": {
 					"uv": [16, 0, 0, 48],
+					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
+					"rotation": 180,
 					"texture": 0
 				},
 				"west": {
 					"uv": [16, 0, 0, 48],
+					"rotation": 90,
 					"texture": 0
 				},
 				"up": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 16],
+					"rotation": 90,
 					"texture": 0
 				},
 				"down": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 16],
+					"rotation": 90,
 					"texture": 0
 				}
 			},
 			"type": "cube",
-			"uuid": "e660ba0d-87d6-62a7-7dbc-31d9f843d95f"
+			"uuid": "9fd16021-bacd-b7a8-dee7-2ae5bff90ba6"
 		},
 		{
 			"name": "cube",
@@ -704,45 +620,39 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-56, 32, -24],
-			"to": [-40, 48, 24],
+			"from": [-75.73333, -41, -8],
+			"to": [-59.73333, 7, 8],
 			"autouv": 0,
-			"color": 0,
-			"origin": [-24, -168, 0],
+			"color": 4,
+			"origin": [420.26667, -216, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"east": {
 					"uv": [16, 0, 0, 48],
-					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"west": {
 					"uv": [16, 0, 0, 48],
-					"rotation": 90,
 					"texture": 0
 				},
 				"up": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"down": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				}
 			},
 			"type": "cube",
-			"uuid": "a35da1ec-7424-7dff-ecf7-f1c49730f7a9"
+			"uuid": "c9e7a92f-a699-7df4-f15d-25b9dde3063f"
 		},
 		{
 			"name": "cube",
@@ -752,11 +662,11 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-72, 32, -24],
-			"to": [-56, 48, 24],
+			"from": [-27.73333, 23, -24],
+			"to": [-11.73333, 39, 24],
 			"autouv": 0,
-			"color": 0,
-			"origin": [-40, -168, 0],
+			"color": 4,
+			"origin": [464.26667, -232, -8],
 			"faces": {
 				"north": {
 					"uv": [16, 0, 0, 16],
@@ -790,7 +700,7 @@
 				}
 			},
 			"type": "cube",
-			"uuid": "0ee7749b-95de-937e-f64b-f17b3410371f"
+			"uuid": "e2dd29bf-c9cb-8fd8-6304-9fa46e6d8d3b"
 		},
 		{
 			"name": "cube",
@@ -800,11 +710,11 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-72, 16, -8],
-			"to": [-56, 64, 8],
+			"from": [-43.73333, -9, -8],
+			"to": [-27.73333, 39, 8],
 			"autouv": 0,
-			"color": 0,
-			"origin": [-36, -104, 4],
+			"color": 4,
+			"origin": [452.26667, -184, -4],
 			"faces": {
 				"north": {
 					"uv": [16, 0, 0, 48],
@@ -832,7 +742,7 @@
 				}
 			},
 			"type": "cube",
-			"uuid": "34ebcf9d-a6fc-a8ce-8097-29c4e7fad78a"
+			"uuid": "ce90faaa-4ab3-5c07-909b-302ac95a0a69"
 		},
 		{
 			"name": "cube",
@@ -842,11 +752,11 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-40, 16, -24],
-			"to": [-24, 32, 24],
+			"from": [-43.73333, 7, -24],
+			"to": [-27.73333, 23, 24],
 			"autouv": 0,
-			"color": 0,
-			"origin": [-8, -184, 0],
+			"color": 4,
+			"origin": [448.26667, -248, -8],
 			"faces": {
 				"north": {
 					"uv": [16, 0, 0, 16],
@@ -880,7 +790,7 @@
 				}
 			},
 			"type": "cube",
-			"uuid": "7e3f1a49-67ca-9113-519e-5b5fa771981b"
+			"uuid": "230c8e4f-208d-9f3b-91ab-4c9795aa3fe6"
 		},
 		{
 			"name": "cube",
@@ -890,39 +800,45 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-40, 0, -8],
-			"to": [-24, 48, 8],
+			"from": [-59.73333, -9, -24],
+			"to": [-43.73333, 7, 24],
 			"autouv": 0,
-			"color": 0,
-			"origin": [-4, -120, 4],
+			"color": 4,
+			"origin": [432.26667, -264, -8],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
+					"rotation": 180,
 					"texture": 0
 				},
 				"east": {
 					"uv": [16, 0, 0, 48],
+					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
+					"rotation": 180,
 					"texture": 0
 				},
 				"west": {
 					"uv": [16, 0, 0, 48],
+					"rotation": 90,
 					"texture": 0
 				},
 				"up": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 16],
+					"rotation": 90,
 					"texture": 0
 				},
 				"down": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 16],
+					"rotation": 90,
 					"texture": 0
 				}
 			},
 			"type": "cube",
-			"uuid": "46570dfb-f041-c908-b445-aae0201c4dbf"
+			"uuid": "b65e8fd1-2aa2-87fc-5d8d-9b2208fd2e15"
 		},
 		{
 			"name": "cube",
@@ -932,26 +848,26 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-7.9, -32, -8],
-			"to": [8, 32, 8],
+			"from": [-59.73333, -25, -8],
+			"to": [-43.73333, 23, 8],
 			"autouv": 0,
-			"color": 0,
-			"origin": [28, -152, 4],
+			"color": 4,
+			"origin": [436.26667, -200, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 64],
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"east": {
-					"uv": [16, 0, 0, 64],
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 64],
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"west": {
-					"uv": [16, 0, 0, 64],
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"up": {
@@ -964,7 +880,7 @@
 				}
 			},
 			"type": "cube",
-			"uuid": "e426c280-9d08-446d-4d7e-3e1b112d68a0"
+			"uuid": "0055bdfe-7c8f-cd71-d4cd-bd74b0f1b662"
 		},
 		{
 			"name": "cube",
@@ -974,45 +890,39 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-8, -16, -24],
-			"to": [8, 0, 24],
+			"from": [-27.73333, 7, -8],
+			"to": [-11.73333, 55, 8],
 			"autouv": 0,
-			"color": 0,
-			"origin": [24, -216, 0],
+			"color": 4,
+			"origin": [468.26667, -168, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"east": {
 					"uv": [16, 0, 0, 48],
-					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"west": {
 					"uv": [16, 0, 0, 48],
-					"rotation": 90,
 					"texture": 0
 				},
 				"up": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"down": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				}
 			},
 			"type": "cube",
-			"uuid": "b7adda27-f91b-9745-0d5e-b4dbff598c6f"
+			"uuid": "5b765be3-3a79-2bee-bb35-c4123c96e774"
 		},
 		{
 			"name": "cube",
@@ -1022,45 +932,39 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-24, 16, -24],
-			"to": [-8, 32, 24],
+			"from": [-11.73333, 22, -8],
+			"to": [4.26667, 70, 8],
 			"autouv": 0,
-			"color": 0,
-			"origin": [8, -184, 0],
+			"color": 4,
+			"origin": [484.26667, -153, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"east": {
 					"uv": [16, 0, 0, 48],
-					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"west": {
 					"uv": [16, 0, 0, 48],
-					"rotation": 90,
 					"texture": 0
 				},
 				"up": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"down": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				}
 			},
 			"type": "cube",
-			"uuid": "20bd926c-5f4a-0eb8-a3d2-57eafa6a63ac"
+			"uuid": "c9376758-2de7-e88b-6753-14d0cc81f1da"
 		},
 		{
 			"name": "cube",
@@ -1070,39 +974,45 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-24, 0, -8],
-			"to": [-8, 48, 8],
+			"from": [-11.73333, 38, -24],
+			"to": [4.26667, 70, 24],
 			"autouv": 0,
-			"color": 0,
-			"origin": [12, -120, 4],
+			"color": 4,
+			"origin": [480.26667, -217, -8],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
+					"rotation": 180,
 					"texture": 0
 				},
 				"east": {
-					"uv": [16, 0, 0, 48],
+					"uv": [32, 0, 0, 48],
+					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 32],
+					"rotation": 180,
 					"texture": 0
 				},
 				"west": {
-					"uv": [16, 0, 0, 48],
+					"uv": [32, 0, 0, 48],
+					"rotation": 90,
 					"texture": 0
 				},
 				"up": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 16],
+					"rotation": 90,
 					"texture": 0
 				},
 				"down": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 16],
+					"rotation": 90,
 					"texture": 0
 				}
 			},
 			"type": "cube",
-			"uuid": "6a19dfef-4900-7181-fb9e-3b89bd819705"
+			"uuid": "67332659-9530-e2b6-6c6a-7615baec817a"
 		},
 		{
 			"name": "cube",
@@ -1112,26 +1022,26 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [56, -80, -8],
-			"to": [72, -32, 8],
+			"from": [4.26667, 38, -8],
+			"to": [20.26667, 70, 8],
 			"autouv": 0,
-			"color": 0,
-			"origin": [92, -200, 4],
+			"color": 4,
+			"origin": [500.26667, -137, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 32],
 					"texture": 0
 				},
 				"east": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 32],
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 32],
 					"texture": 0
 				},
 				"west": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 32],
 					"texture": 0
 				},
 				"up": {
@@ -1144,7 +1054,7 @@
 				}
 			},
 			"type": "cube",
-			"uuid": "620992d5-9468-b60a-4c78-5788e05dd6b2"
+			"uuid": "5b7192f2-cf32-9500-afa1-c6ddaaf6754e"
 		},
 		{
 			"name": "cube",
@@ -1154,45 +1064,39 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [56, -64, -24],
-			"to": [72, -48, 24],
+			"from": [4.26667, 70, -24],
+			"to": [20.26667, 118, 24],
 			"autouv": 0,
-			"color": 0,
-			"origin": [88, -264, 0],
+			"color": 4,
+			"origin": [500.26667, -105, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"east": {
 					"uv": [16, 0, 0, 48],
-					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"west": {
 					"uv": [16, 0, 0, 48],
-					"rotation": 90,
 					"texture": 0
 				},
 				"up": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"down": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				}
 			},
 			"type": "cube",
-			"uuid": "51d23020-279b-9643-c618-7bd274a6c556"
+			"uuid": "d7e657c7-204b-1449-2a20-7ca6a38a0b67"
 		},
 		{
 			"name": "cube",
@@ -1202,39 +1106,45 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [40, -80, -8],
-			"to": [56, -32, 8],
+			"from": [-11.73333, 70, -8],
+			"to": [36.26667, 118, 8],
 			"autouv": 0,
-			"color": 0,
-			"origin": [76, -200, 4],
+			"color": 4,
+			"origin": [512.26667, -185, 8],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
+					"rotation": 180,
 					"texture": 0
 				},
 				"east": {
 					"uv": [16, 0, 0, 48],
+					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
+					"rotation": 180,
 					"texture": 0
 				},
 				"west": {
 					"uv": [16, 0, 0, 48],
+					"rotation": 90,
 					"texture": 0
 				},
 				"up": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 16],
+					"rotation": 90,
 					"texture": 0
 				},
 				"down": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 16],
+					"rotation": 90,
 					"texture": 0
 				}
 			},
 			"type": "cube",
-			"uuid": "afe82ceb-d46f-7677-e6ef-7128df834be1"
+			"uuid": "54141208-2426-f4c5-f2bc-b17b909cc0eb"
 		},
 		{
 			"name": "cube",
@@ -1244,45 +1154,39 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [40, -64, -24],
-			"to": [56, -48, 24],
+			"from": [4.26667, 118, -8],
+			"to": [20.26667, 134, 8],
 			"autouv": 0,
-			"color": 0,
-			"origin": [72, -264, 0],
+			"color": 4,
+			"origin": [500.26667, -57, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 32],
 					"texture": 0
 				},
 				"east": {
-					"uv": [16, 0, 0, 48],
-					"rotation": 90,
+					"uv": [16, 0, 0, 32],
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 32],
 					"texture": 0
 				},
 				"west": {
-					"uv": [16, 0, 0, 48],
-					"rotation": 90,
+					"uv": [16, 0, 0, 32],
 					"texture": 0
 				},
 				"up": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"down": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				}
 			},
 			"type": "cube",
-			"uuid": "6c00818e-97c9-301a-77d4-48b7683b2a5d"
+			"uuid": "3ccfa2ce-1455-4412-5537-8d97d6549358"
 		},
 		{
 			"name": "cube",
@@ -1292,39 +1196,45 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [8, -48, -8],
-			"to": [24, 16, 8],
+			"from": [-11.73333, 118, -24],
+			"to": [4.26667, 134, 24],
 			"autouv": 0,
-			"color": 0,
-			"origin": [44, -168, 4],
+			"color": 4,
+			"origin": [480.26667, -136, -8],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 64],
+					"uv": [16, 0, 0, 16],
+					"rotation": 180,
 					"texture": 0
 				},
 				"east": {
-					"uv": [16, 0, 0, 64],
+					"uv": [16, 0, 0, 48],
+					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 64],
+					"uv": [16, 0, 0, 16],
+					"rotation": 180,
 					"texture": 0
 				},
 				"west": {
-					"uv": [16, 0, 0, 64],
+					"uv": [16, 0, 0, 48],
+					"rotation": 90,
 					"texture": 0
 				},
 				"up": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 16],
+					"rotation": 90,
 					"texture": 0
 				},
 				"down": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 16],
+					"rotation": 90,
 					"texture": 0
 				}
 			},
 			"type": "cube",
-			"uuid": "6b8c03ea-0a7e-4e49-8dd5-0f63d092c953"
+			"uuid": "e27ff337-8b3a-90cf-5f89-b4539529b9bd"
 		},
 		{
 			"name": "cube",
@@ -1334,11 +1244,11 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [8, -32, -24],
-			"to": [24, -16, 24],
+			"from": [-27.73333, 134, -24],
+			"to": [-11.73333, 150, 24],
 			"autouv": 0,
-			"color": 0,
-			"origin": [40, -232, 0],
+			"color": 4,
+			"origin": [464.26667, -120, -8],
 			"faces": {
 				"north": {
 					"uv": [16, 0, 0, 16],
@@ -1372,7 +1282,7 @@
 				}
 			},
 			"type": "cube",
-			"uuid": "04a37f24-aefe-4f2a-3c4b-a1dd5105f2c7"
+			"uuid": "99c38cb4-c41e-bd27-8b27-ce533adbe200"
 		},
 		{
 			"name": "cube",
@@ -1382,11 +1292,11 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [24, -48, -24],
-			"to": [40, -32, 24],
+			"from": [-43.73333, 134, -24],
+			"to": [-27.73333, 150, 24],
 			"autouv": 0,
-			"color": 0,
-			"origin": [56, -248, 0],
+			"color": 4,
+			"origin": [448.26667, -120, -8],
 			"faces": {
 				"north": {
 					"uv": [16, 0, 0, 16],
@@ -1420,7 +1330,7 @@
 				}
 			},
 			"type": "cube",
-			"uuid": "93f20674-e6d2-312a-f88a-02c078ba4ab3"
+			"uuid": "03da1173-1061-8872-f47a-d0a05d29a462"
 		},
 		{
 			"name": "cube",
@@ -1430,39 +1340,45 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [24, -64, -8],
-			"to": [40, -16, 8],
+			"from": [-59.73333, 150, -24],
+			"to": [-43.73333, 166, 24],
 			"autouv": 0,
-			"color": 0,
-			"origin": [60, -184, 4],
+			"color": 4,
+			"origin": [432.26667, -104, -8],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
+					"rotation": 180,
 					"texture": 0
 				},
 				"east": {
 					"uv": [16, 0, 0, 48],
+					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
+					"rotation": 180,
 					"texture": 0
 				},
 				"west": {
 					"uv": [16, 0, 0, 48],
+					"rotation": 90,
 					"texture": 0
 				},
 				"up": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 16],
+					"rotation": 90,
 					"texture": 0
 				},
 				"down": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 16],
+					"rotation": 90,
 					"texture": 0
 				}
 			},
 			"type": "cube",
-			"uuid": "ff6dc59e-d0e5-cd08-d110-de0b8ef7fb45"
+			"uuid": "f300a99f-7f41-8b67-20aa-993ee2b0e0bb"
 		},
 		{
 			"name": "cube",
@@ -1472,39 +1388,45 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [104, -96, -8],
-			"to": [120, -48, 8],
+			"from": [-75.73333, 166, -24],
+			"to": [-59.73333, 198, 24],
 			"autouv": 0,
-			"color": 0,
-			"origin": [140, -216, 4],
+			"color": 4,
+			"origin": [416.26667, -88, -8],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
+					"rotation": 180,
 					"texture": 0
 				},
 				"east": {
-					"uv": [16, 0, 0, 48],
+					"uv": [32, 0, 0, 48],
+					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 32],
+					"rotation": 180,
 					"texture": 0
 				},
 				"west": {
-					"uv": [16, 0, 0, 48],
+					"uv": [32, 0, 0, 48],
+					"rotation": 90,
 					"texture": 0
 				},
 				"up": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 16],
+					"rotation": 90,
 					"texture": 0
 				},
 				"down": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 16],
+					"rotation": 90,
 					"texture": 0
 				}
 			},
 			"type": "cube",
-			"uuid": "ee19afca-73ab-80e3-c571-75bb13c0cbb9"
+			"uuid": "b3f78e2d-24a1-28cc-32d3-2ebf67f169c9"
 		},
 		{
 			"name": "cube",
@@ -1514,11 +1436,11 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [104, -80, -24],
-			"to": [120, -64, 24],
+			"from": [-91.73333, 198, -24],
+			"to": [-75.73333, 246, 24],
 			"autouv": 0,
-			"color": 0,
-			"origin": [136, -280, 0],
+			"color": 4,
+			"origin": [400.26667, -56, -8],
 			"faces": {
 				"north": {
 					"uv": [16, 0, 0, 16],
@@ -1526,17 +1448,17 @@
 					"texture": 0
 				},
 				"east": {
-					"uv": [16, 0, 0, 48],
+					"uv": [32, 0, 0, 48],
 					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 16],
+					"uv": [16, 0, 0, 32],
 					"rotation": 180,
 					"texture": 0
 				},
 				"west": {
-					"uv": [16, 0, 0, 48],
+					"uv": [32, 0, 0, 48],
 					"rotation": 90,
 					"texture": 0
 				},
@@ -1552,7 +1474,7 @@
 				}
 			},
 			"type": "cube",
-			"uuid": "228e049f-e402-704f-a8e8-2dfc3a4245f2"
+			"uuid": "90768b9c-8e64-d702-46a0-1cf2b005cf69"
 		},
 		{
 			"name": "cube",
@@ -1562,11 +1484,11 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [88, -96, -8],
-			"to": [104, -48, 8],
+			"from": [-11.73333, 134, -8],
+			"to": [4.26667, 150, 8],
 			"autouv": 0,
-			"color": 0,
-			"origin": [124, -216, 4],
+			"color": 4,
+			"origin": [484.26667, -57, -4],
 			"faces": {
 				"north": {
 					"uv": [16, 0, 0, 48],
@@ -1594,7 +1516,7 @@
 				}
 			},
 			"type": "cube",
-			"uuid": "baddf2a5-26dd-b6c1-f0ad-e42b36332182"
+			"uuid": "f02cdc67-d711-baa4-c096-f98ae199719c"
 		},
 		{
 			"name": "cube",
@@ -1604,45 +1526,39 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [88, -80, -24],
-			"to": [104, -64, 24],
+			"from": [-43.73333, 118, -8],
+			"to": [-11.73333, 166, 8],
 			"autouv": 0,
-			"color": 0,
-			"origin": [120, -280, 0],
+			"color": 4,
+			"origin": [468.26667, -57, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"east": {
 					"uv": [16, 0, 0, 48],
-					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"west": {
 					"uv": [16, 0, 0, 48],
-					"rotation": 90,
 					"texture": 0
 				},
 				"up": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"down": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				}
 			},
 			"type": "cube",
-			"uuid": "965b0005-4f30-f47c-b079-b9b173a8ae38"
+			"uuid": "00e15a44-6a4e-366d-473f-89c8b8351b95"
 		},
 		{
 			"name": "cube",
@@ -1652,45 +1568,39 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [72, -80, -24],
-			"to": [88, -64, 24],
+			"from": [-59.73333, 134, -8],
+			"to": [-43.73333, 198, 8],
 			"autouv": 0,
-			"color": 0,
-			"origin": [104, -280, 0],
+			"color": 4,
+			"origin": [436.26667, -41, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"east": {
 					"uv": [16, 0, 0, 48],
-					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"west": {
 					"uv": [16, 0, 0, 48],
-					"rotation": 90,
 					"texture": 0
 				},
 				"up": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"down": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				}
 			},
 			"type": "cube",
-			"uuid": "5020cb7e-1417-c8c2-f1e4-df2f80636d4c"
+			"uuid": "5e340988-b4bf-311f-716f-7b5274e8db86"
 		},
 		{
 			"name": "cube",
@@ -1700,11 +1610,11 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [72, -96, -8],
-			"to": [88, -48, 8],
+			"from": [-75.73333, 150, -8],
+			"to": [-59.73333, 166, 8],
 			"autouv": 0,
-			"color": 0,
-			"origin": [108, -216, 4],
+			"color": 4,
+			"origin": [420.26667, -25, -4],
 			"faces": {
 				"north": {
 					"uv": [16, 0, 0, 48],
@@ -1732,7 +1642,7 @@
 				}
 			},
 			"type": "cube",
-			"uuid": "2041a316-6298-de31-85b8-4402f260a433"
+			"uuid": "bcb3e10d-72a1-142f-8852-d8c3388ab0cf"
 		},
 		{
 			"name": "cube",
@@ -1742,45 +1652,39 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [-8, 0, -24],
-			"to": [8, 16, 24],
+			"from": [-91.73333, 166, -8],
+			"to": [-75.73333, 198, 8],
 			"autouv": 0,
-			"color": 0,
-			"origin": [24, -200, 0],
+			"color": 4,
+			"origin": [404.26667, -9, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"east": {
 					"uv": [16, 0, 0, 48],
-					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"west": {
 					"uv": [16, 0, 0, 48],
-					"rotation": 90,
 					"texture": 0
 				},
 				"up": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"down": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				}
 			},
 			"type": "cube",
-			"uuid": "16765039-45be-63d3-8294-82d224829fea"
+			"uuid": "ae508375-cb0a-331a-357a-ba1926ee504f"
 		},
 		{
 			"name": "cube",
@@ -1790,45 +1694,39 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [120, -64, -24],
-			"to": [136, -48, 24],
+			"from": [-107.73333, 198, -8],
+			"to": [-59.73333, 246, 8],
 			"autouv": 0,
-			"color": 0,
-			"origin": [152, -264, 0],
+			"color": 4,
+			"origin": [404.26667, 23, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"east": {
 					"uv": [16, 0, 0, 48],
-					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 16],
-					"rotation": 180,
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"west": {
 					"uv": [16, 0, 0, 48],
-					"rotation": 90,
 					"texture": 0
 				},
 				"up": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"down": {
-					"uv": [48, 0, 0, 16],
-					"rotation": 90,
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				}
 			},
 			"type": "cube",
-			"uuid": "b803a2f9-7008-70b2-e3d8-4c442afcb56e"
+			"uuid": "3ed1ae9f-f4ce-c25d-1af1-d7c0cde3f24c"
 		},
 		{
 			"name": "cube",
@@ -1838,53 +1736,11 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [120, -80, -8],
-			"to": [136, -32, 8],
+			"from": [-123.73333, -25, -24],
+			"to": [-107.73333, -9, 24],
 			"autouv": 0,
-			"color": 0,
-			"origin": [156, -200, 4],
-			"faces": {
-				"north": {
-					"uv": [16, 0, 0, 48],
-					"texture": 0
-				},
-				"east": {
-					"uv": [16, 0, 0, 48],
-					"texture": 0
-				},
-				"south": {
-					"uv": [16, 0, 0, 48],
-					"texture": 0
-				},
-				"west": {
-					"uv": [16, 0, 0, 48],
-					"texture": 0
-				},
-				"up": {
-					"uv": [16, 0, 0, 16],
-					"texture": 0
-				},
-				"down": {
-					"uv": [16, 0, 0, 16],
-					"texture": 0
-				}
-			},
-			"type": "cube",
-			"uuid": "127a6878-6938-d9ba-3ad0-b77aec507d15"
-		},
-		{
-			"name": "cube",
-			"box_uv": false,
-			"rescale": false,
-			"locked": false,
-			"light_emission": 0,
-			"render_order": "default",
-			"allow_mirror_modeling": true,
-			"from": [136, -64, -24],
-			"to": [152, -48, 24],
-			"autouv": 0,
-			"color": 0,
-			"origin": [168, -264, 0],
+			"color": 4,
+			"origin": [368.26667, -280, -8],
 			"faces": {
 				"north": {
 					"uv": [16, 0, 0, 16],
@@ -1918,7 +1774,7 @@
 				}
 			},
 			"type": "cube",
-			"uuid": "31f771ba-5816-9fac-cb63-32e11610592d"
+			"uuid": "49bba9f6-b8a5-f335-c4ef-dd2c9a96b8a0"
 		},
 		{
 			"name": "cube",
@@ -1928,11 +1784,11 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [136, -80, -8],
-			"to": [152, -32, 8],
+			"from": [-123.73333, -41, -8],
+			"to": [-107.73333, 7, 8],
 			"autouv": 0,
-			"color": 0,
-			"origin": [172, -200, 4],
+			"color": 4,
+			"origin": [372.26667, -216, -4],
 			"faces": {
 				"north": {
 					"uv": [16, 0, 0, 48],
@@ -1960,14 +1816,15 @@
 				}
 			},
 			"type": "cube",
-			"uuid": "4f778844-8867-6eea-8004-9f5f94c1756b"
+			"uuid": "500095a7-bdc0-3ef8-729b-4c42e9c4727b"
 		}
 	],
 	"outliner": [
 		{
 			"name": "root",
-			"origin": [28, 0, 4],
-			"color": 0,
+			"origin": [-41.86667, 81.33333, 0],
+			"rotation": [0, -180, 0],
+			"color": 4,
 			"configs": {
 				"variants": {},
 				"default": {
@@ -1976,7 +1833,7 @@
 					"use_nbt": true
 				}
 			},
-			"uuid": "474eed47-47f2-8d73-a30b-234f53967c2b",
+			"uuid": "20ae5770-90a2-4ba2-638b-8dd661f19a1e",
 			"export": true,
 			"mirror_uv": false,
 			"isOpen": true,
@@ -1984,41 +1841,38 @@
 			"visibility": true,
 			"autouv": 0,
 			"children": [
-				"2cacfd08-7f91-93db-ff8f-29507f6cdffa",
-				"c91df189-5dcc-442c-c254-79a33d6e8549",
-				"3c7b2b0d-275f-ac3a-635d-20fd998cc9d8",
-				"96f1b387-1feb-9dc4-ceb9-36206a2895ca",
-				"9c335465-0973-e565-0e5a-8e67aeced59e",
-				"e0507f50-b1d3-a3d0-d280-c45fa68cfd35",
-				"2041a316-6298-de31-85b8-4402f260a433",
-				"5020cb7e-1417-c8c2-f1e4-df2f80636d4c",
-				"965b0005-4f30-f47c-b079-b9b173a8ae38",
-				"baddf2a5-26dd-b6c1-f0ad-e42b36332182",
-				"228e049f-e402-704f-a8e8-2dfc3a4245f2",
-				"ee19afca-73ab-80e3-c571-75bb13c0cbb9",
-				"34ebcf9d-a6fc-a8ce-8097-29c4e7fad78a",
-				"0ee7749b-95de-937e-f64b-f17b3410371f",
-				"a35da1ec-7424-7dff-ecf7-f1c49730f7a9",
-				"e660ba0d-87d6-62a7-7dbc-31d9f843d95f",
-				"46570dfb-f041-c908-b445-aae0201c4dbf",
-				"7e3f1a49-67ca-9113-519e-5b5fa771981b",
-				"6a19dfef-4900-7181-fb9e-3b89bd819705",
-				"20bd926c-5f4a-0eb8-a3d2-57eafa6a63ac",
-				"ff6dc59e-d0e5-cd08-d110-de0b8ef7fb45",
-				"93f20674-e6d2-312a-f88a-02c078ba4ab3",
-				"04a37f24-aefe-4f2a-3c4b-a1dd5105f2c7",
-				"6b8c03ea-0a7e-4e49-8dd5-0f63d092c953",
-				"6c00818e-97c9-301a-77d4-48b7683b2a5d",
-				"afe82ceb-d46f-7677-e6ef-7128df834be1",
-				"51d23020-279b-9643-c618-7bd274a6c556",
-				"620992d5-9468-b60a-4c78-5788e05dd6b2",
-				"127a6878-6938-d9ba-3ad0-b77aec507d15",
-				"b803a2f9-7008-70b2-e3d8-4c442afcb56e",
-				"4f778844-8867-6eea-8004-9f5f94c1756b",
-				"31f771ba-5816-9fac-cb63-32e11610592d",
-				"b7adda27-f91b-9745-0d5e-b4dbff598c6f",
-				"16765039-45be-63d3-8294-82d224829fea",
-				"e426c280-9d08-446d-4d7e-3e1b112d68a0"
+				"9889f7f0-ee6e-f742-ab33-28f511378ef2",
+				"78685d60-2b6a-630d-8c7e-9dcc38f626a3",
+				"500095a7-bdc0-3ef8-729b-4c42e9c4727b",
+				"49bba9f6-b8a5-f335-c4ef-dd2c9a96b8a0",
+				"bf9c66b0-b4eb-d988-fee8-a709ea428246",
+				"aad64195-279d-578f-d466-3b2cfc19327b",
+				"9fd16021-bacd-b7a8-dee7-2ae5bff90ba6",
+				"c9e7a92f-a699-7df4-f15d-25b9dde3063f",
+				"5b765be3-3a79-2bee-bb35-c4123c96e774",
+				"00e15a44-6a4e-366d-473f-89c8b8351b95",
+				"5e340988-b4bf-311f-716f-7b5274e8db86",
+				"bcb3e10d-72a1-142f-8852-d8c3388ab0cf",
+				"ae508375-cb0a-331a-357a-ba1926ee504f",
+				"3ed1ae9f-f4ce-c25d-1af1-d7c0cde3f24c",
+				"f02cdc67-d711-baa4-c096-f98ae199719c",
+				"0055bdfe-7c8f-cd71-d4cd-bd74b0f1b662",
+				"b65e8fd1-2aa2-87fc-5d8d-9b2208fd2e15",
+				"230c8e4f-208d-9f3b-91ab-4c9795aa3fe6",
+				"ce90faaa-4ab3-5c07-909b-302ac95a0a69",
+				"e2dd29bf-c9cb-8fd8-6304-9fa46e6d8d3b",
+				"e27ff337-8b3a-90cf-5f89-b4539529b9bd",
+				"99c38cb4-c41e-bd27-8b27-ce533adbe200",
+				"03da1173-1061-8872-f47a-d0a05d29a462",
+				"f300a99f-7f41-8b67-20aa-993ee2b0e0bb",
+				"54141208-2426-f4c5-f2bc-b17b909cc0eb",
+				"d7e657c7-204b-1449-2a20-7ca6a38a0b67",
+				"67332659-9530-e2b6-6c6a-7615baec817a",
+				"b3f78e2d-24a1-28cc-32d3-2ebf67f169c9",
+				"90768b9c-8e64-d702-46a0-1cf2b005cf69",
+				"c9376758-2de7-e88b-6753-14d0cc81f1da",
+				"5b7192f2-cf32-9500-afa1-c6ddaaf6754e",
+				"3ccfa2ce-1455-4412-5537-8d97d6549358"
 			]
 		},
 		{
@@ -2115,7 +1969,7 @@
 		"default": {
 			"name": "default",
 			"display_name": "Default",
-			"uuid": "67ca484e-e789-02ab-2d1f-fdf7faf876a5",
+			"uuid": "92f4c1c9-3bf3-0e77-7267-d8529e3158cb",
 			"texture_map": {},
 			"excluded_nodes": [],
 			"is_default": true
@@ -2165,7 +2019,7 @@
 				}
 			],
 			"animators": {
-				"474eed47-47f2-8d73-a30b-234f53967c2b": {
+				"20ae5770-90a2-4ba2-638b-8dd661f19a1e": {
 					"name": "root",
 					"type": "bone",
 					"keyframes": [
@@ -2178,7 +2032,7 @@
 									"z": "0"
 								}
 							],
-							"uuid": "1f0f154a-dce5-c7cd-894f-2dad466177aa",
+							"uuid": "7bf61026-7502-ad75-acdc-5ba08300dca1",
 							"time": 0,
 							"color": -1,
 							"interpolation": "catmullrom",
@@ -2194,7 +2048,7 @@
 									"z": "0"
 								}
 							],
-							"uuid": "a38fe458-aa33-c90d-c372-551b7ad47be1",
+							"uuid": "6dc7e00c-3f81-6b90-7036-9ccdc2f7b99d",
 							"time": 3,
 							"color": -1,
 							"interpolation": "catmullrom",
@@ -2210,7 +2064,7 @@
 									"z": -1
 								}
 							],
-							"uuid": "9b98ed23-39ff-8301-5719-109cb0d16e0f",
+							"uuid": "d8c03078-00dc-c337-8c3a-59ac547a26cb",
 							"time": 1,
 							"color": -1,
 							"interpolation": "catmullrom",
@@ -2226,7 +2080,7 @@
 									"z": 1
 								}
 							],
-							"uuid": "6c2176c1-7c43-c12c-dd9c-34611cd893fc",
+							"uuid": "965e0131-6a44-bf96-f3b3-6fed7caebfbc",
 							"time": 2,
 							"color": -1,
 							"interpolation": "catmullrom",
@@ -2242,7 +2096,7 @@
 									"z": "1"
 								}
 							],
-							"uuid": "27737606-7dfd-c3f7-3b58-ed390d695f80",
+							"uuid": "3e0d21d9-62e2-ceb2-f502-77e7043c050f",
 							"time": 0.45,
 							"color": -1,
 							"uniform": true,
@@ -2259,7 +2113,7 @@
 									"z": 1
 								}
 							],
-							"uuid": "04450786-0948-44e1-abed-69789b3d7304",
+							"uuid": "4674be8c-2de8-f328-330c-82143acdbe46",
 							"time": 0.8,
 							"color": -1,
 							"uniform": true,
@@ -2276,7 +2130,7 @@
 									"z": "1.02"
 								}
 							],
-							"uuid": "1c36032c-c051-951f-5844-009a097c7659",
+							"uuid": "0f4393df-e7fb-213a-2394-034d5778a48f",
 							"time": 0.6,
 							"color": -1,
 							"uniform": true,

--- a/resourcepack/assets/omega-flowey/models/entity/decorative/summitpetalpipeleft.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/decorative/summitpetalpipeleft.ajblueprint
@@ -1984,7 +1984,7 @@
 			"name": "move",
 			"loop": "loop",
 			"override": false,
-			"length": 3,
+			"length": 3.5,
 			"snapping": 20,
 			"selected": true,
 			"saved": false,
@@ -2051,7 +2051,7 @@
 								}
 							],
 							"uuid": "6dc7e00c-3f81-6b90-7036-9ccdc2f7b99d",
-							"time": 3,
+							"time": 3.5,
 							"color": -1,
 							"interpolation": "catmullrom",
 							"easing": "linear",
@@ -2116,7 +2116,7 @@
 								}
 							],
 							"uuid": "4674be8c-2de8-f328-330c-82143acdbe46",
-							"time": 0.8,
+							"time": 1,
 							"color": -1,
 							"uniform": true,
 							"interpolation": "catmullrom",

--- a/resourcepack/assets/omega-flowey/models/entity/decorative/summitpetalpipeleft.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/decorative/summitpetalpipeleft.ajblueprint
@@ -891,25 +891,25 @@
 			"render_order": "default",
 			"allow_mirror_modeling": true,
 			"from": [-27.73333, 7, -8],
-			"to": [-11.73333, 55, 8],
+			"to": [-11.73333, 71, 8],
 			"autouv": 0,
 			"color": 4,
 			"origin": [468.26667, -168, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 64],
 					"texture": 0
 				},
 				"east": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 64],
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 64],
 					"texture": 0
 				},
 				"west": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 64],
 					"texture": 0
 				},
 				"up": {
@@ -1075,7 +1075,7 @@
 					"texture": 0
 				},
 				"east": {
-					"uv": [16, 0, 0, 48],
+					"uv": [48, 0, 0, 48],
 					"texture": 0
 				},
 				"south": {
@@ -1087,11 +1087,11 @@
 					"texture": 0
 				},
 				"up": {
-					"uv": [16, 0, 0, 16],
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				},
 				"down": {
-					"uv": [16, 0, 0, 16],
+					"uv": [16, 0, 0, 48],
 					"texture": 0
 				}
 			},
@@ -1113,32 +1113,32 @@
 			"origin": [512.26667, -185, 8],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 48],
 					"rotation": 180,
 					"texture": 0
 				},
 				"east": {
-					"uv": [16, 0, 0, 48],
+					"uv": [48, 0, 0, 16],
 					"rotation": 90,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 48],
 					"rotation": 180,
 					"texture": 0
 				},
 				"west": {
-					"uv": [16, 0, 0, 48],
+					"uv": [48, 0, 0, 16],
 					"rotation": 90,
 					"texture": 0
 				},
 				"up": {
-					"uv": [48, 0, 0, 16],
+					"uv": [16, 0, 0, 48],
 					"rotation": 90,
 					"texture": 0
 				},
 				"down": {
-					"uv": [48, 0, 0, 16],
+					"uv": [16, 0, 0, 48],
 					"rotation": 90,
 					"texture": 0
 				}
@@ -1161,19 +1161,19 @@
 			"origin": [500.26667, -57, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 32],
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"east": {
-					"uv": [16, 0, 0, 32],
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 32],
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"west": {
-					"uv": [16, 0, 0, 32],
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"up": {
@@ -1443,23 +1443,23 @@
 			"origin": [400.26667, -56, -8],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 16],
+					"uv": [16, 0, 0, 48],
 					"rotation": 180,
 					"texture": 0
 				},
 				"east": {
-					"uv": [32, 0, 0, 48],
-					"rotation": 90,
+					"uv": [48, 0, 0, 48],
+					"rotation": 180,
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 32],
+					"uv": [16, 0, 0, 48],
 					"rotation": 180,
 					"texture": 0
 				},
 				"west": {
-					"uv": [32, 0, 0, 48],
-					"rotation": 90,
+					"uv": [48, 0, 0, 48],
+					"rotation": 180,
 					"texture": 0
 				},
 				"up": {
@@ -1491,19 +1491,19 @@
 			"origin": [484.26667, -57, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"east": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"west": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"up": {
@@ -1533,7 +1533,7 @@
 			"origin": [468.26667, -57, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 48],
+					"uv": [32, 0, 0, 48],
 					"texture": 0
 				},
 				"east": {
@@ -1541,7 +1541,7 @@
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 48],
+					"uv": [32, 0, 0, 48],
 					"texture": 0
 				},
 				"west": {
@@ -1549,11 +1549,11 @@
 					"texture": 0
 				},
 				"up": {
-					"uv": [16, 0, 0, 16],
+					"uv": [32, 0, 0, 16],
 					"texture": 0
 				},
 				"down": {
-					"uv": [16, 0, 0, 16],
+					"uv": [32, 0, 0, 16],
 					"texture": 0
 				}
 			},
@@ -1575,19 +1575,19 @@
 			"origin": [436.26667, -41, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 64],
 					"texture": 0
 				},
 				"east": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 64],
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 64],
 					"texture": 0
 				},
 				"west": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 64],
 					"texture": 0
 				},
 				"up": {
@@ -1617,19 +1617,19 @@
 			"origin": [420.26667, -25, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"east": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"west": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 16],
 					"texture": 0
 				},
 				"up": {
@@ -1659,19 +1659,19 @@
 			"origin": [404.26667, -9, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 32],
 					"texture": 0
 				},
 				"east": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 32],
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 32],
 					"texture": 0
 				},
 				"west": {
-					"uv": [16, 0, 0, 48],
+					"uv": [16, 0, 0, 32],
 					"texture": 0
 				},
 				"up": {
@@ -1695,13 +1695,14 @@
 			"render_order": "default",
 			"allow_mirror_modeling": true,
 			"from": [-107.73333, 198, -8],
-			"to": [-59.73333, 246, 8],
+			"to": [-59.73333, 245.9, 8],
 			"autouv": 0,
 			"color": 4,
 			"origin": [404.26667, 23, -4],
 			"faces": {
 				"north": {
-					"uv": [16, 0, 0, 48],
+					"uv": [48, 0, 0, 48],
+					"rotation": 180,
 					"texture": 0
 				},
 				"east": {
@@ -1709,7 +1710,8 @@
 					"texture": 0
 				},
 				"south": {
-					"uv": [16, 0, 0, 48],
+					"uv": [48, 0, 0, 48],
+					"rotation": 180,
 					"texture": 0
 				},
 				"west": {
@@ -1717,11 +1719,11 @@
 					"texture": 0
 				},
 				"up": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 16],
 					"texture": 0
 				},
 				"down": {
-					"uv": [16, 0, 0, 16],
+					"uv": [48, 0, 0, 16],
 					"texture": 0
 				}
 			},
@@ -1885,7 +1887,7 @@
 			"uuid": "b309dce6-da19-98c1-e15e-c4ed2d0255f7",
 			"export": false,
 			"mirror_uv": false,
-			"isOpen": false,
+			"isOpen": true,
 			"locked": false,
 			"visibility": true,
 			"autouv": 0,
@@ -1918,7 +1920,7 @@
 					"uuid": "3e6a4440-7393-7ec5-7963-38c7563feb2a",
 					"export": false,
 					"mirror_uv": false,
-					"isOpen": false,
+					"isOpen": true,
 					"locked": false,
 					"visibility": true,
 					"autouv": 0,

--- a/resourcepack/assets/omega-flowey/models/entity/decorative/summitpetalpipetop.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/decorative/summitpetalpipetop.ajblueprint
@@ -491,19 +491,19 @@
 			"origin": [792, -462, -4],
 			"faces": {
 				"north": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 16],
 					"texture": 0
 				},
 				"east": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 16],
 					"texture": 0
 				},
 				"south": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 16],
 					"texture": 0
 				},
 				"west": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 16],
 					"texture": 0
 				},
 				"up": {
@@ -583,19 +583,19 @@
 			"origin": [776, -430, -4],
 			"faces": {
 				"north": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 16],
 					"texture": 0
 				},
 				"east": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 16],
 					"texture": 0
 				},
 				"south": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 16],
 					"texture": 0
 				},
 				"west": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 16],
 					"texture": 0
 				},
 				"up": {
@@ -627,23 +627,19 @@
 			"origin": [772, -494, -8],
 			"faces": {
 				"north": {
-					"uv": [4, 0, 0, 4],
-					"rotation": 180,
+					"uv": [0, 0, 4, 8],
 					"texture": 0
 				},
 				"east": {
-					"uv": [12, 0, 0, 4],
-					"rotation": 180,
+					"uv": [0, 0, 12, 8],
 					"texture": 0
 				},
 				"south": {
-					"uv": [4, 0, 0, 4],
-					"rotation": 180,
+					"uv": [0, 0, 4, 8],
 					"texture": 0
 				},
 				"west": {
-					"uv": [12, 0, 0, 4],
-					"rotation": 180,
+					"uv": [0, 0, 12, 8],
 					"texture": 0
 				},
 				"up": {
@@ -675,22 +671,22 @@
 			"origin": [756, -462, -8],
 			"faces": {
 				"north": {
-					"uv": [4, 0, 0, 4],
+					"uv": [4, 0, 0, 8],
 					"rotation": 180,
 					"texture": 0
 				},
 				"east": {
-					"uv": [12, 0, 0, 4],
+					"uv": [12, 0, 0, 8],
 					"rotation": 180,
 					"texture": 0
 				},
 				"south": {
-					"uv": [4, 0, 0, 4],
+					"uv": [4, 0, 0, 8],
 					"rotation": 180,
 					"texture": 0
 				},
 				"west": {
-					"uv": [12, 0, 0, 4],
+					"uv": [12, 0, 0, 8],
 					"rotation": 180,
 					"texture": 0
 				},
@@ -717,35 +713,33 @@
 			"render_order": "default",
 			"allow_mirror_modeling": true,
 			"from": [264, 32, -8],
-			"to": [280, 96, 8],
+			"to": [280, 64, 8],
 			"autouv": 0,
 			"color": 6,
 			"origin": [760, -398, -4],
 			"faces": {
 				"north": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 8],
 					"texture": 0
 				},
 				"east": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 8],
 					"texture": 0
 				},
 				"south": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 8],
 					"texture": 0
 				},
 				"west": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 8],
 					"texture": 0
 				},
 				"up": {
-					"uv": [4, 0, 0, 4],
-					"rotation": 180,
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				},
 				"down": {
-					"uv": [4, 0, 0, 4],
-					"rotation": 180,
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				}
 			},
@@ -808,36 +802,34 @@
 			"light_emission": 0,
 			"render_order": "default",
 			"allow_mirror_modeling": true,
-			"from": [232, 112, -8],
+			"from": [232, 144, -8],
 			"to": [248, 160, 8],
 			"autouv": 0,
 			"color": 6,
 			"origin": [728, -350, -4],
 			"faces": {
 				"north": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				},
 				"east": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				},
 				"south": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				},
 				"west": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				},
 				"up": {
-					"uv": [4, 0, 0, 4],
-					"rotation": 180,
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				},
 				"down": {
-					"uv": [4, 0, 0, 4],
-					"rotation": 180,
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				}
 			},
@@ -859,22 +851,22 @@
 			"origin": [740, -430, -8],
 			"faces": {
 				"north": {
-					"uv": [4, 0, 0, 4],
+					"uv": [4, 0, 0, 8],
 					"rotation": 180,
 					"texture": 0
 				},
 				"east": {
-					"uv": [12, 0, 0, 4],
+					"uv": [12, 0, 0, 8],
 					"rotation": 180,
 					"texture": 0
 				},
 				"south": {
-					"uv": [4, 0, 0, 4],
+					"uv": [4, 0, 0, 8],
 					"rotation": 180,
 					"texture": 0
 				},
 				"west": {
-					"uv": [12, 0, 0, 4],
+					"uv": [12, 0, 0, 8],
 					"rotation": 180,
 					"texture": 0
 				},
@@ -951,19 +943,19 @@
 			"origin": [744, -382, -4],
 			"faces": {
 				"north": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 8],
 					"texture": 0
 				},
 				"east": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 8],
 					"texture": 0
 				},
 				"south": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 8],
 					"texture": 0
 				},
 				"west": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 8],
 					"texture": 0
 				},
 				"up": {
@@ -2191,29 +2183,27 @@
 			"origin": [504, -414, -4],
 			"faces": {
 				"north": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				},
 				"east": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				},
 				"south": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				},
 				"west": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				},
 				"up": {
-					"uv": [4, 0, 0, 4],
-					"rotation": 180,
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				},
 				"down": {
-					"uv": [4, 0, 0, 4],
-					"rotation": 180,
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				}
 			},
@@ -2235,22 +2225,22 @@
 			"origin": [500, -478, -8],
 			"faces": {
 				"north": {
-					"uv": [4, 0, 0, 4],
+					"uv": [4, 0, 0, 8],
 					"rotation": 180,
 					"texture": 0
 				},
 				"east": {
-					"uv": [12, 0, 0, 4],
+					"uv": [12, 0, 0, 8],
 					"rotation": 180,
 					"texture": 0
 				},
 				"south": {
-					"uv": [4, 0, 0, 4],
+					"uv": [4, 0, 0, 8],
 					"rotation": 180,
 					"texture": 0
 				},
 				"west": {
-					"uv": [12, 0, 0, 4],
+					"uv": [12, 0, 0, 8],
 					"rotation": 180,
 					"texture": 0
 				},
@@ -2283,29 +2273,27 @@
 			"origin": [488, -398, -4],
 			"faces": {
 				"north": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				},
 				"east": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				},
 				"south": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				},
 				"west": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				},
 				"up": {
-					"uv": [4, 0, 0, 4],
-					"rotation": 180,
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				},
 				"down": {
-					"uv": [4, 0, 0, 4],
-					"rotation": 180,
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				}
 			},
@@ -2327,29 +2315,27 @@
 			"origin": [488, -414, -4],
 			"faces": {
 				"north": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 12, 4],
 					"texture": 0
 				},
 				"east": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				},
 				"south": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 12, 4],
 					"texture": 0
 				},
 				"west": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 4],
 					"texture": 0
 				},
 				"up": {
-					"uv": [4, 0, 0, 4],
-					"rotation": 180,
+					"uv": [0, 0, 12, 4],
 					"texture": 0
 				},
 				"down": {
-					"uv": [4, 0, 0, 4],
-					"rotation": 180,
+					"uv": [0, 0, 12, 4],
 					"texture": 0
 				}
 			},
@@ -2371,22 +2357,22 @@
 			"origin": [484, -510, -8],
 			"faces": {
 				"north": {
-					"uv": [4, 0, 0, 4],
+					"uv": [4, 0, 0, 12],
 					"rotation": 180,
 					"texture": 0
 				},
 				"east": {
-					"uv": [12, 0, 0, 4],
+					"uv": [12, 0, 0, 12],
 					"rotation": 180,
 					"texture": 0
 				},
 				"south": {
-					"uv": [4, 0, 0, 4],
+					"uv": [4, 0, 0, 12],
 					"rotation": 180,
 					"texture": 0
 				},
 				"west": {
-					"uv": [12, 0, 0, 4],
+					"uv": [12, 0, 0, 12],
 					"rotation": 180,
 					"texture": 0
 				},
@@ -2419,7 +2405,7 @@
 			"origin": [472, -430, -4],
 			"faces": {
 				"north": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 12, 12],
 					"texture": 0
 				},
 				"east": {
@@ -2427,7 +2413,7 @@
 					"texture": 0
 				},
 				"south": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 12, 12],
 					"texture": 0
 				},
 				"west": {
@@ -2435,12 +2421,12 @@
 					"texture": 0
 				},
 				"up": {
-					"uv": [4, 0, 0, 4],
+					"uv": [12, 0, 0, 4],
 					"rotation": 180,
 					"texture": 0
 				},
 				"down": {
-					"uv": [4, 0, 0, 4],
+					"uv": [12, 0, 0, 4],
 					"rotation": 180,
 					"texture": 0
 				}
@@ -2641,7 +2627,7 @@
 			"render_order": "default",
 			"allow_mirror_modeling": true,
 			"from": [360, -32, -24],
-			"to": [376, -16, 24],
+			"to": [376.1, -16, 24],
 			"autouv": 0,
 			"color": 6,
 			"origin": [852, -574, -8],
@@ -2739,28 +2725,28 @@
 			"origin": [760, -350, -4],
 			"faces": {
 				"north": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 12, 8],
 					"texture": 0
 				},
 				"east": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 8],
 					"texture": 0
 				},
 				"south": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 12, 8],
 					"texture": 0
 				},
 				"west": {
-					"uv": [0, 0, 4, 12],
+					"uv": [0, 0, 4, 8],
 					"texture": 0
 				},
 				"up": {
-					"uv": [4, 0, 0, 4],
+					"uv": [12, 0, 0, 4],
 					"rotation": 180,
 					"texture": 0
 				},
 				"down": {
-					"uv": [4, 0, 0, 4],
+					"uv": [12, 0, 0, 4],
 					"rotation": 180,
 					"texture": 0
 				}
@@ -2894,7 +2880,7 @@
 			"uuid": "b962f578-5c1e-7b97-a5ac-9ff6f00656ba",
 			"export": false,
 			"mirror_uv": false,
-			"isOpen": false,
+			"isOpen": true,
 			"locked": false,
 			"visibility": true,
 			"autouv": 0,
@@ -2927,7 +2913,7 @@
 					"uuid": "e0027098-fff7-4ba7-253d-f2d358d66b70",
 					"export": false,
 					"mirror_uv": false,
-					"isOpen": false,
+					"isOpen": true,
 					"locked": false,
 					"visibility": true,
 					"autouv": 0,
@@ -2978,7 +2964,7 @@
 		"default": {
 			"name": "default",
 			"display_name": "Default",
-			"uuid": "9969b0b5-3e09-98ca-d7d7-98a3adc9d7a5",
+			"uuid": "5b7c200d-8862-7a00-c1e2-1541c8732526",
 			"texture_map": {},
 			"excluded_nodes": [],
 			"is_default": true

--- a/resourcepack/assets/omega-flowey/models/entity/decorative/summitpetalpipetop.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/decorative/summitpetalpipetop.ajblueprint
@@ -2969,7 +2969,7 @@
 		"default": {
 			"name": "default",
 			"display_name": "Default",
-			"uuid": "eddbb4cb-4ba8-6539-5794-145fd95150af",
+			"uuid": "26f223f5-9929-344c-3bf3-7bcb5cea06c4",
 			"texture_map": {},
 			"excluded_nodes": [],
 			"is_default": true
@@ -3034,7 +3034,7 @@
 							"data_points": [
 								{
 									"x": 1,
-									"y": 1.5,
+									"y": "0.5",
 									"z": -1
 								}
 							],
@@ -3050,7 +3050,7 @@
 							"data_points": [
 								{
 									"x": -1,
-									"y": -3,
+									"y": "-1",
 									"z": 1
 								}
 							],

--- a/resourcepack/assets/omega-flowey/models/entity/decorative/summitpetalpipetop.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/decorative/summitpetalpipetop.ajblueprint
@@ -2805,7 +2805,12 @@
 			"origin": [182.03774, 93.28302, 0],
 			"color": 0,
 			"configs": {
-				"variants": {}
+				"variants": {},
+				"default": {
+					"inherit_settings": true,
+					"nbt": "{ brightness: { block: 5, sky: 15 }, view_range: 1.2f }",
+					"use_nbt": true
+				}
 			},
 			"uuid": "045ebb3b-abd2-0331-9e78-b0cf5794bf48",
 			"export": true,
@@ -2964,7 +2969,7 @@
 		"default": {
 			"name": "default",
 			"display_name": "Default",
-			"uuid": "5b7c200d-8862-7a00-c1e2-1541c8732526",
+			"uuid": "eddbb4cb-4ba8-6539-5794-145fd95150af",
 			"texture_map": {},
 			"excluded_nodes": [],
 			"is_default": true

--- a/resourcepack/assets/omega-flowey/models/entity/decorative/summitpetalpipetop.ajblueprint
+++ b/resourcepack/assets/omega-flowey/models/entity/decorative/summitpetalpipetop.ajblueprint
@@ -1,0 +1,3130 @@
+{
+	"meta": {
+		"format": "animated_java_blueprint",
+		"format_version": "1.4.2",
+		"uuid": "ff528772-a108-d7c3-2be6-170151baa63e",
+		"save_location": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\models\\entity\\decorative\\summitpetalpipetop.ajblueprint",
+		"last_used_export_namespace": "summitpetalpipetop"
+	},
+	"blueprint_settings": {
+		"export_namespace": "summitpetalpipetop",
+		"show_bounding_box": false,
+		"auto_bounding_box": true,
+		"bounding_box": [48, 48],
+		"enable_plugin_mode": false,
+		"resource_pack_export_mode": "raw",
+		"data_pack_export_mode": "raw",
+		"display_item": "minecraft:white_dye",
+		"custom_model_data_offset": 0,
+		"enable_advanced_resource_pack_settings": false,
+		"enable_advanced_resource_pack_folders": false,
+		"resource_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack",
+		"display_item_path": "",
+		"model_folder": "",
+		"texture_folder": "",
+		"enable_advanced_data_pack_settings": false,
+		"data_pack": "G:\\Coding\\omega-flowey-minecraft-remastered\\datapacks\\animated_java",
+		"summon_commands": "tag @s add omega-flowey-remastered",
+		"ticking_commands": "",
+		"interpolation_duration": 1,
+		"teleportation_duration": 1,
+		"use_storage_for_animation": false,
+		"baked_animations": true,
+		"json_file": ""
+	},
+	"resolution": {
+		"width": 16,
+		"height": 16
+	},
+	"elements": [
+		{
+			"name": "screen",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [-120.2, -201.6, -44],
+			"to": [122.2, -28.8, 49.6],
+			"autouv": 0,
+			"color": 8,
+			"export": false,
+			"origin": [7, -252, 35.2],
+			"faces": {
+				"north": {
+					"uv": [2, 0.7, 14, 9.61429]
+				},
+				"east": {
+					"uv": [1.1, 0, 14.9, 9.81429],
+					"rotation": 180
+				},
+				"south": {
+					"uv": [1.1, 0, 14.9, 9.81429],
+					"rotation": 180
+				},
+				"west": {
+					"uv": [1.1, 0, 14.9, 9.81429],
+					"rotation": 180
+				},
+				"up": {
+					"uv": [1.1, 0, 14.9, 9.81429],
+					"rotation": 180
+				},
+				"down": {
+					"uv": [1.1, 0, 14.9, 9.81429],
+					"rotation": 180
+				}
+			},
+			"type": "cube",
+			"uuid": "c869499d-3c5b-d2b4-92cf-7e6022b34771"
+		},
+		{
+			"name": "warning",
+			"position": [1, -176, -42.05],
+			"rotation": [0, 0, 0],
+			"ignore_inherited_scale": false,
+			"visibility": true,
+			"locked": false,
+			"config": {
+				"use_entity": true,
+				"entity_type": "minecraft:marker",
+				"summon_commands": "data merge entity @s {}"
+			},
+			"export": false,
+			"uuid": "c13977e7-cf02-6b09-6569-16422309f429",
+			"type": "locator"
+		},
+		{
+			"name": "soul_event",
+			"position": [1, -128, -42.05],
+			"rotation": [0, 0, 0],
+			"ignore_inherited_scale": false,
+			"visibility": true,
+			"locked": false,
+			"config": {
+				"use_entity": true,
+				"entity_type": "minecraft:marker",
+				"summon_commands": "data merge entity @s {}"
+			},
+			"export": false,
+			"uuid": "897e080d-86e4-9293-933e-917e883b8d7f",
+			"type": "locator"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [-149, -252, -36.8],
+			"to": [151, -230.4, 49.6],
+			"autouv": 0,
+			"color": 0,
+			"export": false,
+			"origin": [7, -252, -36.8],
+			"faces": {
+				"north": {
+					"uv": [0, 14, 16, 16]
+				},
+				"east": {
+					"uv": [5, 14, 16, 16]
+				},
+				"south": {
+					"uv": [1, 14, 15, 16]
+				},
+				"west": {
+					"uv": [3, 14, 14, 16]
+				},
+				"up": {
+					"uv": [2, 2, 14, 14],
+					"rotation": 180
+				},
+				"down": {
+					"uv": [0, 6, 16, 12],
+					"rotation": 180
+				}
+			},
+			"type": "cube",
+			"uuid": "12ee858f-c998-030b-6a6f-37046d16a56c"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [-149, -230.4, -51.2],
+			"to": [151, -201.6, 49.6],
+			"autouv": 0,
+			"color": 0,
+			"export": false,
+			"origin": [7, -252, -36.8],
+			"faces": {
+				"north": {
+					"uv": [0, 14, 16, 16]
+				},
+				"east": {
+					"uv": [5, 14, 16, 16]
+				},
+				"south": {
+					"uv": [0, 14, 16, 16]
+				},
+				"west": {
+					"uv": [0, 14, 11, 16]
+				},
+				"up": {
+					"uv": [2, 2, 14, 14],
+					"rotation": 180
+				},
+				"down": {
+					"uv": [2, 2, 14, 14],
+					"rotation": 180
+				}
+			},
+			"type": "cube",
+			"uuid": "b8ed9a04-56c9-0291-8cb9-dc7aa42e47b3"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [-134.6, -230.4, 49.6],
+			"to": [136.6, -28.8, 78.4],
+			"autouv": 0,
+			"color": 0,
+			"export": false,
+			"origin": [7, -252, -36.8],
+			"faces": {
+				"north": {
+					"uv": [0, 2, 16, 6]
+				},
+				"east": {
+					"uv": [2, 0, 5, 16]
+				},
+				"south": {
+					"uv": [2, 1, 14, 16]
+				},
+				"west": {
+					"uv": [11, 0, 14, 16]
+				},
+				"up": {
+					"uv": [0, 10, 16, 12],
+					"rotation": 180
+				},
+				"down": {
+					"uv": [0, 14, 16, 16],
+					"rotation": 180
+				}
+			},
+			"type": "cube",
+			"uuid": "2060386c-9aa1-1cc6-cf56-1d8a9a0ee7fb"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [-134.6, -195.4, 78.4],
+			"to": [136.6, -29.8, 107.2],
+			"autouv": 0,
+			"color": 0,
+			"export": false,
+			"origin": [7, -253, -36.8],
+			"faces": {
+				"north": {
+					"uv": [0, 2, 16, 6]
+				},
+				"east": {
+					"uv": [0, 0, 3, 13]
+				},
+				"south": {
+					"uv": [0, 0, 16, 16]
+				},
+				"west": {
+					"uv": [13, 0, 16, 13]
+				},
+				"up": {
+					"uv": [0, 0, 16, 2],
+					"rotation": 180
+				},
+				"down": {
+					"uv": [1, 14, 15, 16],
+					"rotation": 180
+				}
+			},
+			"type": "cube",
+			"uuid": "3493a626-2273-c39c-d661-9c74f3730b6c"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [-149, -28.8, -51.2],
+			"to": [151, 0, 49.6],
+			"autouv": 0,
+			"color": 0,
+			"export": false,
+			"origin": [7, -252, -36.8],
+			"faces": {
+				"north": {
+					"uv": [16, 0, 0, 2]
+				},
+				"east": {
+					"uv": [5, 0, 16, 2]
+				},
+				"south": {
+					"uv": [0, 7, 16, 9]
+				},
+				"west": {
+					"uv": [0, 0, 11, 2]
+				},
+				"up": {
+					"uv": [0, 9, 16, 15],
+					"rotation": 180
+				},
+				"down": {
+					"uv": [2, 2, 14, 14],
+					"rotation": 180
+				}
+			},
+			"type": "cube",
+			"uuid": "b7ef9a14-a56a-aa35-84e5-09556edda8a4"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [122.2, -201.6, -51.2],
+			"to": [151, -28.8, 49.6],
+			"autouv": 0,
+			"color": 0,
+			"export": false,
+			"origin": [7, -252, -36.8],
+			"faces": {
+				"north": {
+					"uv": [0, 6, 3, 15]
+				},
+				"east": {
+					"uv": [5, 3, 16, 14]
+				},
+				"south": {
+					"uv": [14, 3, 16, 14]
+				},
+				"west": {
+					"uv": [2, 2, 14, 14]
+				},
+				"up": {
+					"uv": [2, 2, 14, 14],
+					"rotation": 180
+				},
+				"down": {
+					"uv": [2, 2, 14, 14],
+					"rotation": 180
+				}
+			},
+			"type": "cube",
+			"uuid": "1566e157-fad4-d0d8-715e-1fd881f24372"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [-149, -201.6, -51.2],
+			"to": [-120.2, -28.8, 49.6],
+			"autouv": 0,
+			"color": 0,
+			"export": false,
+			"origin": [7, -252, -36.8],
+			"faces": {
+				"north": {
+					"uv": [13, 5, 16, 15]
+				},
+				"east": {
+					"uv": [2, 2, 14, 14]
+				},
+				"south": {
+					"uv": [0, 3, 2, 14]
+				},
+				"west": {
+					"uv": [0, 3, 11, 14]
+				},
+				"up": {
+					"uv": [2, 2, 14, 14],
+					"rotation": 180
+				},
+				"down": {
+					"uv": [2, 2, 14, 14],
+					"rotation": 180
+				}
+			},
+			"type": "cube",
+			"uuid": "2cbbb6df-7cd0-09be-34d8-eb4428ca5aa9"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [312, -16, -8],
+			"to": [328, 32, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [808, -478, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "e69a1267-4962-c271-ca90-de8b8dee23b2"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [312, 0, -24],
+			"to": [328, 16, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [804, -542, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "18fedfc7-6ac2-6d19-55af-f42f709eceb5"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [296, 0, -8],
+			"to": [312, 64, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [792, -462, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "ab4edd44-fd24-8dc2-9be3-c9bf17330fce"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [296, 16, -24],
+			"to": [312, 32, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [788, -526, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "6a07d523-e4ca-ae74-23a6-477b352dc323"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [280, 32, -8],
+			"to": [296, 96, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [776, -430, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "e894320e-b8e5-a121-bf8c-92ff67b4d9ff"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [280, 32, -24],
+			"to": [296, 64, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [772, -494, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "e3c57b2e-a911-8764-907e-e6b795777fdb"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [264, 64, -24],
+			"to": [280, 96, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [756, -462, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "bb5cebec-dbeb-4dd0-b085-86ab44adc40e"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [264, 32, -8],
+			"to": [280, 96, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [760, -398, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "ad3dfe14-a329-0742-a338-c9efa8291312"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [232, 128, -24],
+			"to": [248, 144, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [724, -414, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "29a25f6b-6034-81e7-fba3-5236ea76d1c5"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [232, 112, -8],
+			"to": [248, 160, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [728, -350, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "f658f1ef-ddb8-7d0d-8510-9e52193fd0b7"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [248, 96, -24],
+			"to": [264, 128, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [740, -430, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "e74d96b3-5b9e-ff83-0109-1bc98d43ca55"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [248, 96, -8],
+			"to": [264, 144, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [744, -366, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "61320eae-6ac5-0cf9-621e-5605388eea53"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [248, 64, -8],
+			"to": [264, 96, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [744, -382, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "187341d9-7344-d107-134b-8c9726d2ad89"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [200, 144, -24],
+			"to": [216, 160, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [692, -398, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "a6a3c611-56a7-504d-822f-b9347deff770"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [200, 128, -8],
+			"to": [216, 176, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [696, -334, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "e73e10f1-24bc-60f3-d2f5-3697b2ae35af"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [216, 144, -24],
+			"to": [232, 160, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [708, -398, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "b08f0781-2ce5-dfd6-8e80-e556a6107828"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [216, 128, -8],
+			"to": [232, 176, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [712, -334, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "71d85963-71db-0098-dd5e-31aed06b187e"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [184, 144, -8],
+			"to": [200, 192, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [680, -318, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "a514e396-8f11-1836-5a15-89340982fb72"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [184, 160, -24],
+			"to": [200, 176, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [676, -382, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "91cc5143-adf5-0b95-41df-acf1a4b7f1d6"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [168, 144, -8],
+			"to": [184, 192, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [664, -318, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "659a0b5c-42c7-913c-0873-6d3e8110ab20"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [168, 160, -24],
+			"to": [184, 176, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [660, -382, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "5cc66986-181b-ea3f-7a66-c69ae2be97b4"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [152, 144, -8],
+			"to": [168, 192, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [648, -318, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "b519e0ef-667c-c1ab-d5be-57b541c66ab9"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [152, 160, -24],
+			"to": [168, 176, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [644, -382, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "b048c3db-1651-ab7e-4040-928c1d474000"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [136, 128, -8],
+			"to": [152, 176, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [632, -334, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "a7596d0b-d83c-ef2a-7d9a-243a256c4b53"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [136, 144, -24],
+			"to": [152, 160, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [628, -398, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "4a51c74a-5434-253a-8abd-7a7e7dd2e751"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [120, 128, -8],
+			"to": [136, 176, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [616, -334, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "992b1e22-fc6e-8f8f-1988-0e263c9172d8"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [120, 144, -24],
+			"to": [136, 160, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [612, -398, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "e0934f6d-a01b-af4e-d322-30d928304b97"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [88, 128, -24],
+			"to": [104, 144, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [580, -414, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "ad3df6d6-75d2-b3d5-aba9-a64225f8688f"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [88, 112, -8],
+			"to": [104, 160, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [584, -350, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "854ddbe6-4423-244f-92d4-b7e585981f4f"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [104, 128, -24],
+			"to": [120, 144, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [596, -414, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "e41cd0be-c5a0-ed1d-af29-a18d998529b7"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [104, 112, -8],
+			"to": [120, 160, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [600, -350, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "15e0a253-32cc-1d79-86e9-c247d063cb05"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [56, 112, -24],
+			"to": [72, 128, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [548, -430, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "edf8878e-7261-ecf1-cfc8-0378b92ff45a"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [56, 96, -8],
+			"to": [72, 144, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [552, -366, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "cf3a21a3-19a1-0203-1ea5-be845b9888c3"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [72, 112, -24],
+			"to": [88, 128, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [564, -430, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "69d9ae40-d918-6f8b-166b-dd995d2174cd"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [72, 96, -8],
+			"to": [88, 144, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [568, -366, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "bc3456cf-1d43-53b3-164d-4e210880e8d0"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [24, 80, -24],
+			"to": [40, 96, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [516, -462, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "c0c7caf8-ddf2-a60e-2566-c5cff7fd76e3"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [24, 64, -8],
+			"to": [40, 112, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [520, -398, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "e9f86c89-850b-81e7-8b62-0f6cdf1ac419"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [40, 96, -24],
+			"to": [56, 112, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [532, -446, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "07c3eb1a-8485-65f7-25c8-e88c835f2c9b"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [40, 80, -8],
+			"to": [56, 128, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [536, -382, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "ba346a1e-d12b-3277-8ca7-7e3ed06956ac"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [8, 80, -8],
+			"to": [24, 96, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [504, -414, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "53f6d5ff-a943-3d5b-8bae-efc6e9858834"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [8, 48, -24],
+			"to": [24, 80, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [500, -478, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "1c8477e0-1dd3-6e76-eec0-b5365436b587"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [-8, 64, -8],
+			"to": [8, 80, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [488, -398, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "2a553aef-3c05-92eb-ec82-81dcefbaf894"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [-8, 48, -8],
+			"to": [40, 64, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [488, -414, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "6a846b9a-a047-58e4-1bd5-057d1dcbe213"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [-8, 0, -24],
+			"to": [8, 48, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [484, -510, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "3d605caf-87f0-b8b9-7551-3f19954ce943"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [-24, 0, -8],
+			"to": [24, 48, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [472, -430, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "871f893e-3348-298b-30f7-42c6696d3bf5"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [328, -16, -24],
+			"to": [344, 0, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [820, -558, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "5b5a8e76-662d-cb93-fe1e-78a39d876f64"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [328, -32, -8],
+			"to": [344, 16, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [824, -494, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "16eccb92-d82a-4f6f-b6d2-94415fa2f59e"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [344, -16, -24],
+			"to": [360, 0, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [836, -558, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "f99d3b12-eac9-6ab1-bfe8-e57d3935d19a"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [344, -32, -8],
+			"to": [360, 16, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [840, -494, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "f8fd0116-785e-8abe-2760-6d0871e209a2"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [360, -32, -24],
+			"to": [376, -16, 24],
+			"autouv": 0,
+			"color": 6,
+			"origin": [852, -574, -8],
+			"faces": {
+				"north": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"east": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"south": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"west": {
+					"uv": [12, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 12],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "d129a1d2-d4fa-8626-8701-e29eba121964"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [360, -48, -8],
+			"to": [376, 0, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [856, -510, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "ce03d84f-c667-f567-fa4e-8b2e5b7f3048"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [232, 96, -8],
+			"to": [280, 128, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [760, -350, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "cb7c2aaa-15ee-5a26-7616-05481f0e4b17"
+		},
+		{
+			"name": "cube",
+			"box_uv": false,
+			"rescale": false,
+			"locked": false,
+			"light_emission": 0,
+			"render_order": "default",
+			"allow_mirror_modeling": true,
+			"from": [280, 16, -8],
+			"to": [296, 64, 8],
+			"autouv": 0,
+			"color": 6,
+			"origin": [776, -446, -4],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"east": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"south": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"west": {
+					"uv": [0, 0, 4, 12],
+					"texture": 0
+				},
+				"up": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				},
+				"down": {
+					"uv": [4, 0, 0, 4],
+					"rotation": 180,
+					"texture": 0
+				}
+			},
+			"type": "cube",
+			"uuid": "74f78de0-84e4-8bca-ba4e-563a1ad67052"
+		}
+	],
+	"outliner": [
+		{
+			"name": "root",
+			"origin": [182.03774, 93.28302, 0],
+			"color": 0,
+			"configs": {
+				"variants": {}
+			},
+			"uuid": "045ebb3b-abd2-0331-9e78-b0cf5794bf48",
+			"export": true,
+			"mirror_uv": false,
+			"isOpen": true,
+			"locked": false,
+			"visibility": true,
+			"autouv": 0,
+			"children": [
+				"18fedfc7-6ac2-6d19-55af-f42f709eceb5",
+				"e69a1267-4962-c271-ca90-de8b8dee23b2",
+				"6a07d523-e4ca-ae74-23a6-477b352dc323",
+				"ab4edd44-fd24-8dc2-9be3-c9bf17330fce",
+				"74f78de0-84e4-8bca-ba4e-563a1ad67052",
+				"e3c57b2e-a911-8764-907e-e6b795777fdb",
+				"e894320e-b8e5-a121-bf8c-92ff67b4d9ff",
+				"ce03d84f-c667-f567-fa4e-8b2e5b7f3048",
+				"d129a1d2-d4fa-8626-8701-e29eba121964",
+				"f8fd0116-785e-8abe-2760-6d0871e209a2",
+				"f99d3b12-eac9-6ab1-bfe8-e57d3935d19a",
+				"16eccb92-d82a-4f6f-b6d2-94415fa2f59e",
+				"5b5a8e76-662d-cb93-fe1e-78a39d876f64",
+				"ad3dfe14-a329-0742-a338-c9efa8291312",
+				"bb5cebec-dbeb-4dd0-b085-86ab44adc40e",
+				"187341d9-7344-d107-134b-8c9726d2ad89",
+				"cb7c2aaa-15ee-5a26-7616-05481f0e4b17",
+				"61320eae-6ac5-0cf9-621e-5605388eea53",
+				"e74d96b3-5b9e-ff83-0109-1bc98d43ca55",
+				"f658f1ef-ddb8-7d0d-8510-9e52193fd0b7",
+				"29a25f6b-6034-81e7-fba3-5236ea76d1c5",
+				"71d85963-71db-0098-dd5e-31aed06b187e",
+				"b08f0781-2ce5-dfd6-8e80-e556a6107828",
+				"e73e10f1-24bc-60f3-d2f5-3697b2ae35af",
+				"a6a3c611-56a7-504d-822f-b9347deff770",
+				"b048c3db-1651-ab7e-4040-928c1d474000",
+				"b519e0ef-667c-c1ab-d5be-57b541c66ab9",
+				"5cc66986-181b-ea3f-7a66-c69ae2be97b4",
+				"659a0b5c-42c7-913c-0873-6d3e8110ab20",
+				"91cc5143-adf5-0b95-41df-acf1a4b7f1d6",
+				"a514e396-8f11-1836-5a15-89340982fb72",
+				"e0934f6d-a01b-af4e-d322-30d928304b97",
+				"992b1e22-fc6e-8f8f-1988-0e263c9172d8",
+				"4a51c74a-5434-253a-8abd-7a7e7dd2e751",
+				"a7596d0b-d83c-ef2a-7d9a-243a256c4b53",
+				"15e0a253-32cc-1d79-86e9-c247d063cb05",
+				"e41cd0be-c5a0-ed1d-af29-a18d998529b7",
+				"854ddbe6-4423-244f-92d4-b7e585981f4f",
+				"ad3df6d6-75d2-b3d5-aba9-a64225f8688f",
+				"bc3456cf-1d43-53b3-164d-4e210880e8d0",
+				"69d9ae40-d918-6f8b-166b-dd995d2174cd",
+				"cf3a21a3-19a1-0203-1ea5-be845b9888c3",
+				"edf8878e-7261-ecf1-cfc8-0378b92ff45a",
+				"ba346a1e-d12b-3277-8ca7-7e3ed06956ac",
+				"07c3eb1a-8485-65f7-25c8-e88c835f2c9b",
+				"e9f86c89-850b-81e7-8b62-0f6cdf1ac419",
+				"2a553aef-3c05-92eb-ec82-81dcefbaf894",
+				"6a846b9a-a047-58e4-1bd5-057d1dcbe213",
+				"871f893e-3348-298b-30f7-42c6696d3bf5",
+				"c0c7caf8-ddf2-a60e-2566-c5cff7fd76e3",
+				"1c8477e0-1dd3-6e76-eec0-b5365436b587",
+				"3d605caf-87f0-b8b9-7551-3f19954ce943",
+				"53f6d5ff-a943-3d5b-8bae-efc6e9858834"
+			]
+		},
+		{
+			"name": "tv_screen_reference",
+			"origin": [0, -140, 0],
+			"color": 0,
+			"configs": {
+				"variants": {}
+			},
+			"uuid": "b962f578-5c1e-7b97-a5ac-9ff6f00656ba",
+			"export": false,
+			"mirror_uv": false,
+			"isOpen": false,
+			"locked": false,
+			"visibility": true,
+			"autouv": 0,
+			"children": [
+				{
+					"name": "screen",
+					"origin": [-453, -307, 43.2],
+					"color": 0,
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
+					"uuid": "56c25618-6b39-c055-5c95-28e18820184c",
+					"export": false,
+					"mirror_uv": false,
+					"isOpen": false,
+					"locked": false,
+					"visibility": true,
+					"autouv": 0,
+					"children": ["c869499d-3c5b-d2b4-92cf-7e6022b34771", "c13977e7-cf02-6b09-6569-16422309f429", "897e080d-86e4-9293-933e-917e883b8d7f"]
+				},
+				{
+					"name": "box",
+					"origin": [-453, -307, 31.2],
+					"color": 0,
+					"configs": {
+						"default": {},
+						"variants": {}
+					},
+					"uuid": "e0027098-fff7-4ba7-253d-f2d358d66b70",
+					"export": false,
+					"mirror_uv": false,
+					"isOpen": false,
+					"locked": false,
+					"visibility": true,
+					"autouv": 0,
+					"children": [
+						"12ee858f-c998-030b-6a6f-37046d16a56c",
+						"b8ed9a04-56c9-0291-8cb9-dc7aa42e47b3",
+						"2060386c-9aa1-1cc6-cf56-1d8a9a0ee7fb",
+						"3493a626-2273-c39c-d661-9c74f3730b6c",
+						"b7ef9a14-a56a-aa35-84e5-09556edda8a4",
+						"1566e157-fad4-d0d8-715e-1fd881f24372",
+						"2cbbb6df-7cd0-09be-34d8-eb4428ca5aa9"
+					]
+				}
+			]
+		}
+	],
+	"textures": [
+		{
+			"path": "G:\\Coding\\omega-flowey-minecraft-remastered\\resourcepack\\assets\\omega-flowey\\textures\\custom\\pipe\\polished_andesite.png",
+			"name": "polished_andesite.png",
+			"folder": "",
+			"namespace": "",
+			"id": "0",
+			"group": "",
+			"width": 64,
+			"height": 64,
+			"uv_width": 16,
+			"uv_height": 16,
+			"particle": false,
+			"use_as_default": false,
+			"layers_enabled": false,
+			"sync_to_project": "",
+			"render_mode": "default",
+			"render_sides": "auto",
+			"frame_time": 1,
+			"frame_order_type": "loop",
+			"frame_order": "",
+			"frame_interpolate": false,
+			"visible": true,
+			"internal": false,
+			"saved": true,
+			"uuid": "65f95255-bbf4-047c-8b82-a98e92dd5a5a",
+			"source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAAt5JREFUeF7tW1FLVEEUPheTXFFZrYU0lSCIHgMh6DUIwsegl35ST/4AH+utp4he+gFKIESZQYsSrbnEmt5ccQ2LjTO73zQ79/qw9z7Ioe++ONe9H8w5882ZM9+cSZ49X+1WJ6uStlPRv+c94e9of6qnMntNHM4qPnn18kX3/VZdTjq/vO3jlcu+/eNwX65MX3Xv+s3BQVtmZiZFv9n8+EGePH4klvHeAXkjD6fcvjUve61j98nv0453xs7OZ+8Aq/hEp8DXRkt2v+3LjZsLMlebcMYeHabOJh1pdQRYcWms4p2gDFh+eF8s43MZANqPjtakO3LsDA6nCBwTToGQAZbwzgHrG5t+tDHXYZCOfBwH8JvGg+UH98QyPsMApbjSXw3XNp7kz4Rrnp21HBs6p21p7jUzMcAaPsOAmOpqaOdEpDIuUhnrRX88GjdiBljDewZgvn9vNvyyB0PBBA2Q+mBFeLfx1jPAKn4gD8DoYhTPe1djdSrEeYBF/EAMCEc6XAp11Keme1ki8gBtx6uARbxzwOs3azJ/vZftxQ+MguF416mCIGgZ7xkQR3xE+3DJQwq8uFBzcSCMAVbxmWUwL+FRJ6iBuhT+PNr1OUNeImQNP7AMYrTz5nuYICHYwQFIhCzik6crK90v2w1J02ZuDMA/q9VZ14y/u7N0Vyzj3WbI8n6+rB5BPQCCSB7/qQdQD6Ae4HZ/1ANEXBJEPYB6APUANw2oB/STBuoBfVGUesBWPaMgW9ETqAeEByMW9/N6OFtGj6AeQD2A9QG9AgnqAawP+McBS+f7KNEJGTxM/1kfEGuC1s73YwYM23/WB4ABVs/3wYCi/Wd9QBgDLJ7vhzGgSP9ZHwAGWD3fBwOK9p96APUA1gewPoD3BagH8L7AoCI0zH667H78ovHUA6gHRDdGrNX7l72vwPsC4b1Bi/X+4b3FIv3nfQHeF+gfjRXdT5fdj180nnoA9YD/XA/4C06f6XYS8//pAAAAAElFTkSuQmCC",
+			"mode": "bitmap"
+		}
+	],
+	"variants": {
+		"default": {
+			"name": "default",
+			"display_name": "Default",
+			"uuid": "9969b0b5-3e09-98ca-d7d7-98a3adc9d7a5",
+			"texture_map": {},
+			"excluded_nodes": [],
+			"is_default": true
+		},
+		"list": []
+	},
+	"animations": [
+		{
+			"uuid": "c85c932e-f93b-f6d3-80e1-f9cb9d11da0d",
+			"name": "move",
+			"loop": "loop",
+			"override": false,
+			"length": 3.25,
+			"snapping": 20,
+			"selected": true,
+			"saved": false,
+			"path": "",
+			"anim_time_update": "",
+			"blend_weight": "",
+			"start_delay": "",
+			"loop_delay": "0",
+			"excluded_nodes": [],
+			"animators": {
+				"045ebb3b-abd2-0331-9e78-b0cf5794bf48": {
+					"name": "root",
+					"type": "bone",
+					"keyframes": [
+						{
+							"channel": "position",
+							"data_points": [
+								{
+									"x": "0",
+									"y": "0",
+									"z": "0"
+								}
+							],
+							"uuid": "6e81fed3-0489-e140-6848-0d96fad03901",
+							"time": 0,
+							"color": -1,
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
+						},
+						{
+							"channel": "position",
+							"data_points": [
+								{
+									"x": "0",
+									"y": "0",
+									"z": "0"
+								}
+							],
+							"uuid": "eb5feaca-b38b-0638-cf87-02f8c5f0580d",
+							"time": 3.25,
+							"color": -1,
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
+						},
+						{
+							"channel": "position",
+							"data_points": [
+								{
+									"x": 1,
+									"y": 1.5,
+									"z": -1
+								}
+							],
+							"uuid": "f6676aee-5feb-8356-fb03-ad2447b9af04",
+							"time": 1,
+							"color": -1,
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
+						},
+						{
+							"channel": "position",
+							"data_points": [
+								{
+									"x": -1,
+									"y": -3,
+									"z": 1
+								}
+							],
+							"uuid": "762d6066-07e1-b03e-cb46-efdc3df25a5d",
+							"time": 2.25,
+							"color": -1,
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
+						},
+						{
+							"channel": "scale",
+							"data_points": [
+								{
+									"x": "1",
+									"y": "1",
+									"z": "1"
+								}
+							],
+							"uuid": "59072873-29c9-4fad-f475-c3db8bfedeb4",
+							"time": 0.75,
+							"color": -1,
+							"uniform": true,
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
+						},
+						{
+							"channel": "scale",
+							"data_points": [
+								{
+									"x": 1,
+									"y": 1,
+									"z": 1
+								}
+							],
+							"uuid": "8e0b5732-b232-81f4-2410-6f29936057cf",
+							"time": 1.1,
+							"color": -1,
+							"uniform": true,
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
+						},
+						{
+							"channel": "scale",
+							"data_points": [
+								{
+									"x": "1.02",
+									"y": "1.02",
+									"z": "1.02"
+								}
+							],
+							"uuid": "486d3a5e-8db3-a7dd-0a29-e3ef8683007f",
+							"time": 0.9,
+							"color": -1,
+							"uniform": true,
+							"interpolation": "catmullrom",
+							"easing": "linear",
+							"easingArgs": []
+						}
+					]
+				}
+			}
+		}
+	],
+	"animation_controllers": []
+}


### PR DESCRIPTION
# Summary

This PR adds two more decorative models to support the outside tvscreen model on the Summit mountain.

---

## Preview

![2024-10-09_23 49 41](https://github.com/user-attachments/assets/638fed20-4197-4833-aaaf-33c199cad486)

---

## Supplemental changes

- https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/f8a638136f394647bd9a851f80be64df1700fd20: ⚔️ decrease delay after xbullets attacks
- need to decrease this further, but will need to look into terminating earlier than the executor terminate
- https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/cf3c29c7ad6a26a08df9d870438ff281f3b1f278: ⚔️ decrease delay after friendliness-pellets
- https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/613d6014a8def9e86418ae88c5fbb3336a70395b: 📍 move `Welcome...` text to be inline with `by TheAfroOfDoom` text
- https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/3b6091e41fd7e097b70d4c7f8838fad34375c600: 👷 fix build failing due to upper_eye texture dir rename
- https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/51290512cf50032a72e7d42c8b572c5ce9e900f1: 🔇 disable room transition logs
- https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/ffb81573ff3ea1b146de57d2f0fb1c354a1cb6e0: 💡 move outdated comment
- https://github.com/TheAfroOfDoom/omega-flowey-minecraft-remastered/commit/ba3d1f6d4c24b7cecef0c0ff6ce05fdf1a44859e: 💄 remove background from cave text displays on "monitors"