### PR TITLE
🔊 show custom death message when player dies during bossfight

### DIFF
--- a/datapacks/omega-flowey/data/entity/function/utils/damage/as_player.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/utils/damage/as_player.mcfunction
@@ -1,6 +1,9 @@
 # If player is going to die to this hit, disable `showDeathMessages` temporarily and display a custom death message
 scoreboard players set #omegaflowey.bossfight.show_custom_death_message global.flag 0
-$execute if score @s player.health matches ..$(damage) run scoreboard players set #omegaflowey.bossfight.show_custom_death_message global.flag 1
+$execute \
+  if score @s player.health matches ..$(damage) \
+  unless data entity @s active_effects[{ amplifier: 4b, duration: -1, id: "minecraft:resistance" }] \
+  run scoreboard players set #omegaflowey.bossfight.show_custom_death_message global.flag 1
 execute if score #omegaflowey.bossfight.show_custom_death_message global.flag matches 1 store result score @s math.0 run gamerule showDeathMessages
 execute if score #omegaflowey.bossfight.show_custom_death_message global.flag matches 1 \
   if score @s math.0 matches 1 run gamerule showDeathMessages false

--- a/datapacks/omega-flowey/data/entity/function/utils/damage/as_player.mcfunction
+++ b/datapacks/omega-flowey/data/entity/function/utils/damage/as_player.mcfunction
@@ -1,3 +1,10 @@
+# If player is going to die to this hit, disable `showDeathMessages` temporarily and display a custom death message
+scoreboard players set #omegaflowey.bossfight.show_custom_death_message global.flag 0
+$execute if score @s player.health matches ..$(damage) run scoreboard players set #omegaflowey.bossfight.show_custom_death_message global.flag 1
+execute if score #omegaflowey.bossfight.show_custom_death_message global.flag matches 1 store result score @s math.0 run gamerule showDeathMessages
+execute if score #omegaflowey.bossfight.show_custom_death_message global.flag matches 1 \
+  if score @s math.0 matches 1 run gamerule showDeathMessages false
+
 # TODO(39): remove these `unless entity @e[tag=boss_fight]`/`if entity @e[tag=boss_fight]` checks when boss fight is fully setup
 # we have it here for development so that the boss entity (omega-flowey)
 # does not need to exist for attacks to damage.
@@ -13,3 +20,14 @@ schedule function omega-flowey:summit/room/cave/active_player_health_display/sch
 # Reset damage immunity after 0.5s
 # https://minecraft.wiki/w/Damage#Immunity
 schedule function entity:utils/damage/reset_immunity_flag 10t replace
+
+# Show custom death message
+execute if score #omegaflowey.bossfight.show_custom_death_message global.flag matches 1 run tellraw @a [ \
+  { "selector": "@s"}, \
+  " was slain by ", \
+  { "text": "Omega Flowey", "color": "green" } \
+]
+
+# Re-enable `showDeathMessages` if it was enabled previously
+execute if score #omegaflowey.bossfight.show_custom_death_message global.flag matches 1 \
+  if score @s math.0 matches 1 run gamerule showDeathMessages true


### PR DESCRIPTION
# Summary

We can temporarily disable the `showDeathMessages` gamerule when a player dies to a bossfight attack and display a custom message with `/tellraw`.
